### PR TITLE
Move Arch storage config to PolicyEngine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arch
 
-Arch is Cosilico's source-data foundation for social simulation. It captures
+Arch is PolicyEngine's source-data foundation for social simulation. It captures
 source publications, preserves provenance, and represents published values as
 structured, queryable facts.
 
@@ -30,7 +30,7 @@ This repository provides:
 - **Jurisdiction loaders**: Source-specific ETL that emits the shared Arch
   schema.
 
-Arch facts are not Cosilico's assertion that a source claim is ultimately true.
+Arch facts are not PolicyEngine's assertion that a source claim is ultimately true.
 They are source-backed claims with provenance.
 
 ## Boundary
@@ -62,9 +62,9 @@ objects.
 
 ```text
 GitHub repositories:
-  CosilicoAI/arch       # Core schema, validation, harness, DB schema
-  CosilicoAI/arch-us    # US source parsers/specs; emits Arch records
-  CosilicoAI/arch-uk    # UK source parsers/specs; emits Arch records
+  PolicyEngine/arch-data # Core schema, validation, harness, DB schema
+  PolicyEngine/arch-us   # US source parsers/specs; emits Arch records
+  PolicyEngine/arch-uk   # UK source parsers/specs; emits Arch records
 
 Python distributions:
   cosilico-arch
@@ -115,7 +115,7 @@ and calibration code belongs under `micro/`.
 ```bash
 pip install cosilico-arch
 # Or for development:
-git clone https://github.com/CosilicoAI/arch arch
+git clone https://github.com/PolicyEngine/arch-data arch
 cd arch
 pip install -e ".[dev]"
 ```
@@ -312,7 +312,7 @@ files should live in private Cloudflare R2 buckets, with `manifest.yaml` and the
 hosted database carrying the queryable provenance:
 
 ```bash
-# One-time after creating the Cosilico Cloudflare account and running
+# One-time after creating the PolicyEngine Cloudflare account and running
 # `npx wrangler login`:
 uv run arch bootstrap-r2 --raw-bucket arch-raw --derived-bucket arch-derived
 
