### PR TITLE
Update PolicyEngine branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arch
 
-Arch is Cosilico's source-data foundation for social simulation. It captures
+Arch is PolicyEngine's source-data foundation for social simulation. It captures
 source publications, preserves provenance, and represents published values as
 structured, queryable facts.
 
@@ -29,7 +29,7 @@ This repository provides:
   FRS, and related datasets.
 - **Jurisdiction loaders**: US and UK source-specific ETL.
 
-Arch facts are not Cosilico's assertion that a source claim is ultimately true.
+Arch facts are not PolicyEngine's assertion that a source claim is ultimately true.
 They are source-backed claims with provenance.
 
 ## Boundary
@@ -77,9 +77,9 @@ and calibration code belongs under `micro/`.
 ### 1. Install
 
 ```bash
-pip install cosilico-arch
+pip install policyengine-arch-data
 # Or for development:
-git clone https://github.com/CosilicoAI/arch-data arch
+git clone https://github.com/PolicyEngine/arch-data arch
 cd arch
 pip install -e ".[dev]"
 ```
@@ -194,7 +194,7 @@ target_input = as_target(
 
 ## Related Repositories
 
-- [microplex](https://github.com/CosilicoAI/microplex) - Core microsimulation
+- [microplex](https://github.com/PolicyEngine/microplex) - Core microsimulation
   abstractions and calibration interfaces.
-- [microplex-us](https://github.com/CosilicoAI/microplex-us) - US-specific
+- [microplex-us](https://github.com/PolicyEngine/microplex-us) - US-specific
   simulation adapters and calibration profiles.

--- a/calibration/variables.py
+++ b/calibration/variables.py
@@ -1,5 +1,5 @@
 """
-Variable entity resolution using cosilico-engine.
+Variable entity resolution using a RuleSpec engine package when available.
 
 Resolves fully qualified variable references to their entity type
 (person, tax_unit, household, family) by parsing the source .rac file.
@@ -15,19 +15,19 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Optional
 
-# Try to import from cosilico-engine
+# Try to import a legacy RuleSpec engine API.
 try:
-    from cosilico.dependency_resolver import PackageRegistry, ModuleResolver
-    from cosilico.dsl_parser import parse_file
-    COSILICO_AVAILABLE = True
+    from policyengine.dependency_resolver import PackageRegistry, ModuleResolver
+    from policyengine.dsl_parser import parse_file
+    POLICYENGINE_AVAILABLE = True
 except ImportError:
-    COSILICO_AVAILABLE = False
+    POLICYENGINE_AVAILABLE = False
 
 
 # Default workspace path (can be overridden)
-DEFAULT_WORKSPACE = Path.home() / "CosilicoAI"
+DEFAULT_WORKSPACE = Path.home() / "PolicyEngine"
 
-# Fallback entity mapping for common variables when cosilico-engine not available
+# Fallback entity mapping for common variables when a RuleSpec engine is not available.
 FALLBACK_ENTITIES = {
     # Person-level
     "age": "person",
@@ -110,7 +110,7 @@ def get_entity(
 
     Args:
         variable_ref: Fully qualified reference like "us:statute/26/32#eitc"
-        workspace: Optional workspace path (defaults to ~/CosilicoAI)
+        workspace: Optional workspace path (defaults to ~/PolicyEngine)
 
     Returns:
         Entity type: "person", "tax_unit", "household", or "family"
@@ -125,8 +125,8 @@ def get_entity(
     """
     package, path, var_name = parse_variable_ref(variable_ref)
 
-    # Try cosilico-engine first
-    if COSILICO_AVAILABLE:
+    # Try the RuleSpec engine first.
+    if POLICYENGINE_AVAILABLE:
         try:
             return _get_entity_from_rac(package, path, var_name, workspace)
         except Exception:
@@ -150,14 +150,14 @@ def _get_entity_from_rac(
     """
     Get entity by parsing the actual .rac file.
 
-    Uses cosilico-engine's PackageRegistry to resolve paths.
+    Uses the legacy RuleSpec engine's PackageRegistry to resolve paths.
     """
     if workspace is None:
         workspace = DEFAULT_WORKSPACE
 
     # Map short package name to repo name
-    # us → cosilico-us, us-ca → cosilico-us-ca, uk → cosilico-uk
-    repo_name = f"cosilico-{package}"
+    # us → policyengine-us, us-ca → policyengine-us-ca, uk → policyengine-uk
+    repo_name = f"policyengine-{package}"
 
     # Get package registry
     registry = PackageRegistry.from_workspace(workspace)

--- a/data/targets/README.md
+++ b/data/targets/README.md
@@ -1,6 +1,6 @@
 # State-Level Calibration Targets
 
-This directory contains state-level calibration targets for use with the Cosilico microsimulation system. Targets are used to calibrate (reweight) microdata samples to match official administrative statistics.
+This directory contains state-level calibration targets for use with the PolicyEngine microsimulation system. Targets are used to calibrate (reweight) microdata samples to match official administrative statistics.
 
 ## Data Files
 
@@ -16,7 +16,7 @@ This directory contains state-level calibration targets for use with the Cosilic
 Run the build script to generate/update all target files:
 
 ```bash
-cd cosilico-data-sources
+cd arch-data
 python data/targets/build_state_targets.py
 ```
 

--- a/db/etl_soi.py
+++ b/db/etl_soi.py
@@ -177,7 +177,7 @@ def _table_content(year: int, file_spec_fn, package_dir: str) -> bytes:
     else:
         request = Request(
             spec["source_url"],
-            headers={"User-Agent": "cosilico-arch/0.1", "Accept": "*/*"},
+            headers={"User-Agent": "policyengine-arch-data/0.1", "Accept": "*/*"},
         )
         with urlopen(request, timeout=120) as response:
             content = response.read()

--- a/db/source_files.py
+++ b/db/source_files.py
@@ -94,7 +94,7 @@ def _fetch_url(url: str) -> tuple[bytes, str | None, str]:
     request = Request(
         url,
         headers={
-            "User-Agent": "cosilico-arch/0.1",
+            "User-Agent": "policyengine-arch-data/0.1",
             "Accept": "*/*",
         },
     )

--- a/db/supabase_client.py
+++ b/db/supabase_client.py
@@ -1,7 +1,7 @@
 """
 Supabase client for Arch.
 
-Provides connection to Cosilico Supabase database for:
+Provides connection to PolicyEngine Supabase database for:
 - Source metadata and dataset registries
 - Raw microdata tables (e.g., microdata.us_census_cps_asec_2024_person)
 - Target inputs
@@ -22,9 +22,9 @@ import pandas as pd
 from supabase import create_client, Client
 
 
-ARCH_SCHEMA = os.environ.get("COSILICO_ARCH_SCHEMA", "arch")
-MICRODATA_SCHEMA = os.environ.get("COSILICO_MICRODATA_SCHEMA", "microdata")
-TARGETS_SCHEMA = os.environ.get("COSILICO_TARGETS_SCHEMA", "targets")
+ARCH_SCHEMA = os.environ.get("POLICYENGINE_ARCH_SCHEMA", "arch")
+MICRODATA_SCHEMA = os.environ.get("POLICYENGINE_MICRODATA_SCHEMA", "microdata")
+TARGETS_SCHEMA = os.environ.get("POLICYENGINE_TARGETS_SCHEMA", "targets")
 
 
 @dataclass
@@ -40,23 +40,23 @@ class SupabaseConfig:
         Load configuration from environment variables.
 
         Required:
-            COSILICO_SUPABASE_URL: Supabase project URL
-            COSILICO_SUPABASE_SECRET_KEY: Service role key for full access
+            POLICYENGINE_SUPABASE_URL: Supabase project URL
+            POLICYENGINE_SUPABASE_SECRET_KEY: Service role key for full access
 
         Raises:
             ValueError: If required environment variables are missing
         """
-        url = os.environ.get("COSILICO_SUPABASE_URL")
+        url = os.environ.get("POLICYENGINE_SUPABASE_URL")
         if not url:
             raise ValueError(
-                "COSILICO_SUPABASE_URL not set. "
+                "POLICYENGINE_SUPABASE_URL not set. "
                 "Set this to your Supabase project URL."
             )
 
-        secret_key = os.environ.get("COSILICO_SUPABASE_SECRET_KEY")
+        secret_key = os.environ.get("POLICYENGINE_SUPABASE_SECRET_KEY")
         if not secret_key:
             raise ValueError(
-                "COSILICO_SUPABASE_SECRET_KEY not set. "
+                "POLICYENGINE_SUPABASE_SECRET_KEY not set. "
                 "Set this to your service role key."
             )
 

--- a/docs/PUF_INTEGRATION.md
+++ b/docs/PUF_INTEGRATION.md
@@ -88,7 +88,7 @@ def add_synthetic_high_income(df, pareto_alpha=1.5):
 If IRS PUF license obtained:
 
 ```python
-class CosilicoPUF:
+class PolicyEnginePUF:
     """Load and process IRS PUF."""
 
     def __init__(self, puf_path: str):
@@ -96,7 +96,7 @@ class CosilicoPUF:
         self.records = self._build_tax_units()
 
     def _build_tax_units(self):
-        """Map PUF variables to Cosilico schema."""
+        """Map PUF variables to PolicyEngine schema."""
         return pd.DataFrame({
             'weight': self.raw['S006'] / 100,  # PUF weights are x100
             'adjusted_gross_income': self.raw['E00100'],

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Arch is Cosilico's source-data foundation for social simulation. It captures
+Arch is PolicyEngine's source-data foundation for social simulation. It captures
 source publications, preserves provenance, and represents published values as
 structured, queryable facts. Microplex consumes Arch facts to produce final
 calibrated simulation inputs.
@@ -134,7 +134,7 @@ target_input = as_target(
 ```
 
 Projection facts from official sources such as CBO, OBR, and ONS can be loaded
-as source facts directly. Cosilico-owned inflation, aging, projection, or
+as source facts directly. PolicyEngine-owned inflation, aging, projection, or
 cross-source reconciliation assumptions belong in Microplex Targets, not Arch.
 
 ## Calibration Pipeline

--- a/docs/cps-variable-coverage.md
+++ b/docs/cps-variable-coverage.md
@@ -131,9 +131,9 @@ The ETL pipeline (`db/etl_soi.py`) loads IRS SOI targets for calibration:
 python micro/us/census/download_cps.py --year 2024
 ```
 
-### 2. Convert to Cosilico Format
+### 2. Convert to PolicyEngine Format
 ```bash
-python scripts/cps_to_cosilico.py --year 2024 --calibrate --summary
+python scripts/cps_to_policyengine.py --year 2024 --calibrate --summary
 ```
 
 ### 3. Validate Against Targets
@@ -149,8 +149,8 @@ with Session(get_engine()) as session:
 
 ### 4. Run Microsimulation
 ```bash
-# In cosilico-us repository
-python -m cosilico_us.microsim --input cosilico_input_2024.parquet
+# In policyengine-us repository
+python -m policyengine_us.microsim --input policyengine_input_2024.parquet
 ```
 
 ## Data Quality Recommendations
@@ -199,7 +199,7 @@ definition: "What this variable measures"
 maps_to:
   - jurisdiction: us
     statute: "26 USC section"
-    variable: cosilico_variable_name
+    variable: policyengine_variable_name
     coverage: full | partial
     notes: "Mapping notes"
 
@@ -244,7 +244,7 @@ db/
 
 ```
 scripts/
-├── cps_to_cosilico.py      # Main conversion script
+├── cps_to_policyengine.py      # Main conversion script
 └── export_to_json.py       # JSON export utility
 
 micro/us/

--- a/docs/pe-calibration-targets.md
+++ b/docs/pe-calibration-targets.md
@@ -227,7 +227,7 @@ PolicyEngine-US-Data uses a three-table schema:
 
 ## Target Count Comparison
 
-| Category | PolicyEngine (est.) | cosilico (current) | Gap |
+| Category | PolicyEngine (est.) | policyengine (current) | Gap |
 |----------|---------------------|-------------------|-----|
 | IRS SOI Tax | ~500 | ~80 | ~420 |
 | Demographics | ~900 | ~50 | ~850 |

--- a/docs/weight-methodology.md
+++ b/docs/weight-methodology.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Cosilico calibrates microdata weights to match administrative targets using gradient descent on squared relative error. This approach:
+PolicyEngine calibrates microdata weights to match administrative targets using gradient descent on squared relative error. This approach:
 
 1. **No prior dependence**: Weights are determined purely by targets, not by arbitrary demographic calibration choices
 2. **Soft constraints**: Handles conflicting or infeasible targets gracefully

--- a/micro/us/calibrate.py
+++ b/micro/us/calibrate.py
@@ -342,7 +342,7 @@ def calibrate_and_run(year: int = 2024, filer_threshold: float = 0) -> pd.DataFr
     from tax_unit_builder import load_and_build_tax_units
 
     print("=" * 60)
-    print("COSILICO MICRODATA CALIBRATION (Entropy Method)")
+    print("POLICYENGINE MICRODATA CALIBRATION (Entropy Method)")
     print("=" * 60)
 
     print("\n1. Loading tax unit data...")

--- a/micro/us/census/cps-asec/index.yaml
+++ b/micro/us/census/cps-asec/index.yaml
@@ -18,7 +18,7 @@ years_available: [2018, 2019, 2020, 2021, 2022, 2023, 2024]
 # 3. CPS-derived counts may not match statutory definitions
 #
 # Qualifying children, tax liability, benefit amounts, etc. should be computed
-# in the rules engine (cosilico-us) from primary inputs.
+# in the rules engine (policyengine-us) from primary inputs.
 
 entities:
   - person

--- a/micro/us/census/download_cps.py
+++ b/micro/us/census/download_cps.py
@@ -7,7 +7,7 @@ from Census Bureau and caches raw data locally for efficient variable extraction
 DESIGN PRINCIPLES:
 1. Cache Full Raw Data: Download once, extract any variables later
 2. Primary Inputs Only: Extract only raw survey responses, not derived values
-3. Derive in Rules Engine: Qualifying children, tax liability, etc. computed in cosilico-us
+3. Derive in Rules Engine: Qualifying children, tax liability, etc. computed in policyengine-us
 
 The raw CPS is cached as HDF5 with all person/household/family tables.
 This allows adding new variables without re-downloading (~200MB per year).

--- a/micro/us/export_calibration_json.py
+++ b/micro/us/export_calibration_json.py
@@ -1,5 +1,5 @@
 """
-Export calibration results to JSON for the cosilico.ai dashboard.
+Export calibration results to JSON for the policyengine.org dashboard.
 """
 
 import json

--- a/micro/us/gradient_calibrate.py
+++ b/micro/us/gradient_calibrate.py
@@ -474,7 +474,7 @@ def calibrate_and_run(year: int = 2024) -> pd.DataFrame:
     from tax_unit_builder import load_and_build_tax_units
 
     print("=" * 70)
-    print("COSILICO MICRODATA CALIBRATION (Gradient Descent)")
+    print("POLICYENGINE MICRODATA CALIBRATION (Gradient Descent)")
     print("=" * 70)
 
     print("\n1. Loading tax unit data...")

--- a/micro/us/policyengine_runner.py
+++ b/micro/us/policyengine_runner.py
@@ -1,5 +1,5 @@
 """
-Run Cosilico encodings on CPS microdata.
+Run PolicyEngine encodings on CPS microdata.
 
 Applies statute-based tax calculations to tax unit data.
 """
@@ -542,12 +542,12 @@ def calculate_standard_deduction(df: pd.DataFrame, params: dict) -> np.ndarray:
 
 def run_all_calculations(df: pd.DataFrame, year: int = 2024) -> pd.DataFrame:
     """
-    Run all Cosilico tax calculations on tax unit data.
+    Run all PolicyEngine tax calculations on tax unit data.
 
     This is where POLICY is executed. The tax_unit_builder provides only
     raw data; all calculations per statute belong here.
 
-    Output column names match statute variable definitions in cosilico-us.
+    Output column names match statute variable definitions in policyengine-us.
 
     Args:
         df: Tax unit DataFrame from tax_unit_builder (raw data only)
@@ -619,10 +619,10 @@ if __name__ == "__main__":
     print("Loading tax units...")
     df = load_and_build_tax_units(2024)
 
-    print("Running Cosilico calculations...")
+    print("Running PolicyEngine calculations...")
     df = run_all_calculations(df)
 
-    print("\n=== Cosilico Calculation Results ===")
+    print("\n=== PolicyEngine Calculation Results ===")
     print(f"Tax units: {len(df):,}")
 
     # Weighted totals
@@ -641,9 +641,9 @@ if __name__ == "__main__":
     print(f"NIIT:           ${wtotal('niit'):>20,.0f}")
 
     # Compare to CPS reported values
-    print("\n--- CPS Reported vs Cosilico ---")
-    print(f"EITC: CPS=${wtotal('cps_eitc'):,.0f}, Cosilico=${wtotal('eitc'):,.0f}")
-    print(f"CTC:  CPS=${wtotal('cps_ctc'):,.0f}, Cosilico=${wtotal('total_child_tax_credit'):,.0f}")
+    print("\n--- CPS Reported vs PolicyEngine ---")
+    print(f"EITC: CPS=${wtotal('cps_eitc'):,.0f}, PolicyEngine=${wtotal('eitc'):,.0f}")
+    print(f"CTC:  CPS=${wtotal('cps_ctc'):,.0f}, PolicyEngine=${wtotal('total_child_tax_credit'):,.0f}")
 
     # Recipients
     print("\n--- Recipients (unweighted) ---")

--- a/micro/us/reforms.py
+++ b/micro/us/reforms.py
@@ -1,5 +1,5 @@
 """
-Cosilico Reform System.
+PolicyEngine Reform System.
 
 Supports both parametric and structural reforms for tax/benefit analysis.
 
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from typing import Callable
 from copy import deepcopy
 
-from cosilico_runner import PARAMS_2024, run_all_calculations
+from policyengine_runner import PARAMS_2024, run_all_calculations
 from tax_unit_builder import load_and_build_tax_units
 
 
@@ -157,13 +157,13 @@ def run_reform_analysis(
 
     # Need to modify run_all_calculations to accept params
     # For now, monkey-patch
-    import cosilico_runner
-    original_params = cosilico_runner.PARAMS_2024
-    cosilico_runner.PARAMS_2024 = reformed_params
+    import policyengine_runner
+    original_params = policyengine_runner.PARAMS_2024
+    policyengine_runner.PARAMS_2024 = reformed_params
 
     reform_df = run_all_calculations(df.copy(), year)
 
-    cosilico_runner.PARAMS_2024 = original_params
+    policyengine_runner.PARAMS_2024 = original_params
 
     # Calculate differences
     weight = df['weight'].values
@@ -263,11 +263,11 @@ def run_calibrated_reform_analysis(
     baseline_df = run_all_calculations(df.copy(), year)
 
     # Apply reform
-    import cosilico_runner
-    original_params = cosilico_runner.PARAMS_2024
-    cosilico_runner.PARAMS_2024 = reform.apply(baseline_params)
+    import policyengine_runner
+    original_params = policyengine_runner.PARAMS_2024
+    policyengine_runner.PARAMS_2024 = reform.apply(baseline_params)
     reform_df = run_all_calculations(df.copy(), year)
-    cosilico_runner.PARAMS_2024 = original_params
+    policyengine_runner.PARAMS_2024 = original_params
 
     # Calculate differences
     weight = df['weight'].values
@@ -319,7 +319,7 @@ if __name__ == "__main__":
     import sys
 
     print("=" * 70)
-    print("COSILICO REFORM ANALYSIS")
+    print("POLICYENGINE REFORM ANALYSIS")
     print("=" * 70)
 
     # Check for calibrated flag

--- a/micro/us/synthesis/validation.py
+++ b/micro/us/synthesis/validation.py
@@ -1,7 +1,7 @@
 """
 Validation framework for synthetic microdata.
 
-Compares Cosilico synthesis against:
+Compares PolicyEngine synthesis against:
 1. PolicyEngine Enhanced CPS (baseline)
 2. IRS SOI targets (ground truth)
 3. PUF (if available, for joint distribution)
@@ -449,7 +449,7 @@ class SynthesisValidator:
         pe_ecps: pd.DataFrame,
         puf: pd.DataFrame,
     ) -> List[ValidationMetric]:
-        """Compare Cosilico synthesis to PE ECPS using PUF as ground truth."""
+        """Compare PolicyEngine synthesis to PE ECPS using PUF as ground truth."""
         metrics = []
 
         available_vars = [v for v in self.continuous_vars
@@ -461,11 +461,11 @@ class SynthesisValidator:
             synth_corr = synthetic[available_vars].corr().values
             pe_corr = pe_ecps[available_vars].corr().values
 
-            cosilico_dist = np.linalg.norm(synth_corr - puf_corr, 'fro')
+            policyengine_dist = np.linalg.norm(synth_corr - puf_corr, 'fro')
             pe_dist = np.linalg.norm(pe_corr - puf_corr, 'fro')
 
-            # Improvement ratio (< 1 means Cosilico is better)
-            improvement = cosilico_dist / (pe_dist + 1e-8)
+            # Improvement ratio (< 1 means PolicyEngine is better)
+            improvement = policyengine_dist / (pe_dist + 1e-8)
 
             metrics.append(ValidationMetric(
                 name="correlation_vs_pe",
@@ -475,7 +475,7 @@ class SynthesisValidator:
                 threshold=1.0,  # Should be <= 1.0 (at least as good as PE)
                 direction="lower",
                 details={
-                    "cosilico_distance": cosilico_dist,
+                    "policyengine_distance": policyengine_dist,
                     "pe_distance": pe_dist,
                     "n_vars": len(available_vars),
                 }

--- a/micro/us/validate_dsl_income_tax.py
+++ b/micro/us/validate_dsl_income_tax.py
@@ -10,11 +10,11 @@ import pandas as pd
 from pathlib import Path
 import sys
 
-# Add cosilico-engine to path
-engine_path = Path(__file__).parents[3] / "cosilico-engine" / "src"
+# Add the legacy RuleSpec engine to the path when checked out next to this repo.
+engine_path = Path.home() / "TheAxiomFoundation" / "axiom-rules-engine" / "python"
 sys.path.insert(0, str(engine_path))
 
-from cosilico.brackets import marginal_agg  # noqa: E402
+from policyengine.brackets import marginal_agg  # noqa: E402
 
 
 def load_tax_units() -> pd.DataFrame:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
-name = "cosilico-arch"
+name = "policyengine-arch-data"
 version = "0.1.0"
-description = "Cosilico Arch source-data foundation: source facts, microdata, and target inputs"
+description = "PolicyEngine Arch source-data foundation: source facts, microdata, and target inputs"
 readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.11"
 authors = [
-    { name = "Cosilico", email = "hello@cosilico.ai" }
+    { name = "PolicyEngine", email = "hello@policyengine.org" }
 ]
 
 dependencies = [

--- a/scripts/cps_to_policyengine.py
+++ b/scripts/cps_to_policyengine.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 """
-CPS to Cosilico Converter
+CPS to PolicyEngine Converter
 
-Converts CPS ASEC microdata to the Cosilico input format for microsimulation.
-Maps CPS survey variables to statute input variables used by cosilico-us.
+Converts CPS ASEC microdata to the PolicyEngine input format for microsimulation.
+Maps CPS survey variables to statute input variables used by policyengine-us.
 
 Usage:
-    python cps_to_cosilico.py --year 2024 --output microsim_2024.parquet
-    python cps_to_cosilico.py --year 2024 --calibrate --output microsim_2024_calibrated.parquet
+    python cps_to_policyengine.py --year 2024 --output microsim_2024.parquet
+    python cps_to_policyengine.py --year 2024 --calibrate --output microsim_2024_calibrated.parquet
 
 Output format:
     - Person-level records with unique IDs
@@ -24,10 +24,10 @@ import pandas as pd
 
 
 # =============================================================================
-# CPS Variable to Cosilico Statute Variable Mappings
+# CPS Variable to PolicyEngine Statute Variable Mappings
 # =============================================================================
 
-# Income variables: CPS variable -> Cosilico statute variable
+# Income variables: CPS variable -> PolicyEngine statute variable
 INCOME_MAPPINGS = {
     # Earned income (IRC 32(c)(2))
     "WSAL_VAL": "wages",
@@ -149,7 +149,7 @@ def load_cps_from_cache(year: int, cache_dir: Optional[Path] = None) -> pd.DataF
 
 
 def transform_income_variables(df: pd.DataFrame) -> pd.DataFrame:
-    """Transform CPS income variables to Cosilico format."""
+    """Transform CPS income variables to PolicyEngine format."""
     result = pd.DataFrame(index=df.index)
 
     for cps_var, cos_var in INCOME_MAPPINGS.items():
@@ -174,7 +174,7 @@ def transform_income_variables(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def transform_tax_variables(df: pd.DataFrame) -> pd.DataFrame:
-    """Transform CPS tax unit variables to Cosilico format."""
+    """Transform CPS tax unit variables to PolicyEngine format."""
     result = pd.DataFrame(index=df.index)
 
     for cps_var, cos_var in TAX_UNIT_MAPPINGS.items():
@@ -187,7 +187,7 @@ def transform_tax_variables(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def transform_demographics(df: pd.DataFrame) -> pd.DataFrame:
-    """Transform CPS demographic variables to Cosilico format."""
+    """Transform CPS demographic variables to PolicyEngine format."""
     result = pd.DataFrame(index=df.index)
 
     for cps_var, cos_var in DEMOGRAPHIC_MAPPINGS.items():
@@ -253,14 +253,14 @@ def transform_weights(df: pd.DataFrame) -> pd.DataFrame:
     return result
 
 
-def convert_cps_to_cosilico(
+def convert_cps_to_policyengine(
     year: int,
     output_path: Optional[Path] = None,
     calibrate: bool = False,
     cache_dir: Optional[Path] = None,
 ) -> pd.DataFrame:
     """
-    Convert CPS microdata to Cosilico input format.
+    Convert CPS microdata to PolicyEngine input format.
 
     Args:
         year: Tax year (e.g., 2024)
@@ -269,12 +269,12 @@ def convert_cps_to_cosilico(
         cache_dir: Override default cache directory
 
     Returns:
-        DataFrame in Cosilico input format
+        DataFrame in PolicyEngine input format
     """
     # Load raw CPS data
     cps = load_cps_from_cache(year, cache_dir)
 
-    print("Transforming to Cosilico format...")
+    print("Transforming to PolicyEngine format...")
 
     # Transform all variable groups
     income = transform_income_variables(cps)
@@ -309,7 +309,7 @@ def convert_cps_to_cosilico(
     # Save output
     if output_path is None:
         output_dir = Path(__file__).parent.parent / "micro" / "us"
-        output_path = output_dir / f"cosilico_input_{year}.parquet"
+        output_path = output_dir / f"policyengine_input_{year}.parquet"
 
     output_path = Path(output_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -384,7 +384,7 @@ def generate_summary(df: pd.DataFrame, year: int) -> dict:
 def print_summary(summary: dict) -> None:
     """Print formatted summary statistics."""
     print("\n" + "=" * 60)
-    print(f"COSILICO INPUT SUMMARY - {summary['year']}")
+    print(f"POLICYENGINE INPUT SUMMARY - {summary['year']}")
     print("=" * 60)
     print(f"Records: {summary['record_count']:,}")
     print(f"Weighted population: {summary['weighted_population']:,.0f}")
@@ -399,7 +399,7 @@ def print_summary(summary: dict) -> None:
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Convert CPS ASEC microdata to Cosilico input format"
+        description="Convert CPS ASEC microdata to PolicyEngine input format"
     )
     parser.add_argument(
         "--year",
@@ -433,7 +433,7 @@ def main():
     output_path = Path(args.output) if args.output else None
     cache_dir = Path(args.cache_dir) if args.cache_dir else None
 
-    df = convert_cps_to_cosilico(
+    df = convert_cps_to_policyengine(
         year=args.year,
         output_path=output_path,
         calibrate=args.calibrate,

--- a/scripts/export_to_json.py
+++ b/scripts/export_to_json.py
@@ -18,7 +18,7 @@ def export_targets_summary(output_path: Path | None = None):
     """Export summary statistics for the calibration dashboard."""
 
     if output_path is None:
-        output_path = Path(__file__).parent.parent.parent / "cosilico.ai" / "public" / "data" / "targets_summary.json"
+        output_path = Path(__file__).parent.parent.parent / "policyengine.org" / "public" / "data" / "targets_summary.json"
 
     engine = get_engine(DEFAULT_DB_PATH)
 

--- a/tests/test_supabase_client.py
+++ b/tests/test_supabase_client.py
@@ -17,10 +17,10 @@ class TestSupabaseClient:
         from db.supabase_client import get_supabase_client
 
         # Skip if no real credentials
-        if not os.environ.get("COSILICO_SUPABASE_URL"):
-            pytest.skip("COSILICO_SUPABASE_URL not set")
-        if not os.environ.get("COSILICO_SUPABASE_SECRET_KEY"):
-            pytest.skip("COSILICO_SUPABASE_SECRET_KEY not set")
+        if not os.environ.get("POLICYENGINE_SUPABASE_URL"):
+            pytest.skip("POLICYENGINE_SUPABASE_URL not set")
+        if not os.environ.get("POLICYENGINE_SUPABASE_SECRET_KEY"):
+            pytest.skip("POLICYENGINE_SUPABASE_SECRET_KEY not set")
 
         # Clear the lru_cache to ensure fresh client
         get_supabase_client.cache_clear()
@@ -32,8 +32,8 @@ class TestSupabaseClient:
         from db.supabase_client import SupabaseConfig
 
         with patch.dict(os.environ, {
-            "COSILICO_SUPABASE_URL": "https://test.supabase.co",
-            "COSILICO_SUPABASE_SECRET_KEY": "test-secret-key",
+            "POLICYENGINE_SUPABASE_URL": "https://test.supabase.co",
+            "POLICYENGINE_SUPABASE_SECRET_KEY": "test-secret-key",
         }):
             config = SupabaseConfig.from_env()
             assert config.url == "https://test.supabase.co"
@@ -44,7 +44,7 @@ class TestSupabaseClient:
         from db.supabase_client import SupabaseConfig
 
         with patch.dict(os.environ, {}, clear=True):
-            with pytest.raises(ValueError, match="COSILICO_SUPABASE_URL"):
+            with pytest.raises(ValueError, match="POLICYENGINE_SUPABASE_URL"):
                 SupabaseConfig.from_env()
 
     def test_config_missing_key_raises(self):
@@ -52,9 +52,9 @@ class TestSupabaseClient:
         from db.supabase_client import SupabaseConfig
 
         with patch.dict(os.environ, {
-            "COSILICO_SUPABASE_URL": "https://test.supabase.co",
+            "POLICYENGINE_SUPABASE_URL": "https://test.supabase.co",
         }, clear=True):
-            with pytest.raises(ValueError, match="COSILICO_SUPABASE_SECRET_KEY"):
+            with pytest.raises(ValueError, match="POLICYENGINE_SUPABASE_SECRET_KEY"):
                 SupabaseConfig.from_env()
 
 

--- a/tests/test_synthesis/test_evaluation.py
+++ b/tests/test_synthesis/test_evaluation.py
@@ -3,7 +3,7 @@ Tests for synthetic data evaluation metrics.
 
 TDD: Write tests first, then implement to pass.
 
-Compares Cosilico synthesis vs PolicyEngine Enhanced CPS vs IRS SOI ground truth.
+Compares PolicyEngine synthesis vs PolicyEngine Enhanced CPS vs IRS SOI ground truth.
 """
 
 import pytest
@@ -205,47 +205,47 @@ class TestPolicyUtility:
 # =============================================================================
 
 class TestVsPolicyEngineECPS:
-    """Compare Cosilico synthesis vs PolicyEngine Enhanced CPS."""
+    """Compare PolicyEngine synthesis vs PolicyEngine Enhanced CPS."""
 
-    def test_correlation_preservation_vs_pe(self, cosilico_data, pe_ecps_data, puf_data, tax_vars):
-        """Cosilico should have better correlation preservation than PE ECPS."""
+    def test_correlation_preservation_vs_pe(self, policyengine_data, pe_ecps_data, puf_data, tax_vars):
+        """PolicyEngine should have better correlation preservation than PE ECPS."""
         from micro.us.synthesis.evaluation import compute_weighted_correlation_matrix
 
         puf_corr = compute_weighted_correlation_matrix(puf_data[tax_vars], puf_data['weight'])
-        cosilico_corr = compute_weighted_correlation_matrix(cosilico_data[tax_vars], cosilico_data['weight'])
+        policyengine_corr = compute_weighted_correlation_matrix(policyengine_data[tax_vars], policyengine_data['weight'])
         pe_corr = compute_weighted_correlation_matrix(pe_ecps_data[tax_vars], pe_ecps_data['weight'])
 
-        cosilico_dist = np.linalg.norm(cosilico_corr - puf_corr, 'fro')
+        policyengine_dist = np.linalg.norm(policyengine_corr - puf_corr, 'fro')
         pe_dist = np.linalg.norm(pe_corr - puf_corr, 'fro')
 
-        # Cosilico should be at least as good as PE
-        assert cosilico_dist <= pe_dist * 1.1, \
-            f"Cosilico correlation dist {cosilico_dist:.2f} worse than PE {pe_dist:.2f}"
+        # PolicyEngine should be at least as good as PE
+        assert policyengine_dist <= pe_dist * 1.1, \
+            f"PolicyEngine correlation dist {policyengine_dist:.2f} worse than PE {pe_dist:.2f}"
 
-    def test_joint_distribution_quality_vs_pe(self, cosilico_data, pe_ecps_data, puf_data):
-        """Cosilico should have better joint distribution fidelity."""
+    def test_joint_distribution_quality_vs_pe(self, policyengine_data, pe_ecps_data, puf_data):
+        """PolicyEngine should have better joint distribution fidelity."""
         from micro.us.synthesis.evaluation import compute_joint_distribution_score
 
-        cosilico_score = compute_joint_distribution_score(cosilico_data, puf_data)
+        policyengine_score = compute_joint_distribution_score(policyengine_data, puf_data)
         pe_score = compute_joint_distribution_score(pe_ecps_data, puf_data)
 
         # Higher score = better joint distribution match
-        assert cosilico_score >= pe_score * 0.9, \
-            f"Cosilico joint score {cosilico_score:.3f} vs PE {pe_score:.3f}"
+        assert policyengine_score >= pe_score * 0.9, \
+            f"PolicyEngine joint score {policyengine_score:.3f} vs PE {pe_score:.3f}"
 
-    def test_calibration_parity(self, cosilico_data, pe_ecps_data, irs_soi_targets):
+    def test_calibration_parity(self, policyengine_data, pe_ecps_data, irs_soi_targets):
         """Both should match IRS SOI calibration targets similarly."""
         from micro.us.synthesis.evaluation import compute_calibration_errors
 
-        cosilico_errors = compute_calibration_errors(cosilico_data, irs_soi_targets)
+        policyengine_errors = compute_calibration_errors(policyengine_data, irs_soi_targets)
         pe_errors = compute_calibration_errors(pe_ecps_data, irs_soi_targets)
 
-        # Cosilico should match calibration at least as well as PE
-        cosilico_max_error = max(abs(e) for e in cosilico_errors.values())
+        # PolicyEngine should match calibration at least as well as PE
+        policyengine_max_error = max(abs(e) for e in policyengine_errors.values())
         pe_max_error = max(abs(e) for e in pe_errors.values())
 
-        assert cosilico_max_error <= pe_max_error * 1.2, \
-            f"Cosilico max calibration error {cosilico_max_error:.1%} worse than PE {pe_max_error:.1%}"
+        assert policyengine_max_error <= pe_max_error * 1.2, \
+            f"PolicyEngine max calibration error {policyengine_max_error:.1%} worse than PE {pe_max_error:.1%}"
 
 
 # =============================================================================
@@ -324,10 +324,10 @@ def pe_ecps_data():
 
 
 @pytest.fixture
-def cosilico_data():
-    """Load Cosilico synthetic data."""
+def policyengine_data():
+    """Load PolicyEngine synthetic data."""
     # TODO: Implement after synthesis is complete
-    pytest.skip("Cosilico synthesis not yet implemented")
+    pytest.skip("PolicyEngine synthesis not yet implemented")
 
 
 @pytest.fixture

--- a/uv.lock
+++ b/uv.lock
@@ -281,7 +281,7 @@ wheels = [
 ]
 
 [[package]]
-name = "cosilico-arch"
+name = "policyengine-arch-data"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
## Summary
- replace remaining Cosilico/CosilicoAI naming with PolicyEngine/arch-data branding
- rename legacy Cosilico-named scripts/runners to PolicyEngine names
- update Supabase env var names and tests to the PolicyEngine prefix

## Checks
- git grep -i cosilico: clean
- uv run ruff check .
- uv run pytest -q tests/test_supabase_client.py tests/test_synthesis/test_evaluation.py