@@ -556,7 +556,7 @@ target_input = as_target(
 
 ## Related Repositories
 
-- [microplex](https://github.com/CosilicoAI/microplex) - Core microsimulation
+- [microplex](https://github.com/PolicyEngine/microplex) - Core microsimulation
   abstractions and calibration interfaces.
-- [microplex-us](https://github.com/CosilicoAI/microplex-us) - US-specific
+- [microplex-us](https://github.com/PolicyEngine/microplex-us) - US-specific
   simulation adapters and calibration profiles.

--- a/arch/artifacts.py
+++ b/arch/artifacts.py
@@ -753,7 +753,7 @@ def bootstrap_r2_buckets(
             authenticated=False,
             errors=(
                 "wrangler_not_authenticated: run `npx wrangler login` in the "
-                "Cosilico Cloudflare account, then rerun this command.",
+                "PolicyEngine Cloudflare account, then rerun this command.",
             ),
         )
 

--- a/db/supabase_client.py
+++ b/db/supabase_client.py
@@ -1,7 +1,7 @@
 """
 Supabase client for Arch.
 
-Provides connection to Cosilico Supabase database for:
+Provides connection to PolicyEngine Supabase database for:
 - Source metadata and dataset registries
 - Raw microdata tables (e.g., microdata.us_census_cps_asec_2024_person)
 - Target inputs
@@ -22,9 +22,24 @@ import pandas as pd
 from supabase import create_client, Client
 
 
-ARCH_SCHEMA = os.environ.get("COSILICO_ARCH_SCHEMA", "arch")
-MICRODATA_SCHEMA = os.environ.get("COSILICO_MICRODATA_SCHEMA", "microdata")
-TARGETS_SCHEMA = os.environ.get("COSILICO_TARGETS_SCHEMA", "targets")
+def _env(name: str, legacy_name: str | None = None) -> str | None:
+    """Read PolicyEngine-owned storage config with legacy fallback."""
+    value = os.environ.get(name)
+    if value:
+        return value
+    if legacy_name:
+        return os.environ.get(legacy_name)
+    return None
+
+
+ARCH_SCHEMA = _env("POLICYENGINE_ARCH_SCHEMA", "COSILICO_ARCH_SCHEMA") or "arch"
+MICRODATA_SCHEMA = (
+    _env("POLICYENGINE_MICRODATA_SCHEMA", "COSILICO_MICRODATA_SCHEMA")
+    or "microdata"
+)
+TARGETS_SCHEMA = (
+    _env("POLICYENGINE_TARGETS_SCHEMA", "COSILICO_TARGETS_SCHEMA") or "targets"
+)
 
 
 @dataclass
@@ -40,23 +55,26 @@ class SupabaseConfig:
         Load configuration from environment variables.
 
         Required:
-            COSILICO_SUPABASE_URL: Supabase project URL
-            COSILICO_SUPABASE_SECRET_KEY: Service role key for full access
+            POLICYENGINE_SUPABASE_URL: Supabase project URL
+            POLICYENGINE_SUPABASE_SERVICE_KEY: Service role key for full access
 
         Raises:
             ValueError: If required environment variables are missing
         """
-        url = os.environ.get("COSILICO_SUPABASE_URL")
+        url = _env("POLICYENGINE_SUPABASE_URL", "COSILICO_SUPABASE_URL")
         if not url:
             raise ValueError(
-                "COSILICO_SUPABASE_URL not set. "
+                "POLICYENGINE_SUPABASE_URL not set. "
                 "Set this to your Supabase project URL."
             )
 
-        secret_key = os.environ.get("COSILICO_SUPABASE_SECRET_KEY")
+        secret_key = _env(
+            "POLICYENGINE_SUPABASE_SERVICE_KEY",
+            "POLICYENGINE_SUPABASE_SECRET_KEY",
+        ) or os.environ.get("COSILICO_SUPABASE_SECRET_KEY")
         if not secret_key:
             raise ValueError(
-                "COSILICO_SUPABASE_SECRET_KEY not set. "
+                "POLICYENGINE_SUPABASE_SERVICE_KEY not set. "
                 "Set this to your service role key."
             )
 

--- a/docs/agent-source-package-harness.md
+++ b/docs/agent-source-package-harness.md
@@ -456,8 +456,8 @@ uv run arch load-supabase-mirror \
   --build-artifacts /tmp/arch-build-artifacts.jsonl
 ```
 
-The live load requires `COSILICO_SUPABASE_URL` and
-`COSILICO_SUPABASE_SECRET_KEY`, the Arch mirror migration applied, and the
+The live load requires `POLICYENGINE_SUPABASE_URL` and
+`POLICYENGINE_SUPABASE_SERVICE_KEY`, the Arch mirror migration applied, and the
 `arch` schema exposed by the Supabase Data API.
 
 ## Declarative Authoring Contract

--- a/docs/arch-fact-identity-review-packet.md
+++ b/docs/arch-fact-identity-review-packet.md
@@ -5,7 +5,7 @@ fact keys or letting agents populate many new source packages.
 
 ## Context
 
-Arch is Cosilico's source-data foundation. It should preserve publisher source
+Arch is PolicyEngine's source-data foundation. It should preserve publisher source
 artifacts, parsed source rows/cells, source-backed aggregate facts, dimensions,
 constraints, concept alignments, and provenance. Microplex should consume Arch
 through downstream adapters and own source selection, aging, reconciliation,
@@ -149,7 +149,7 @@ Introduce a v2 identity split:
 ## Paste-Ready ChatGPT Pro Prompt
 
 ```text
-We are building Arch as Cosilico's standalone source-data registry and build
+We are building Arch as PolicyEngine's standalone source-data registry and build
 harness. Arch should store publisher/source facts with provenance, source-row or
 source-cell lineage, dimensions, constraints, concept alignments, and stable
 keys. Microplex consumes Arch through downstream adapters and owns source

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Arch is Cosilico's source-data foundation for social simulation. It captures
+Arch is PolicyEngine's source-data foundation for social simulation. It captures
 source publications, preserves provenance, and represents published values as
 structured, queryable facts. Microplex consumes Arch facts to produce final
 calibrated simulation inputs.
@@ -67,7 +67,7 @@ Jurisdiction source packages should use short import namespaces and published
 distribution names with a Cosilico prefix:
 
 ```text
-repo: CosilicoAI/arch-us
+repo: PolicyEngine/arch-us
 distribution: cosilico-arch-us
 import: arch_us
 ```
@@ -166,7 +166,7 @@ target_input = as_target(
 ```
 
 Projection facts from official sources such as CBO, OBR, and ONS can be loaded
-as source facts directly. Cosilico-owned inflation, aging, projection, or
+as source facts directly. PolicyEngine-owned inflation, aging, projection, or
 cross-source reconciliation assumptions belong in Microplex Targets, not Arch.
 
 ### Downstream Adapter Aliases

--- a/docs/repository-model.md
+++ b/docs/repository-model.md
@@ -8,9 +8,9 @@ family.
 
 ```text
 GitHub repositories:
-  CosilicoAI/arch
-  CosilicoAI/arch-us
-  CosilicoAI/arch-uk
+  PolicyEngine/arch-data
+  PolicyEngine/arch-us
+  PolicyEngine/arch-uk
 
 Python distributions:
   cosilico-arch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "cosilico-arch"
 version = "0.1.0"
-description = "Cosilico Arch source-data foundation: source facts, microdata, and target inputs"
+description = "PolicyEngine Arch source-data foundation: source facts, microdata, and target inputs"
 readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.11"
 authors = [
-    { name = "Cosilico", email = "hello@cosilico.ai" }
+    { name = "PolicyEngine", email = "hello@policyengine.org" }
 ]
 
 dependencies = [

--- a/tests/test_supabase_client.py
+++ b/tests/test_supabase_client.py
@@ -17,10 +17,10 @@ class TestSupabaseClient:
         from db.supabase_client import get_supabase_client
 
         # Skip if no real credentials
-        if not os.environ.get("COSILICO_SUPABASE_URL"):
-            pytest.skip("COSILICO_SUPABASE_URL not set")
-        if not os.environ.get("COSILICO_SUPABASE_SECRET_KEY"):
-            pytest.skip("COSILICO_SUPABASE_SECRET_KEY not set")
+        if not os.environ.get("POLICYENGINE_SUPABASE_URL"):
+            pytest.skip("POLICYENGINE_SUPABASE_URL not set")
+        if not os.environ.get("POLICYENGINE_SUPABASE_SERVICE_KEY"):
+            pytest.skip("POLICYENGINE_SUPABASE_SERVICE_KEY not set")
 
         # Clear the lru_cache to ensure fresh client
         get_supabase_client.cache_clear()
@@ -32,19 +32,31 @@ class TestSupabaseClient:
         from db.supabase_client import SupabaseConfig
 
         with patch.dict(os.environ, {
-            "COSILICO_SUPABASE_URL": "https://test.supabase.co",
-            "COSILICO_SUPABASE_SECRET_KEY": "test-secret-key",
+            "POLICYENGINE_SUPABASE_URL": "https://test.supabase.co",
+            "POLICYENGINE_SUPABASE_SERVICE_KEY": "test-secret-key",
         }):
             config = SupabaseConfig.from_env()
             assert config.url == "https://test.supabase.co"
             assert config.secret_key == "test-secret-key"
+
+    def test_config_uses_legacy_env_as_fallback(self):
+        """Legacy Cosilico env names keep existing deployments working."""
+        from db.supabase_client import SupabaseConfig
+
+        with patch.dict(os.environ, {
+            "COSILICO_SUPABASE_URL": "https://legacy.supabase.co",
+            "COSILICO_SUPABASE_SECRET_KEY": "legacy-secret-key",
+        }, clear=True):
+            config = SupabaseConfig.from_env()
+            assert config.url == "https://legacy.supabase.co"
+            assert config.secret_key == "legacy-secret-key"
 
     def test_config_missing_url_raises(self):
         """Missing URL raises ValueError."""
         from db.supabase_client import SupabaseConfig
 
         with patch.dict(os.environ, {}, clear=True):
-            with pytest.raises(ValueError, match="COSILICO_SUPABASE_URL"):
+            with pytest.raises(ValueError, match="POLICYENGINE_SUPABASE_URL"):
                 SupabaseConfig.from_env()
 
     def test_config_missing_key_raises(self):
@@ -52,9 +64,9 @@ class TestSupabaseClient:
         from db.supabase_client import SupabaseConfig
 
         with patch.dict(os.environ, {
-            "COSILICO_SUPABASE_URL": "https://test.supabase.co",
+            "POLICYENGINE_SUPABASE_URL": "https://test.supabase.co",
         }, clear=True):
-            with pytest.raises(ValueError, match="COSILICO_SUPABASE_SECRET_KEY"):
+            with pytest.raises(ValueError, match="POLICYENGINE_SUPABASE_SERVICE_KEY"):
                 SupabaseConfig.from_env()
 
 


### PR DESCRIPTION
## Summary
- prefer PolicyEngine-owned Supabase environment variables while retaining legacy Cosilico fallbacks
- standardize Arch on `POLICYENGINE_SUPABASE_SERVICE_KEY` as the primary elevated Supabase key name
- update R2/bootstrap docs and messages to reference the PolicyEngine Cloudflare account
- update Arch repository ownership docs and metadata to PolicyEngine

## Supabase follow-up
- checked the shared credentials docs available through Google Drive; I did not find a PolicyEngine Supabase API/service key there
- found the existing PolicyEngine Supabase project `policyengine-strategy` (`naalkftuqvyhjpvwlvnd`), but Supabase reports it as `INACTIVE` and refuses restore because it has been paused for more than 90 days
- did not leave GitHub repo variables/secrets pointing to that dead project

## Tests
- uv run ruff check db/supabase_client.py tests/test_supabase_client.py arch/artifacts.py
- uv run pytest tests/test_supabase_client.py tests/test_arch_namespace.py -q