### PR TITLE
Add KFF marketplace enrollment source package

### DIFF
--- a/arch/source_package.py
+++ b/arch/source_package.py
@@ -93,6 +93,9 @@ SOURCE_PACKAGE_ALIASES = {
     ),
     "hhs-acf-tanf-caseload-2024": Path("hhs_acf/tanf_caseload_2024"),
     "hhs-acf-tanf-financial-2024": Path("hhs_acf/tanf_financial_2024"),
+    "kff-marketplace-effectuated-enrollment": Path(
+        "kff/marketplace_effectuated_enrollment"
+    ),
     "usda-snap-fy69-to-current": Path("usda_snap/fy69_to_current"),
 }
 SOURCE_ARTIFACT_CACHE_ENV = "ARCH_SOURCE_ARTIFACT_CACHE_DIR"

--- a/db/data/kff/marketplace_effectuated_enrollment/full-year-average-marketplace-effectuated-enrollment.html
+++ b/db/data/kff/marketplace_effectuated_enrollment/full-year-average-marketplace-effectuated-enrollment.html
@@ -1,0 +1,1105 @@
+<!DOCTYPE html>
+<html lang="en-US" class="no-js">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>(function(html){html.className = html.className.replace(/\bno-js\b/,'js')})(document.documentElement);</script>
+<meta name='robots' content='index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1' />
+	<style>img:is([sizes="auto" i], [sizes^="auto," i]) { contain-intrinsic-size: 3000px 1500px }</style>
+	
+	<!-- This site is optimized with the Yoast SEO Premium plugin v27.5 (Yoast SEO v27.5) - https://yoast.com/product/yoast-seo-premium-wordpress/ -->
+	<title>Full Year Average Marketplace Effectuated Enrollment, 2017-2024 | KFF State Health Facts</title>
+	<meta name="description" content="State level data on Full Year Average Marketplace Effectuated Enrollment, 2017-2024 from KFF, the leading health policy organization in the U.S." />
+	<link rel="canonical" href="https://www.kff.org/affordable-care-act/state-indicator/full-year-average-marketplace-effectuated-enrollment/" />
+	<meta property="og:locale" content="en_US" />
+	<meta property="og:type" content="article" />
+	<meta property="og:title" content="Full Year Average Marketplace Effectuated Enrollment, 2017-2024 | KFF State Health Facts" />
+	<meta property="og:description" content="State level data on Full Year Average Marketplace Effectuated Enrollment, 2017-2024 from KFF, the leading health policy organization in the U.S." />
+	<meta property="og:url" content="https://www.kff.org/affordable-care-act/state-indicator/full-year-average-marketplace-effectuated-enrollment/" />
+	<meta property="og:site_name" content="KFF" />
+	<meta property="article:modified_time" content="2026-04-09T19:57:12+00:00" />
+	<meta property="og:image" content="https://www.kff.org/wp-content/uploads/sites/7/2022/04/250421_State-Health-Facts_FI.png" />
+	<meta property="og:image:width" content="1920" />
+	<meta property="og:image:height" content="1080" />
+	<meta property="og:image:type" content="image/png" />
+	<meta name="twitter:card" content="summary_large_image" />
+	<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https:\/\/schema.org","@graph":[{"@type":"WebPage","@id":"https:\/\/www.kff.org\/affordable-care-act\/state-indicator\/full-year-average-marketplace-effectuated-enrollment\/","url":"https:\/\/www.kff.org\/affordable-care-act\/state-indicator\/full-year-average-marketplace-effectuated-enrollment\/","name":"Full Year Average Marketplace Effectuated Enrollment, 2017-2024 | KFF State Health Facts","isPartOf":{"@id":"https:\/\/www.kff.org\/#website"},"datePublished":"2026-04-09T19:49:33+00:00","dateModified":"2026-04-09T19:57:12+00:00","description":"State level data on Full Year Average Marketplace Effectuated Enrollment, 2017-2024 from KFF, the leading health policy organization in the U.S.","breadcrumb":{"@id":"https:\/\/www.kff.org\/affordable-care-act\/state-indicator\/full-year-average-marketplace-effectuated-enrollment\/#breadcrumb"},"inLanguage":"en-US","potentialAction":[{"@type":"ReadAction","target":["https:\/\/www.kff.org\/affordable-care-act\/state-indicator\/full-year-average-marketplace-effectuated-enrollment\/"]}]},{"@type":"WebSite","@id":"https:\/\/www.kff.org\/#website","url":"https:\/\/www.kff.org\/","name":"KFF - The independent source for health policy research, polling, and news","description":"The independent source for health policy research, polling, and news","publisher":{"@id":"https:\/\/www.kff.org\/#organization"},"potentialAction":[{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https:\/\/www.kff.org\/?s={search_term_string}"},"query-input":{"@type":"PropertyValueSpecification","valueRequired":true,"valueName":"search_term_string"}}],"inLanguage":"en-US"},{"@type":"Organization","@id":"https:\/\/www.kff.org\/#organization","name":"KFF","url":"https:\/\/www.kff.org\/","logo":{"@type":"ImageObject","inLanguage":"en-US","@id":"https:\/\/www.kff.org\/#\/schema\/logo\/image\/","url":"https:\/\/www.kff.org\/wp-content\/uploads\/sites\/7\/2025\/04\/KFF_Black.png","contentUrl":"https:\/\/www.kff.org\/wp-content\/uploads\/sites\/7\/2025\/04\/KFF_Black.png","width":3186,"height":1296,"caption":"KFF"},"image":{"@id":"https:\/\/www.kff.org\/#\/schema\/logo\/image\/"}},{"@type":"BreadcrumbList","@id":"https:\/\/www.kff.org\/affordable-care-act\/state-indicator\/full-year-average-marketplace-effectuated-enrollment\/#breadcrumb","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https:\/\/www.kff.org"},{"@type":"ListItem","position":2,"name":"State Health Facts","item":"\/state-health-facts\/"},{"@type":"ListItem","position":3,"name":"Affordable Care Act","item":"https:\/\/www.kff.org\/state-category\/affordable-care-act\/"},{"@type":"ListItem","position":4,"name":"Health Insurance Marketplaces","item":"https:\/\/www.kff.org\/state-category\/affordable-care-act\/health-insurance-marketplaces\/"},{"@type":"ListItem","position":5,"name":"Full Year Average Marketplace Effectuated Enrollment, 2017-2024"}]}]}</script>
+	<!-- / Yoast SEO Premium plugin. -->
+
+
+<link rel='dns-prefetch' href='//ajax.googleapis.com' />
+<link rel='dns-prefetch' href='//secure.gravatar.com' />
+<link rel='dns-prefetch' href='//www.google.com' />
+<link rel='dns-prefetch' href='//stats.wp.com' />
+<link rel='dns-prefetch' href='//v0.wordpress.com' />
+<link rel="alternate" type="application/rss+xml" title="KFF &raquo; Feed" href="https://www.kff.org/feed/" />
+<link rel="alternate" type="application/rss+xml" title="KFF &raquo; Comments Feed" href="https://www.kff.org/comments/feed/" />
+<link rel='stylesheet' id='wp-block-library-css' href='https://www.kff.org/wp-includes/css/dist/block-library/style.min.css?ver=6.8.5' type='text/css' media='all' />
+<link rel='stylesheet' id='jetpack-forms-layout-css' href='https://www.kff.org/wp-content/mu-plugins/jetpack-15.7/jetpack_vendor/automattic/jetpack-forms/src/../dist/contact-form/css/jetpack-forms-layout.css?ver=15.7' type='text/css' media='all' />
+<style id='kff-common-guided-content-entry-style-inline-css' type='text/css'>
+.gc-entry-meta{align-items:center;-moz-column-gap:1.25rem;column-gap:1.25rem;display:flex;flex-wrap:wrap;margin-bottom:.5rem;order:-1;row-gap:.5rem}.gc-entry-meta p{font-weight:600!important;line-height:1.3!important}.gc-entry-label{background-color:#d9d9d9;border-radius:2px;margin:0;padding:.375rem .75rem}.gc-entry-eyebrow{font-weight:400;margin:0;padding:.375rem 0;width:-moz-fit-content;width:fit-content}.gc-entry__subtitle{font-size:11px;font-weight:500;line-height:1.4;margin-top:0;text-transform:uppercase}
+
+</style>
+<style id='kff-common-share-tools-style-inline-css' type='text/css'>
+.wp-block-kff-common-share-tools .share{margin:20px 0}
+
+</style>
+<style id='kff-common-pym-embed-style-inline-css' type='text/css'>
+@media(max-width:768px){.wp-block-kff-common-pym-embed{height:auto!important;width:100%!important}}@media screen and (min-width:768px){.has-blocks .article-body .wp-block-kff-common-pym-embed.alignfull,.has-blocks .article-body .wp-block-kff-common-pym-embed.alignwide{padding:0 1.5rem}}.wp-block-kff-common-pym-embed .pymjs-embed-inner.pymjs-has-custom-width{display:block;margin-left:auto;margin-right:auto}
+
+</style>
+<style id='kff-shared-authors-style-inline-css' type='text/css'>
+.wp-block-kff-shared-authors{align-items:center;display:flex;gap:var(--m-3)}.wp-block-kff-shared-authors__title{flex-shrink:0;font-size:var(--fs-body-md);font-weight:var(--fw-bold);line-height:var(--lh-m)}.wp-block-kff-shared-authors__list{display:flex;flex-wrap:wrap}@media (min-width:48em){.wp-block-kff-shared-authors__list{gap:var(--m-3)}.wp-block-kff-shared-authors__list.wp-block-kff-shared-authors__list--show-seperators{gap:var(--m-0)}.wp-block-kff-shared-authors__list.wp-block-kff-shared-authors__list--show-seperators .wp-block-kff-shared-authors__seperator{display:block}}.wp-block-kff-shared-authors__author{font-size:var(--fs-body-md);font-weight:var(--fw-semi-bold);line-height:var(--lh-m)}@media (min-width:48em){.wp-block-kff-shared-authors__author{align-items:center;display:flex;gap:var(--m-1)}}a.wp-block-kff-shared-authors__author{color:var(--c-text-action-hover);-webkit-text-decoration:none;text-decoration:none}a.wp-block-kff-shared-authors__author:hover{-webkit-text-decoration:underline;text-decoration:underline}img.wp-block-kff-shared-authors__image{border-radius:50%;display:none;height:50px;-o-object-fit:cover;object-fit:cover;width:50px}@media (min-width:48em){img.wp-block-kff-shared-authors__image{display:block}}.post-type-archive-quick-take img.wp-block-kff-shared-authors__image{display:block}.wp-block-kff-shared-authors__seperator{margin-right:.3125rem}@media (min-width:48em){.wp-block-kff-shared-authors__seperator{display:none}}
+
+</style>
+<style id='kff-shared-contact-info-style-inline-css' type='text/css'>
+.wp-block-kff-shared-contact-info__details span{display:block}.wp-block-kff-shared-contact-info__details a{color:var(--c-text-hover);-webkit-text-decoration:none;text-decoration:none}.wp-block-kff-shared-contact-info__details a:hover{color:var(--c-text-action-hover);-webkit-text-decoration:underline;text-decoration:underline}.wp-block-kff-shared-contact-info__name{font-size:var(--fs-body-lg)}.wp-block-kff-shared-contact-info__title{font-size:var(--fs-body-md)}.wp-block-kff-shared-contact-info__email,.wp-block-kff-shared-contact-info__phone{align-items:center;display:inline-flex;font-size:var(--fs-body-sm);gap:var(--m-1)}.wp-block-kff-shared-contact-info__title-wrapper{margin-bottom:var(--m-2)}
+
+</style>
+<style id='kff-shared-content-main-style-inline-css' type='text/css'>
+.no-sidebar.wp-block-kff-shared-content .wp-block-kff-shared-content-main{max-width:100%}.no-sidebar.wp-block-kff-shared-content .wp-block-kff-shared-content-main .wp-block-kff-shared-content-main__content__inner{max-width:1060px}.wp-block-kff-shared-content-main{margin:0;max-width:910px;padding:0;width:100%}@media (min-width:48em){.wp-block-kff-shared-content-main{flex:1}.wp-block-kff-shared-content-main:has(.wp-block-advgb-table){overflow:hidden}}.wp-block-kff-shared-content-main__content__inner{margin:0 auto;max-width:836px;width:100%}.no-sidebar.wp-block-kff-shared-content.wp-block-kff-shared-content--blank-slate .wp-block-kff-shared-content-main .wp-block-kff-shared-content-main__content__inner,.no-sidebar.wp-block-kff-shared-content.wp-block-kff-shared-content--extra-wide .wp-block-kff-shared-content-main .wp-block-kff-shared-content-main__content__inner{max-width:1280px}.no-sidebar.wp-block-kff-shared-content.wp-block-kff-shared-content--blank-slate .wp-block-kff-shared-content-main__content__inner>:first-child{margin-top:0}
+
+</style>
+<link rel='stylesheet' id='kff-shared-content-sidebar-style-css' href='https://www.kff.org/wp-content/plugins/kff-shared/dist/blocks/content-sidebar/style.css?ver=8daa2f5128cfeae9c2435492025383ac8731eb2850530351c855237edb5426e2' type='text/css' media='all' />
+<style id='kff-shared-content-style-inline-css' type='text/css'>
+.wp-block-kff-shared-content{display:flex;flex-direction:column;margin:var(--m-0);padding:var(--p-0);row-gap:var(--p-2)}@media (min-width:48em){.wp-block-kff-shared-content{-moz-column-gap:var(--p-10);column-gap:var(--p-10);flex-direction:row;justify-content:space-between}}.wp-block-kff-shared-content--extra-wide .post-header{max-width:1280px;text-align:center}.wp-block-kff-shared-content--extra-wide .post-header__social-sharing{justify-content:center}
+
+</style>
+<style id='kff-shared-description-details-style-inline-css' type='text/css'>
+
+
+</style>
+<style id='kff-shared-description-list-style-inline-css' type='text/css'>
+
+
+</style>
+<style id='kff-shared-description-term-style-inline-css' type='text/css'>
+
+
+</style>
+<style id='tenup-editorial-update-item-style-inline-css' type='text/css'>
+.wp-block-tenup-editorial-update-item{border-bottom:1px solid var(--c-border-primary);display:flex;flex-direction:column;gap:var(--m-0-5);padding:var(--p-1) var(--p-0)}.wp-block-tenup-editorial-update-item:last-child{border-bottom:none}.wp-block-tenup-editorial-update-item .editorial-update-item__date{color:var(--c-text-primary);font-size:var(--fs-body-lg);font-weight:var(--fw-semi-bold);line-height:var(--lh-m);margin:var(--m-0);padding:var(--p-0)}.wp-block-tenup-editorial-update-item .editorial-update-item__content{color:var(--c-text-primary);font-size:var(--fs-body-sm);font-weight:var(--fw-normal);line-height:var(--lh-m);margin:var(--m-0);padding:var(--p-0)}.wp-block-tenup-editorial-update-item .editorial-update-item__content a{color:var(--c-text-hover)}.wp-block-tenup-editorial-update-item .editorial-update-item__content a:hover{-webkit-text-decoration:none;text-decoration:none}.wp-block-tenup-editorial-update-item .editorial-update-item__content a:visited{color:var(--c-text-visited)}
+
+</style>
+<link rel='stylesheet' id='tenup-editorial-updates-style-css' href='https://www.kff.org/wp-content/plugins/kff-shared/dist/blocks/editorial-updates/style.css?ver=75943d8add94249060e6f0ca3a4f577fbfd9785d813c7edb09ae0ecba86a1170' type='text/css' media='all' />
+<style id='kff-shared-embeddable-map-style-inline-css' type='text/css'>
+
+
+</style>
+<style id='kff-shared-exhibit-style-inline-css' type='text/css'>
+.wp-block-kff-shared-exhibit__toggle{background:none;border:none;color:var(--c-text-hover);cursor:pointer;font-size:var(--fs-button-lg);font-weight:var(--fw-semi-bold);line-height:var(--lh-m);margin:var(--m-0);padding:var(--p-0);-webkit-text-decoration:none;text-decoration:none}.wp-block-kff-shared-exhibit__toggle:hover{-webkit-text-decoration:underline;text-decoration:underline}.wp-block-kff-shared-exhibit__list{display:none}.wp-block-kff-shared-exhibit.open .wp-block-kff-shared-exhibit__list{display:block}.wp-block-kff-shared-exhibit__link{background:none;border:0;color:var(--c-text-hover);cursor:pointer;margin:var(--m-0);padding:var(--p-0);-webkit-text-decoration:underline;text-decoration:underline}.wp-block-kff-shared-exhibit__link:hover{-webkit-text-decoration:none;text-decoration:none}
+
+</style>
+<style id='kff-shared-indicator-style-inline-css' type='text/css'>
+
+
+</style>
+<style id='kff-shared-people-style-inline-css' type='text/css'>
+.wp-block-kff-shared-people{display:flex;flex-direction:column;gap:var(--m-3)}.wp-block-kff-shared-people__title{font-size:var(--fs-heading-3);font-weight:var(--fw-semi-bold);line-height:var(--lh-s);margin:var(--m-0);padding:var(--p-0)}.wp-block-kff-shared-people__list{display:flex;flex-direction:column;gap:var(--m-3)}@media (min-width:48em){.wp-block-kff-shared-people__list{display:grid;grid-template-columns:repeat(4,minmax(0,210px))}}
+
+</style>
+<style id='kff-shared-person-style-inline-css' type='text/css'>
+.wp-block-kff-shared-person{border-bottom:1px solid var(--c-border-primary);padding-bottom:var(--m-3)}@media (min-width:48em){.wp-block-kff-shared-person{border-bottom:none}}.wp-block-kff-shared-person__image{display:block;height:auto;max-width:100%;width:100%}.wp-block-kff-shared-person__name{color:var(--c-text-primary);font-size:var(--fs-body-lg);font-weight:var(--fw-semi-bold);line-height:var(--lh-m);margin:var(--m-1) var(--m-0) var(--m-0) var(--m-0);padding:var(--p-0)}.wp-block-kff-shared-person__name a{color:var(--c-text-hover);-webkit-text-decoration:none;text-decoration:none}.wp-block-kff-shared-person__name a:hover{-webkit-text-decoration:underline;text-decoration:underline}.wp-block-kff-shared-person__title{color:var(--c-text-primary);font-size:var(--fs-body-lg);font-weight:var(--fw-normal);line-height:var(--lh-m);margin:var(--m-0-5) var(--m-0) var(--m-0) var(--m-0);padding:var(--p-0)}.wp-block-kff-shared-person.is-selected{border-bottom:0;padding-bottom:var(--p-0)}
+
+</style>
+<link rel='stylesheet' id='kff-shared-post-card-style-css' href='https://www.kff.org/wp-content/plugins/kff-shared/dist/blocks/post-card/style-index.css?ver=5.0.0' type='text/css' media='all' />
+<style id='kff-shared-related-content-link-style-inline-css' type='text/css'>
+
+
+</style>
+<style id='kff-shared-related-content-post-style-inline-css' type='text/css'>
+
+
+</style>
+<style id='kff-shared-related-content-style-inline-css' type='text/css'>
+
+
+</style>
+<style id='kff-shared-river-style-inline-css' type='text/css'>
+.wp-block-kff-shared-river__header{color:var(--c-text-primary);display:flex;flex-direction:column-reverse;font-size:var(--fs-body-sm);font-weight:var(--fw-bold);gap:var(--m-0-5);letter-spacing:4%;line-height:var(--lh-ms);padding:var(--p-5) var(--p-0);text-transform:uppercase}@media (min-width:64em){.wp-block-kff-shared-river__header{align-items:center;flex-direction:row;gap:var(--m-1-25);justify-content:space-between}}.wp-block-kff-shared-river__text{flex-shrink:0}.wp-block-kff-shared-river__bar{background-color:var(--c-text-hover);height:4px;position:relative;width:100%}.wp-block-kff-shared-river__bar:before{background-color:var(--c-surface-accent-2);content:"";height:4px;left:0;position:absolute;top:0;width:80px}
+
+</style>
+<style id='kff-shared-rstudio-style-inline-css' type='text/css'>
+.wp-block-kff-shared-rstudio{margin:var(--wp--preset--spacing--m-3) auto}@media (min-width:64em){.wp-block-kff-shared-rstudio{margin:var(--wp--preset--spacing--m-5) auto}}
+
+</style>
+<link rel='stylesheet' id='kff-shared-section-heading-style-css' href='https://www.kff.org/wp-content/plugins/kff-shared/dist/blocks/section-heading/style.css?ver=0f67cedbbe6b2a2e5c037f95a11c8cd451ec6effd6bb44ced1a4f8f66546bec7' type='text/css' media='all' />
+<link rel='stylesheet' id='kff-shared-slab-style-css' href='https://www.kff.org/wp-content/plugins/kff-shared/dist/blocks/slab/style.css?ver=d7ab038f704c0656b0165a713571cc935b531547dfe8d8393f46cd7c66643ae5' type='text/css' media='all' />
+<link rel='stylesheet' id='tenup-table-of-contents-style-css' href='https://www.kff.org/wp-content/plugins/kff-shared/dist/blocks/table-of-contents/style.css?ver=1.0.0' type='text/css' media='all' />
+<style id='advgb-table-style-inline-css' type='text/css'>
+.editor-styles-wrapper .wp-block[data-align=center]>.wp-block-advgb-table td{text-align:left}.advgb-table-wrapper{overflow-x:auto;overflow-y:hidden;overflow:auto hidden}.wp-block-advgb-table{border:none;border-collapse:collapse;border-spacing:0;color:var(--c-text-primary,var(--wp--preset--color--neutral-700));display:table;font-size:var(--fs-body-md);font-weight:var(--fw-normal);letter-spacing:0;line-height:var(--lh-m);margin:0 auto 1em;max-width:100%;min-width:100%;-webkit-overflow-scrolling:touch;table-layout:fixed}@media (--bp-medium ){.wp-block-advgb-table{-webkit-overflow-scrolling:auto;overflow-x:hidden;vertical-align:middle}}.wp-block-advgb-table.aligncenter{display:table;text-align:left}.wp-block-advgb-table th{border-bottom:1px solid var(--wp--preset--color--neutral-700);padding:var(--p-1) var(--p-2);text-align:left}.wp-block-advgb-table tbody{border-bottom:1px solid var(--wp--preset--color--neutral-400)}.wp-block-advgb-table tbody td{border:1px solid var(--wp--preset--color--neutral-300);padding:var(--p-1) var(--p-2)}.wp-block-advgb-table tbody tr td:first-child{border-left:transparent}.wp-block-advgb-table tbody tr td:last-child{border-right:transparent}.wp-block-advgb-table tbody a{color:var(--c-text-hover)}.wp-block-advgb-table tbody a:hover{-webkit-text-decoration:none;text-decoration:none}.wp-block-advgb-table tfoot{font-size:var(--fs-subhead-sm)}.wp-block-advgb-table tfoot td{padding:var(--p-4) var(--p-2)}.wp-block-advgb-table.is-style-stripes tbody tr:nth-child(odd){background-color:var(--wp--preset--color--neutral-200)}
+
+</style>
+<style id='kff-shared-tableau-style-inline-css' type='text/css'>
+.wp-block-kff-shared-tableau{margin:var(--wp--preset--spacing--m-3) auto}@media (min-width:64em){.wp-block-kff-shared-tableau{margin:var(--wp--preset--spacing--m-5) auto}}
+
+</style>
+<style id='kff-shared-where-to-listen-style-inline-css' type='text/css'>
+.wp-block-kff-shared-where-to-listen{display:flex;flex-direction:column;gap:var(--m-3)}@media (min-width:48em){.wp-block-kff-shared-where-to-listen{flex-direction:row;gap:var(--m-5)}}.wp-block-kff-shared-where-to-listen__content{display:flex;flex-direction:column;gap:var(--m-1)}@media (min-width:48em){.wp-block-kff-shared-where-to-listen__content{gap:var(--m-1-5);min-width:140px}}.wp-block-kff-shared-where-to-listen__title{color:var(--c-text-primary);font-size:var(--fs-subhead-md);font-weight:var(--fw-bold);letter-spacing:4%;line-height:var(--lh-ms);margin:var(--m-0);padding:var(--p-0);text-transform:uppercase}.wp-block-kff-shared-where-to-listen__list{display:flex;flex-wrap:wrap;gap:var(--m-1);list-style:none;margin:var(--m-0);padding:var(--p-0)}@media (min-width:48em){.wp-block-kff-shared-where-to-listen__list{flex-direction:column}}.wp-block-kff-shared-where-to-listen__list-item{color:var(--c-text-primary);display:flex;font-size:var(--fs-button-lg);font-weight:var(--fw-normal);letter-spacing:0;line-height:var(--lh-s);text-transform:capitalize}.wp-block-kff-shared-where-to-listen__link{color:var(--c-text-hover);-webkit-text-decoration:none;text-decoration:none}.wp-block-kff-shared-where-to-listen__link:hover{-webkit-text-decoration:underline;text-decoration:underline}@media (min-width:48em){.wp-block-kff-shared-where-to-listen__comma{display:none}}
+
+</style>
+<style id='kff-shared-wufoo-style-inline-css' type='text/css'>
+
+
+</style>
+<link rel='stylesheet' id='createwithrani-superlist-block-style-css' href='https://www.kff.org/wp-content/plugins/superlist-block/build/superlist/style-index.css?ver=0.1.3' type='text/css' media='all' />
+<style id='createwithrani-superlist-item-style-inline-css' type='text/css'>
+.wp-block-createwithrani-superlist-item{--textColor:var(--wp--custom--superlist-item--color--text,inherit);--linkColor:var(--wp--custom--superlist-item--color--link,inherit);--backgroundColor:var( --wp--custom--superlist-item--color--background-color,inherit );--fontSize:var(--wp--custom--superlist-item--typography--font-size,inherit);--fontFamily:var( --wp--custom--superlist-item--typography--font-family,inherit );--lineHeight:var( --wp--custom--superlist-item--typography--line-height,inherit );--textTransform:var( --wp--custom--superlist-item--typography--text-transform,inherit );--fontWeight:var( --wp--custom--superlist-item--typography--font-weight,inherit );--margin:var(--wp--custom--superlist-item--spacing--margin,inherit);--padding:var(--wp--custom--superlist-item--spacing--padding,inherit);background-color:var(--backgroundColor);color:var(--textColor);font-family:var(--fontFamily);font-size:var(--fontSize);font-weight:var(--fontWeight);line-height:var(--lineHeight);margin:var(--margin);padding:var(--padding);text-transform:var(--textTransform)}.wp-block-createwithrani-superlist-item a{color:var(--linkColor)}
+
+</style>
+<style id='tenup-accordion-content-style-inline-css' type='text/css'>
+.wp-block-tenup-accordion-content{display:grid;grid-template-rows:0fr;transition:grid-template-rows .3s ease-in-out,padding .3s ease-in-out}.wp-block-tenup-accordion-content[aria-hidden=true],.wp-block-tenup-accordion-content[aria-hidden=true] .wp-block-tenup-accordion-content__body{padding-bottom:0!important;padding-top:0!important}.wp-block-tenup-accordion-content[aria-hidden=false]{grid-template-rows:1fr}.wp-block-tenup-accordion.has-child-selected .wp-block-tenup-accordion-content,.wp-block-tenup-accordion.is-selected .wp-block-tenup-accordion-content{display:grid;grid-template-rows:1fr;height:100%}[data-type="tenup/accordion"] .wp-block-tenup-accordion-content{transition:none!important}.wp-block-tenup-accordion-content__body{margin-trim:block;overflow:hidden}
+
+</style>
+<style id='tenup-accordion-group-style-inline-css' type='text/css'>
+.wp-block-tenup-accordion-group{align-items:stretch!important}
+
+</style>
+<style id='tenup-accordion-header-style-inline-css' type='text/css'>
+.wp-block-tenup-accordion-header{-webkit-appearance:none;-moz-appearance:none;appearance:none;background-color:transparent;border-color:transparent;border-width:0;cursor:pointer;flex-shrink:0;font-size:var(--wp--custom--font--size--base,1rem);padding:0;transition:all .2s ease-in-out;width:100%}.wp-block-tenup-accordion-header.icon-position-left{flex-direction:row-reverse;justify-content:flex-end}.wp-block-tenup-accordion-item__title{text-align:left}.wp-block-tenup-accordion-item__icon{display:flex;fill:currentColor;width:1rem}.wp-block-tenup-accordion-item{overflow:hidden}[aria-expanded=false] .icon--expanded,[aria-expanded=true] .icon--collapsed{display:none}
+
+</style>
+<style id='tenup-accordion-style-inline-css' type='text/css'>
+.wp-block-tenup-accordion,.wp-block-tenup-accordion *>*{box-sizing:border-box}.wp-block-tenup-accordion.is-layout-flex{align-items:stretch!important}
+
+</style>
+<link rel='stylesheet' id='tenup-tabs-style-css' href='https://www.kff.org/wp-content/plugins/ui-kit-tabs/dist/blocks/tabs/style.css?ver=d9e546ecfb4ef89d7e21005d5679016cec7ce695ded434391a72013332746bc5' type='text/css' media='all' />
+<style id='kaiser-health-news-common-inline-sidebar-promo-style-inline-css' type='text/css'>
+.wp-block-inline-sidebar-promo{border-bottom:4px solid #004b87;border-top:4px solid #004b87;margin:24px 0;padding:15px}.wp-block-inline-sidebar-promo .wp-block-inline-sidebar-promo{border-bottom:unset;border-top:unset;margin:unset;padding:unset}@media(min-width:960px){.wp-block-inline-sidebar-promo{float:right;margin:24px 0 24px 24px;width:400px}}.wp-block-inline-sidebar-promo h5{font-size:21px;font-weight:700;line-height:30px;text-transform:unset}.wp-block-inline-sidebar-promo p{font-size:14px;font-weight:400;line-height:20px}
+
+</style>
+<link rel='stylesheet' id='mediaelement-css' href='https://www.kff.org/wp-includes/js/mediaelement/mediaelementplayer-legacy.min.css?ver=4.2.17' type='text/css' media='all' />
+<link rel='stylesheet' id='wp-mediaelement-css' href='https://www.kff.org/wp-includes/js/mediaelement/wp-mediaelement.min.css?ver=6.8.5' type='text/css' media='all' />
+<style id='jetpack-sharing-buttons-style-inline-css' type='text/css'>
+.jetpack-sharing-buttons__services-list{display:flex;flex-direction:row;flex-wrap:wrap;gap:0;list-style-type:none;margin:5px;padding:0}.jetpack-sharing-buttons__services-list.has-small-icon-size{font-size:12px}.jetpack-sharing-buttons__services-list.has-normal-icon-size{font-size:16px}.jetpack-sharing-buttons__services-list.has-large-icon-size{font-size:24px}.jetpack-sharing-buttons__services-list.has-huge-icon-size{font-size:36px}@media print{.jetpack-sharing-buttons__services-list{display:none!important}}.editor-styles-wrapper .wp-block-jetpack-sharing-buttons{gap:0;padding-inline-start:0}ul.jetpack-sharing-buttons__services-list.has-background{padding:1.25em 2.375em}
+</style>
+<link rel='stylesheet' id='elasticpress-facet-style-css' href='https://www.kff.org/wp-content/mu-plugins/search/elasticpress/dist/css/facets-styles.min.css?ver=6.8.5' type='text/css' media='all' />
+<link rel='stylesheet' id='elasticpress-related-posts-block-css' href='https://www.kff.org/wp-content/mu-plugins/search/elasticpress/dist/css/related-posts-block-styles.min.css?ver=4.2.2' type='text/css' media='all' />
+<style id='htgb-block-glossary-style-inline-css' type='text/css'>
+.hg-glossary *,.hg-glossary :after,.hg-glossary :before{box-sizing:border-box;word-break:normal}.hg-glossary .hg-glossary__header{margin:0 0 1em}.hg-glossary.is-style-boxed{background:#fafafa;padding:4rem}.hg-glossary.is-style-boxed .hg-content .hg-content__letter{border-bottom:1px solid;padding:1rem 0}.hg-glossary .hg-nav{display:flex;flex-wrap:wrap;justify-content:center;margin:0 0 1rem}.hg-glossary .hg-nav a.htgb_active_nav{text-decoration:underline}.hg-glossary .hg-nav a.htgb_disabled,.hg-glossary .hg-nav a.htgb_search_disabled{color:#494c4d;pointer-events:none}.hg-glossary .hg-nav a{display:block;line-height:1;padding:8px;text-decoration:none}.hg-glossary .hg-search{margin:0 0 1rem}.hg-glossary .hg-search input{border:1px solid #ccc;border-radius:4px;max-width:100%;padding:1rem 1.4rem;width:100%}.hg-glossary .hg-content .hg-content__letter{background-color:#fafafa;display:block;font-size:1.1em;font-weight:600;margin:0 0 2rem;padding:1rem 1.1rem}.hg-glossary .hg-content dl{display:flex;flex-flow:row wrap;flex-wrap:nowrap;margin:1rem 0;padding:0}.hg-glossary .hg-content dl dt{flex-basis:20%;font-weight:600;margin:0 20px 0 0}.hg-glossary .hg-content dl dd{flex-basis:80%;flex-grow:1;margin:0}.hg-glossary .hg-content .hg-item-description>p{margin:0}.hg-glossary .hg-nullsearch{display:none;margin:0 0 1em}
+
+</style>
+<style id='filebird-block-filebird-gallery-style-inline-css' type='text/css'>
+ul.filebird-block-filebird-gallery{margin:auto!important;padding:0!important;width:100%}ul.filebird-block-filebird-gallery.layout-grid{display:grid;grid-gap:20px;align-items:stretch;grid-template-columns:repeat(var(--columns),1fr);justify-items:stretch}ul.filebird-block-filebird-gallery.layout-grid li img{border:1px solid #ccc;box-shadow:2px 2px 6px 0 rgba(0,0,0,.3);height:100%;max-width:100%;-o-object-fit:cover;object-fit:cover;width:100%}ul.filebird-block-filebird-gallery.layout-masonry{-moz-column-count:var(--columns);-moz-column-gap:var(--space);column-gap:var(--space);-moz-column-width:var(--min-width);columns:var(--min-width) var(--columns);display:block;overflow:auto}ul.filebird-block-filebird-gallery.layout-masonry li{margin-bottom:var(--space)}ul.filebird-block-filebird-gallery li{list-style:none}ul.filebird-block-filebird-gallery li figure{height:100%;margin:0;padding:0;position:relative;width:100%}ul.filebird-block-filebird-gallery li figure figcaption{background:linear-gradient(0deg,rgba(0,0,0,.7),rgba(0,0,0,.3) 70%,transparent);bottom:0;box-sizing:border-box;color:#fff;font-size:.8em;margin:0;max-height:100%;overflow:auto;padding:3em .77em .7em;position:absolute;text-align:center;width:100%;z-index:2}ul.filebird-block-filebird-gallery li figure figcaption a{color:inherit}
+
+</style>
+<style id='global-styles-inline-css' type='text/css'>
+:root{--wp--preset--aspect-ratio--square: 1;--wp--preset--aspect-ratio--4-3: 4/3;--wp--preset--aspect-ratio--3-4: 3/4;--wp--preset--aspect-ratio--3-2: 3/2;--wp--preset--aspect-ratio--2-3: 2/3;--wp--preset--aspect-ratio--16-9: 16/9;--wp--preset--aspect-ratio--9-16: 9/16;--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink: #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange: #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan: #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue: #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple: #9b51e0;--wp--preset--color--neutral-800: #000;--wp--preset--color--neutral-700: #333;--wp--preset--color--neutral-600: #474747;--wp--preset--color--neutral-500: #666;--wp--preset--color--neutral-400: #999;--wp--preset--color--neutral-300: #ccc;--wp--preset--color--neutral-200: #e5e5e5;--wp--preset--color--neutral-100: #fff;--wp--preset--color--primary-600: #001e36;--wp--preset--color--primary-400: #003c6c;--wp--preset--color--primary-300: #004b88;--wp--preset--color--primary-200: #336f9f;--wp--preset--color--primary-000: #e6edf3;--wp--preset--color--purple-100: #f2eaf3;--wp--preset--color--accent-100: #1a81d4;--wp--preset--color--accent-200: #00b588;--wp--preset--color--accent-300: #93509e;--wp--preset--color--accent-400: #fdc82f;--wp--preset--color--information-400: #0065bd;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange: linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red: linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray: linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum: linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean: linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium: 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large: 42px;--wp--preset--font-size--display-lg: clamp(3.625rem, 3.625rem + ((1vw - 0.2rem) * 0.469), 4rem);--wp--preset--font-size--heading-1: clamp(2.75rem, 2.75rem + ((1vw - 0.2rem) * 0.548), 3.1875rem);--wp--preset--font-size--heading-2: clamp(2.375rem, 2.375rem + ((1vw - 0.2rem) * 0.469), 2.75rem);--wp--preset--font-size--heading-3: clamp(2rem, 2rem + ((1vw - 0.2rem) * 0.469), 2.375rem);--wp--preset--font-size--heading-4: clamp(1.75rem, 1.75rem + ((1vw - 0.2rem) * 0.313), 2rem);--wp--preset--font-size--heading-5: 1.625rem;--wp--preset--font-size--heading-6: 1.5rem;--wp--preset--font-size--51: 3.1875rem;--wp--preset--font-size--38: 2.375rem;--wp--preset--font-size--32: 2rem;--wp--preset--font-size--28: 1.75rem;--wp--preset--font-size--26: 1.625rem;--wp--preset--font-size--24: 1.5rem;--wp--preset--font-size--20: 1.25rem;--wp--preset--font-size--18: 1.125rem;--wp--preset--font-size--16: 1rem;--wp--preset--font-size--14: 0.875rem;--wp--preset--font-size--12: 0.75rem;--wp--preset--font-size--9: 0.5625rem;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40: 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70: 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--spacing--d-0: 0;--wp--preset--spacing--d-0-25: 0.125rem;--wp--preset--spacing--d-0-5: 0.25rem;--wp--preset--spacing--d-0-75: 0.375rem;--wp--preset--spacing--d-1: 0.5rem;--wp--preset--spacing--d-1-25: 0.625rem;--wp--preset--spacing--d-1-5: 0.75rem;--wp--preset--spacing--d-2: 1rem;--wp--preset--spacing--d-2-5: 1.25rem;--wp--preset--spacing--d-3: 1.5rem;--wp--preset--spacing--d-4: 2rem;--wp--preset--spacing--d-5: 2.5rem;--wp--preset--spacing--d-6: 3rem;--wp--preset--spacing--d-7: 3.5rem;--wp--preset--spacing--d-8: 4rem;--wp--preset--spacing--d-9: 4.5rem;--wp--preset--spacing--d-10: 5rem;--wp--preset--spacing--d-11: 5.5rem;--wp--preset--spacing--d-12: 6rem;--wp--preset--spacing--d-13: 6.5rem;--wp--preset--shadow--natural: 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0, 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255, 1), 6px 6px rgba(0, 0, 0, 1);--wp--preset--shadow--crisp: 6px 6px 0px rgba(0, 0, 0, 1);--wp--custom--uikit--separator-height: 1;--wp--custom--tenup--icon-position: right;--wp--custom--tenup--icon--icon-set: kff-icons;--wp--custom--tenup--icon--icon-name: plus;--wp--custom--tenup--expanded--icon--icon-set: kff-icons;--wp--custom--tenup--expanded--icon--icon-name: minus;}.wp-block-cover{--wp--custom--tenup--play-icon--icon-set: uikit;--wp--custom--tenup--play-icon--icon-name: play;--wp--custom--tenup--pause-icon--icon-set: uikit;--wp--custom--tenup--pause-icon--icon-name: pause;--wp--custom--tenup--enable-video-cover-controls: 1;}.wp-block-tenup-accordion-header{--wp--custom--tenup--icon-position: right;--wp--custom--tenup--icon--icon-set: kff-icons;--wp--custom--tenup--icon--icon-name: plus;--wp--custom--tenup--expanded--icon--icon-set: kff-icons;--wp--custom--tenup--expanded--icon--icon-name: minus;}.wp-block-tenup-tabs{--wp--custom--tenup--max-number-of-tabs: 5;--wp--custom--tenup--tabs-spacing: var(--wp--preset--spacing--base, 1rem);}:root { --wp--style--global--content-size: 1280px;--wp--style--global--wide-size: 1280px; }:where(body) { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }:where(.wp-site-blocks) > * { margin-block-start: 24px; margin-block-end: 0; }:where(.wp-site-blocks) > :first-child { margin-block-start: 0; }:where(.wp-site-blocks) > :last-child { margin-block-end: 0; }:root { --wp--style--block-gap: 24px; }:root :where(.is-layout-flow) > :first-child{margin-block-start: 0;}:root :where(.is-layout-flow) > :last-child{margin-block-end: 0;}:root :where(.is-layout-flow) > *{margin-block-start: 24px;margin-block-end: 0;}:root :where(.is-layout-constrained) > :first-child{margin-block-start: 0;}:root :where(.is-layout-constrained) > :last-child{margin-block-end: 0;}:root :where(.is-layout-constrained) > *{margin-block-start: 24px;margin-block-end: 0;}:root :where(.is-layout-flex){gap: 24px;}:root :where(.is-layout-grid){gap: 24px;}.is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}.is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}.is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}.is-layout-constrained > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}.is-layout-constrained > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}.is-layout-constrained > .aligncenter{margin-left: auto !important;margin-right: auto !important;}.is-layout-constrained > :where(:not(.alignleft):not(.alignright):not(.alignfull)){max-width: var(--wp--style--global--content-size);margin-left: auto !important;margin-right: auto !important;}.is-layout-constrained > .alignwide{max-width: var(--wp--style--global--wide-size);}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items: center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display: grid;}.is-layout-grid > :is(*, div){margin: 0;}body{padding-top: 0px;padding-right: 0px;padding-bottom: 0px;padding-left: 0px;}a:where(:not(.wp-element-button)){color: var(--wp--preset--color--neutral-700);text-decoration: underline;}h1{font-size: var(--wp--preset--font-size--heading-1);font-weight: 600;line-height: 1.2;}h2{font-size: var(--wp--preset--font-size--heading-2);font-weight: 600;line-height: 1.2;}h3{font-size: var(--wp--preset--font-size--heading-3);font-weight: 600;line-height: 1.2;}h4{font-size: var(--wp--preset--font-size--heading-4);font-weight: 600;line-height: 1.3;}h5{font-size: var(--wp--preset--font-size--heading-5);font-weight: 600;line-height: 1.3;}h6{font-size: var(--wp--preset--font-size--heading-6);font-weight: 600;line-height: 1.3;}:root :where(.wp-element-button, .wp-block-button__link){background-color: #32373c;border-width: 0;color: #fff;font-family: inherit;font-size: inherit;line-height: inherit;padding: calc(0.667em + 2px) calc(1.333em + 2px);text-decoration: none;}.has-black-color{color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color: var(--wp--preset--color--white) !important;}.has-pale-pink-color{color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color: var(--wp--preset--color--vivid-purple) !important;}.has-neutral-800-color{color: var(--wp--preset--color--neutral-800) !important;}.has-neutral-700-color{color: var(--wp--preset--color--neutral-700) !important;}.has-neutral-600-color{color: var(--wp--preset--color--neutral-600) !important;}.has-neutral-500-color{color: var(--wp--preset--color--neutral-500) !important;}.has-neutral-400-color{color: var(--wp--preset--color--neutral-400) !important;}.has-neutral-300-color{color: var(--wp--preset--color--neutral-300) !important;}.has-neutral-200-color{color: var(--wp--preset--color--neutral-200) !important;}.has-neutral-100-color{color: var(--wp--preset--color--neutral-100) !important;}.has-primary-600-color{color: var(--wp--preset--color--primary-600) !important;}.has-primary-400-color{color: var(--wp--preset--color--primary-400) !important;}.has-primary-300-color{color: var(--wp--preset--color--primary-300) !important;}.has-primary-200-color{color: var(--wp--preset--color--primary-200) !important;}.has-primary-000-color{color: var(--wp--preset--color--primary-000) !important;}.has-purple-100-color{color: var(--wp--preset--color--purple-100) !important;}.has-accent-100-color{color: var(--wp--preset--color--accent-100) !important;}.has-accent-200-color{color: var(--wp--preset--color--accent-200) !important;}.has-accent-300-color{color: var(--wp--preset--color--accent-300) !important;}.has-accent-400-color{color: var(--wp--preset--color--accent-400) !important;}.has-information-400-color{color: var(--wp--preset--color--information-400) !important;}.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color: var(--wp--preset--color--vivid-purple) !important;}.has-neutral-800-background-color{background-color: var(--wp--preset--color--neutral-800) !important;}.has-neutral-700-background-color{background-color: var(--wp--preset--color--neutral-700) !important;}.has-neutral-600-background-color{background-color: var(--wp--preset--color--neutral-600) !important;}.has-neutral-500-background-color{background-color: var(--wp--preset--color--neutral-500) !important;}.has-neutral-400-background-color{background-color: var(--wp--preset--color--neutral-400) !important;}.has-neutral-300-background-color{background-color: var(--wp--preset--color--neutral-300) !important;}.has-neutral-200-background-color{background-color: var(--wp--preset--color--neutral-200) !important;}.has-neutral-100-background-color{background-color: var(--wp--preset--color--neutral-100) !important;}.has-primary-600-background-color{background-color: var(--wp--preset--color--primary-600) !important;}.has-primary-400-background-color{background-color: var(--wp--preset--color--primary-400) !important;}.has-primary-300-background-color{background-color: var(--wp--preset--color--primary-300) !important;}.has-primary-200-background-color{background-color: var(--wp--preset--color--primary-200) !important;}.has-primary-000-background-color{background-color: var(--wp--preset--color--primary-000) !important;}.has-purple-100-background-color{background-color: var(--wp--preset--color--purple-100) !important;}.has-accent-100-background-color{background-color: var(--wp--preset--color--accent-100) !important;}.has-accent-200-background-color{background-color: var(--wp--preset--color--accent-200) !important;}.has-accent-300-background-color{background-color: var(--wp--preset--color--accent-300) !important;}.has-accent-400-background-color{background-color: var(--wp--preset--color--accent-400) !important;}.has-information-400-background-color{background-color: var(--wp--preset--color--information-400) !important;}.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color: var(--wp--preset--color--vivid-purple) !important;}.has-neutral-800-border-color{border-color: var(--wp--preset--color--neutral-800) !important;}.has-neutral-700-border-color{border-color: var(--wp--preset--color--neutral-700) !important;}.has-neutral-600-border-color{border-color: var(--wp--preset--color--neutral-600) !important;}.has-neutral-500-border-color{border-color: var(--wp--preset--color--neutral-500) !important;}.has-neutral-400-border-color{border-color: var(--wp--preset--color--neutral-400) !important;}.has-neutral-300-border-color{border-color: var(--wp--preset--color--neutral-300) !important;}.has-neutral-200-border-color{border-color: var(--wp--preset--color--neutral-200) !important;}.has-neutral-100-border-color{border-color: var(--wp--preset--color--neutral-100) !important;}.has-primary-600-border-color{border-color: var(--wp--preset--color--primary-600) !important;}.has-primary-400-border-color{border-color: var(--wp--preset--color--primary-400) !important;}.has-primary-300-border-color{border-color: var(--wp--preset--color--primary-300) !important;}.has-primary-200-border-color{border-color: var(--wp--preset--color--primary-200) !important;}.has-primary-000-border-color{border-color: var(--wp--preset--color--primary-000) !important;}.has-purple-100-border-color{border-color: var(--wp--preset--color--purple-100) !important;}.has-accent-100-border-color{border-color: var(--wp--preset--color--accent-100) !important;}.has-accent-200-border-color{border-color: var(--wp--preset--color--accent-200) !important;}.has-accent-300-border-color{border-color: var(--wp--preset--color--accent-300) !important;}.has-accent-400-border-color{border-color: var(--wp--preset--color--accent-400) !important;}.has-information-400-border-color{border-color: var(--wp--preset--color--information-400) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background: var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background: var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange) !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background: var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background: var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background: var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background: var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background: var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background: var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background: var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background: var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size: var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size: var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size: var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size: var(--wp--preset--font-size--x-large) !important;}.has-display-lg-font-size{font-size: var(--wp--preset--font-size--display-lg) !important;}.has-heading-1-font-size{font-size: var(--wp--preset--font-size--heading-1) !important;}.has-heading-2-font-size{font-size: var(--wp--preset--font-size--heading-2) !important;}.has-heading-3-font-size{font-size: var(--wp--preset--font-size--heading-3) !important;}.has-heading-4-font-size{font-size: var(--wp--preset--font-size--heading-4) !important;}.has-heading-5-font-size{font-size: var(--wp--preset--font-size--heading-5) !important;}.has-heading-6-font-size{font-size: var(--wp--preset--font-size--heading-6) !important;}.has-51-font-size{font-size: var(--wp--preset--font-size--51) !important;}.has-38-font-size{font-size: var(--wp--preset--font-size--38) !important;}.has-32-font-size{font-size: var(--wp--preset--font-size--32) !important;}.has-28-font-size{font-size: var(--wp--preset--font-size--28) !important;}.has-26-font-size{font-size: var(--wp--preset--font-size--26) !important;}.has-24-font-size{font-size: var(--wp--preset--font-size--24) !important;}.has-20-font-size{font-size: var(--wp--preset--font-size--20) !important;}.has-18-font-size{font-size: var(--wp--preset--font-size--18) !important;}.has-16-font-size{font-size: var(--wp--preset--font-size--16) !important;}.has-14-font-size{font-size: var(--wp--preset--font-size--14) !important;}.has-12-font-size{font-size: var(--wp--preset--font-size--12) !important;}.has-9-font-size{font-size: var(--wp--preset--font-size--9) !important;}
+:root :where(.wp-block-pullquote){font-size: 1.5em;line-height: 1.6;}
+:root :where(.wp-block-tenup-accordion){background-color: var(--wp--preset--color--surface-primary);border-radius: 8px;border-color: var(--wp--custom--color--neutrals--300);border-width: 1px;border-style: solid;color: var(--wp--preset--color--surface-inverted);font-size: var(--wp--preset--font-size--body);}
+:root :where(.wp-block-tenup-accordion-header){font-weight: 700;padding-top: var(--wp--preset--spacing--xs);padding-right: var(--wp--preset--spacing--s);padding-bottom: var(--wp--preset--spacing--xs);padding-left: var(--wp--preset--spacing--s);}
+:root :where(.wp-block-tenup-accordion-content){margin-top: 0;margin-right: var(--wp--preset--spacing--s);margin-bottom: 0;margin-left: var(--wp--preset--spacing--s);padding-top: 0;padding-bottom: var(--wp--preset--spacing--xs);}
+:root :where(.wp-block-tenup-tabs-is-layout-flow) > :first-child{margin-block-start: 0;}:root :where(.wp-block-tenup-tabs-is-layout-flow) > :last-child{margin-block-end: 0;}:root :where(.wp-block-tenup-tabs-is-layout-flow) > *{margin-block-start: var(--wp--preset--spacing--base, 1rem);margin-block-end: 0;}:root :where(.wp-block-tenup-tabs-is-layout-constrained) > :first-child{margin-block-start: 0;}:root :where(.wp-block-tenup-tabs-is-layout-constrained) > :last-child{margin-block-end: 0;}:root :where(.wp-block-tenup-tabs-is-layout-constrained) > *{margin-block-start: var(--wp--preset--spacing--base, 1rem);margin-block-end: 0;}:root :where(.wp-block-tenup-tabs-is-layout-flex){gap: var(--wp--preset--spacing--base, 1rem);}:root :where(.wp-block-tenup-tabs-is-layout-grid){gap: var(--wp--preset--spacing--base, 1rem);}
+</style>
+<link rel='stylesheet' id='kff_shared_plugin_shared-css' href='https://www.kff.org/wp-content/plugins/kff-shared/dist/css/shared.css?ver=8c5b220bf6f482881a90' type='text/css' media='all' />
+<link rel='stylesheet' id='kff_shared_plugin_frontend-css' href='https://www.kff.org/wp-content/plugins/kff-shared/dist/css/frontend.css?ver=b61d5bda18bb08ee34fa' type='text/css' media='all' />
+<style id='kff_shared_plugin_frontend-inline-css' type='text/css'>
+
+			.datawrapper-embed.has-no-top-border,
+			.flourish-embed.has-no-top-border {
+				border-top: none !important;
+				border-block-start: none !important;
+			}
+			.datawrapper-embed.has-no-bottom-border,
+			.flourish-embed.has-no-bottom-border {
+				border-bottom: none !important;
+				border-block-end: none !important;
+			}
+		
+</style>
+<link rel='stylesheet' id='ui-kit-video-cover-controls-styles-css' href='https://www.kff.org/wp-content/plugins/ui-kit-core/dist/css/video-cover-controls-styles.css?ver=4f4139d1d1013647d8e2' type='text/css' media='all' />
+<link rel='stylesheet' id='interactives-screen-css' href='https://www.kff.org/wp-content/themes/kff-org-modern/interactives/static/stylesheets/screen.css?ver=948a67c8a9c6281163c557e098ed06fe2d2fa257' type='text/css' media='all' />
+<link rel='stylesheet' id='styles-css' href='https://www.kff.org/wp-content/themes/kff-org-modern/dist/css/frontend.css?ver=b049b69bd07dc671aa68' type='text/css' media='all' />
+<script type="text/javascript" src="https://www.kff.org/wp-content/plugins/kaiser-foundation/lib/datawrapper.js?ver=6.8.5" id="kaiser-founcation-datawrapper-fix-js"></script>
+<script type="text/javascript" src="https://www.kff.org/wp-includes/js/jquery/jquery.min.js?ver=3.7.1" id="jquery-core-js"></script>
+<script type="text/javascript" src="https://www.kff.org/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1" id="jquery-migrate-js"></script>
+<script type="text/javascript" src="https://www.kff.org/wp-content/themes/kff-org-modern/interactives/static/js/jquery_plugins/jquery.customSelect.min.js?ver=948a67c8a9c6281163c557e098ed06fe2d2fa257" id="customSelect-js"></script>
+<script type="text/javascript" src="https://www.kff.org/wp-content/themes/kff-org-modern/interactives/static/js/jquery_plugins/jquery.hoverIntent.minified.js?ver=948a67c8a9c6281163c557e098ed06fe2d2fa257" id="hoverintent-js"></script>
+<script type="text/javascript" src="https://www.kff.org/wp-content/themes/kff-org-modern/interactives/static/js/jquery_plugins/jquery.stickytableheaders.js?ver=948a67c8a9c6281163c557e098ed06fe2d2fa257" id="jquery-stickytableheaders-js"></script>
+<script type="text/javascript" src="https://www.kff.org/wp-content/themes/kff-org-modern/interactives/static/js/jquery_plugins/jquery.history.js?ver=948a67c8a9c6281163c557e098ed06fe2d2fa257" id="history-js"></script>
+<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/webfont/1.5.18/webfont.js?ver=948a67c8a9c6281163c557e098ed06fe2d2fa257" id="webfont-js"></script>
+<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.6/angular.min.js?ver=6.8.5" id="angularjs-js"></script>
+<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.6/angular-sanitize.min.js?ver=6.8.5" id="ng-sanitize-js"></script>
+<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/angularjs/1.4.6/angular-animate.min.js?ver=6.8.5" id="ng-animate-js"></script>
+<link rel="https://api.w.org/" href="https://www.kff.org/wp-json/" /><link rel="alternate" title="JSON" type="application/json" href="https://www.kff.org/wp-json/wp/v2/state-indicator/706403" /><link rel="alternate" title="oEmbed (JSON)" type="application/json+oembed" href="https://www.kff.org/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.kff.org%2Faffordable-care-act%2Fstate-indicator%2Ffull-year-average-marketplace-effectuated-enrollment%2F" />
+<link rel="alternate" title="oEmbed (XML)" type="text/xml+oembed" href="https://www.kff.org/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.kff.org%2Faffordable-care-act%2Fstate-indicator%2Ffull-year-average-marketplace-effectuated-enrollment%2F&#038;format=xml" />
+	<style>img#wpstats{display:none}</style>
+		<link rel="icon" href="https://www.kff.org/wp-content/uploads/sites/7/2023/04/3976_KFF_favicon_256x256_revised.png?w=32" sizes="32x32" />
+<link rel="icon" href="https://www.kff.org/wp-content/uploads/sites/7/2023/04/3976_KFF_favicon_256x256_revised.png?w=192" sizes="192x192" />
+<link rel="apple-touch-icon" href="https://www.kff.org/wp-content/uploads/sites/7/2023/04/3976_KFF_favicon_256x256_revised.png?w=180" />
+<meta name="msapplication-TileImage" content="https://www.kff.org/wp-content/uploads/sites/7/2023/04/3976_KFF_favicon_256x256_revised.png?w=256" />
+		<style type="text/css" id="wp-custom-css">
+			/* Hide Breadcrumbs on Specific Post Ids */
+.postid-706579 #main > .breadcrumbs span,
+.postid-706714 #main > .breadcrumbs span {
+    display: none !important;
+}
+/* END Breadcrumbs on Specific Post Ids */
+
+
+
+
+/* CSS TO CONTROL PLACEMENT OF FLOURISH SCROLLYTELLY LABELS */
+
+@media screen and (min-width: 600px) {
+	
+.flourish-embed-scrolly-story {
+    margin-right: 25vw!important;
+}
+
+.fl-scrolly-caption{
+    margin-left: 45vw!important;
+    width: 40vw!important;
+}
+	
+.fl-scrolly-caption p {
+    text-align:left;
+}
+	
+	
+.flourish-embed-scrolly-story-02 {
+    margin-right: 0%!important;
+}
+
+.flourish-embed-scrolly-story-02 .fl-scrolly-caption{
+		
+ width:50%!important;
+ margin-left: 60%!important;
+ margin-right: 10%!important;
+
+	}
+	
+
+}
+
+/* END FLOURISH CSS */
+
+
+.mp_query_loop_quick_takes{
+	margin-top:30px !important;
+	margin-bottom:0px !important;
+}
+
+.mp_group_full_bleed{
+	
+	
+	border-top: solid;
+	border-bottom:solid;
+	border-color:#909090;
+	border-width:.5px;
+margin-left: calc((100vw - 100% - var(--scrollbar)) / -2);
+    padding-bottom: var(--p-8);
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: var(--p-8);
+    width: 100cqw;
+	
+}
+
+.mp_three_across h2{
+	font-size:26px;
+}
+
+.mp_news_release{
+	background-color: #F2EAF3!important;
+}
+
+.roper-container .kksiKu.search-container {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0;
+	padding-top: 40px;
+}
+
+.roper-container .kksiKu.search-container .header {
+	min-height: auto;
+}
+
+.interactive-template-single-interactive-custom .sticky-select.is-stuck {
+	display: none;
+}		</style>
+			</head>
+	<body class="wp-singular state-indicator-template-default single single-state-indicator postid-706403 wp-theme-kff-org-modern">
+		
+			<script>
+			window.dataLayer = window.dataLayer || [];
+			window.dataLayer.push({
+				event: 'page_attributes',
+				publication_date: '2026-04-09',
+				authors: '',
+				update_date: '2026-04-09',
+				topics: 'Affordable Care Act',
+				content_types: 'State Health Facts Indicator',
+				series: '',
+				tags: '',
+				id: '706403'
+				
+			});
+		</script>
+
+		<!-- Google Tag Manager -->
+		<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-PPSVK8"
+		height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+		<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+		new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+		j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+		'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+		})(window,document,'script','dataLayer','GTM-PPSVK8');</script>
+		<!-- End Google Tag Manager -->
+
+		<!-- IpMeta must be included after Google Analytics -->
+				<script src="https://ipmeta.io/plugin.js"></script>
+
+		<script>
+			var data  = provideGtmPlugin({
+				gtmEventKey: 'ipmeta_loaded',
+				apiKey: 'cfa8e242ccc23303b21a00da541b3e18fd358f1eb9c5888ce796bd3fff889fff',
+			});
+			window.dataLayer = window.dataLayer || [];
+			window.dataLayer.push(data);
+		</script>
+
+				<div class="wp-block-button is-style-outline">
+				<a href="#main" class="wp-block-button__link wp-element-button skip-to-content-link visually-hidden-focusable">
+					Skip to main content				</a>
+			</div>
+
+			
+<header class="header">
+	<div class="print-container">
+	<div class="print-container__inner print-container__inner--nav">
+		<div class="print__logo">
+			<svg class="print__logo-svg print__logo-svg--nav" xmlns="http://www.w3.org/2000/svg" width="59" height="25" viewBox="0 0 59 25" fill="none">
+				<path d="m13.685.5-7.22 10.351h-.07V.5H0v24h6.396V14.149h.069l7.22 10.351h7.701l-8.872-12 8.872-12h-7.701Zm10.074 0h16.058v4.539h-9.662v5.26h9.25v4.54h-9.25V24.5H23.76V.5Zm19.118 0h16.057v4.539h-9.661v5.26h9.249v4.54h-9.25V24.5h-6.395V.5Z" fill="black"/>
+			</svg>
+		</div>
+		<p class="print__tagline">
+			The independent source for health policy research, polling, and news.		</p>
+	</div>
+</div>
+	
+<nav class="primary-nav">
+	<div class="primary-nav__inner">
+		<div class="primary-nav__header">
+			<a class="primary-nav__logo" href="/">
+				<svg xmlns="http://www.w3.org/2000/svg" width="59" height="25" viewBox="0 0 59 25" fill="none">
+					<path d="m13.685.5-7.22 10.351h-.07V.5H0v24h6.396V14.149h.069l7.22 10.351h7.701l-8.872-12 8.872-12h-7.701Zm10.074 0h16.058v4.539h-9.662v5.26h9.25v4.54h-9.25V24.5H23.76V.5Zm19.118 0h16.057v4.539h-9.661v5.26h9.249v4.54h-9.25V24.5h-6.395V.5Z" fill="white"/>
+				</svg>
+			</a>
+			<p class="primary-nav__tagline">
+				The independent source for health policy research, polling, and news.			</p>
+		</div>
+		<div class="primary-nav__links">
+			<a href="https://www.kff.org/about-us/email/" class="primary-nav__link">Subscribe</a>
+			<a href="https://www.kff.org/about-us/follow-us/" class="primary-nav__link">Follow Us</a>
+			<a href="https://www.kff.org/about-us/conference-centers/" class="primary-nav__link">Conference Centers</a>
+			<a href="https://www.kff.org/about-us/support-our-work/" class="button button--sm">Donate</a>
+			<div class="primary-nav__divider primary-nav__desktop-only"></div>
+			<button class="primary-nav__link primary-nav__link--search" aria-label="Search the site">
+				<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 20 20"><path fill="#000" fill-rule="evenodd" d="M19.18 17.665c.426.42.426 1.103 0 1.523a1.09 1.09 0 0 1-1.526 0L13.296 14.9a8.1 8.1 0 0 1-4.723 1.505C4.122 16.405.5 12.852.5 8.453.5 4.053 4.122.5 8.573.5s8.073 3.553 8.074 7.953a7.83 7.83 0 0 1-1.78 4.967zM2.665 8.453c0 3.199 2.638 5.806 5.908 5.806s5.908-2.607 5.908-5.806c0-3.2-2.638-5.806-5.908-5.806S2.665 5.254 2.665 8.453" clip-rule="evenodd" /></svg>				<span>Search</span>
+			</button>
+			<div class="primary-nav__divider primary-nav__mobile-only"></div>
+			<button aria-label="Open menu" class="primary-nav__link--menu" aria-controls="secondary-nav">
+				<span></span>
+				<span></span>
+				<span></span>
+			</button>
+			<div class="primary-nav__search">
+				
+<div itemscope itemtype="http://schema.org/WebSite">
+	<form role="search" id="searchform" class="search-form" method="get" action="https://www.kff.org/">
+		<meta itemprop="target" content="https://www.kff.org/?s={s}" />
+		<label for="search-field">
+			Search for:		</label>
+		<input itemprop="query-input" type="search" id="search-field" value="" placeholder="Search &hellip;" name="s" />
+		<input type="submit" value="Submit">
+	</form>
+</div>
+				<button class="primary-nav__search-close" aria-label="Close search">
+					<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24"><path fill="#004B88" d="M18.555 4 4 18.213l1.286 1.532L19.84 5.532z" /><path fill="#004B88" d="M12 11h-1v2h1z" /><path fill="#004B88" d="M19.84 18.213 5.286 4 4 5.532l14.555 14.213z" /></svg>				</button>
+			</div>
+		</div>
+	</div>
+</nav>
+	
+<div class="secondary-nav" id="secondary-nav">
+	<a href="/" class="secondary-nav__logo">
+		<svg xmlns="http://www.w3.org/2000/svg" width="40" height="17" viewBox="0 0 40 17" fill="none">
+			<path d="M9.12319 0.5L4.3097 7.40096H4.2637V0.5H0V16.5H4.2637V9.59911H4.3097L9.12296 16.5H14.2576L8.34281 8.49993L14.2576 0.5H9.12319ZM15.8396 0.5H26.5445V3.52578H20.1034V7.03281H26.2694V10.0587H20.1034V16.5H15.8396V0.5ZM28.5848 0.5H39.2896V3.52578H32.8484V7.03281H39.0147V10.0587H32.8484V16.5H28.5848V0.5Z" fill="black"></path>
+		</svg>
+	</a>
+
+	<div class="menu-primary-container"><ul id="menu-main-menu" class="menu"><li id="menu-item-180520" class="menu-item menu-item-type-custom menu-item-object-custom tray__item menu-item-180520"><a href="#">Topics</a><div class="tray tray--custom"><div class="tray__inner"><button aria-label="Close submenu" class="tray__close">Back</button><hr class="secondary-nav__divider" />
+<h2 class="tray__title">Topics</h2><hr class="secondary-nav__divider" /><div class="tray__template">
+<div class="wp-block-columns is-layout-flex wp-container-core-columns-is-layout-744a75a8 wp-block-columns-is-layout-flex" style="margin-top:0">
+<div class="wp-block-column is-layout-flow wp-block-column-is-layout-flow" style="flex-basis:195px">
+<ul class="wp-block-list">
+<li class="wp-block-list-item"><a href="/topic/affordable-care-act/">Affordable Care Act</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/topic/elections/" data-type="from-drew-altman" data-id="642026">Elections</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/topic/global-health-policy/">Global Health Policy</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/topic/health-costs/">Health Costs</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/topic/health-information-trust/" data-type="page" data-id="623485">Health Information and Trust</a></li>
+</ul>
+</div>
+
+
+
+<div class="wp-block-column is-layout-flow wp-block-column-is-layout-flow" style="flex-basis:195px">
+<ul class="wp-block-list">
+<li class="wp-block-list-item"><a href="/topic/hivaids/">HIV/AIDS</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/topic/immigrant-health/">Immigrant Health</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/topic/lgbtq/">LGBTQ</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/topic/medicaid/">Medicaid</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/topic/medicare/">Medicare</a></li>
+</ul>
+</div>
+
+
+
+<div class="wp-block-column is-layout-flow wp-block-column-is-layout-flow" style="flex-basis:195px">
+<ul class="wp-block-list">
+<li class="wp-block-list-item"><a href="/topic/mental-health/">Mental Health</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/topic/patient-consumer-protections/">Patient and Consumer Protections</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/topic/public-opinion/">Public Opinion</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/topic/private-insurance/" data-type="page" data-id="536301">Private Insurance</a></li>
+</ul>
+</div>
+
+
+
+<div class="wp-block-column is-layout-flow wp-block-column-is-layout-flow" style="flex-basis:195px">
+<ul class="wp-block-list">
+<li class="wp-block-list-item"><a href="/topic/racial-equity-and-health-policy/">Racial Equity and Health Policy</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/topic/state-health-policy-data/">State Health Policy and Data</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/topic/uninsured/">Uninsured</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/topic/womens-health-policy/" data-type="post" data-id="625971">Women's Health Policy</a></li>
+</ul>
+</div>
+
+
+
+<div class="wp-block-column featured-tray is-layout-flow wp-block-column-is-layout-flow">
+<ul class="wp-block-list">
+<li class="wp-block-list-item"><strong>FEATURED CONTENT</strong></li>
+
+
+
+<li class="wp-block-list-item"><a href="https://www.kff.org/interactive/subsidy-calculator/">Health Insurance Marketplace Calculator</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="https://www.healthsystemtracker.org/">Peterson-KFF Health System Tracker</a></li>
+</ul>
+</div>
+</div>
+
+
+
+<div class="wp-block-group is-layout-constrained wp-block-group-is-layout-constrained" style="margin-top:30px;margin-bottom:100px">
+<div class="wp-block-buttons is-layout-flex wp-block-buttons-is-layout-flex">
+<div class="wp-block-button is-style-arrow"><a class="wp-block-button__link wp-element-button" href="/topics/">Explore all Topics</a></div>
+</div>
+</div>
+</div></div></div></li>
+<li id="menu-item-681986" class="menu-item menu-item-type-custom menu-item-object-custom tray__item menu-item-681986"><a href="#">Policy Research</a><div class="tray tray--custom-column"><div class="tray__inner"><button aria-label="Close submenu" class="tray__close">Back</button><hr class="secondary-nav__divider" />
+<h2 class="tray__title">Policy Research</h2><hr class="secondary-nav__divider" /><div class="tray__template">
+<p class="has-18-font-size wp-block-paragraph" style="margin-top:var(--wp--preset--spacing--d-0)">KFF’s policy research provides facts and analysis on a wide range of policy issues and public programs.&nbsp;<br></p>
+
+
+
+<div class="wp-block-buttons is-layout-flex wp-block-buttons-is-layout-flex">
+<div class="wp-block-button is-style-arrow"><a class="wp-block-button__link wp-element-button" href="/policy-research/">Explore all Policy Research</a></div>
+</div>
+</div></div></div></li>
+<li id="menu-item-180531" class="menu-item menu-item-type-custom menu-item-object-custom tray__item menu-item-180531"><a href="#">Polling</a><div class="tray tray--custom-column"><div class="tray__inner"><button aria-label="Close submenu" class="tray__close">Back</button><hr class="secondary-nav__divider" />
+<h2 class="tray__title">Polling</h2><hr class="secondary-nav__divider" /><div class="tray__template">
+<p class="mp_menu_tray_text has-18-font-size wp-block-paragraph" style="margin-top:0px">KFF designs, conducts and analyzes original public opinion and survey research on Americans’ attitudes, knowledge, and experiences with the health care system to help amplify the public’s voice in major national debates.</p>
+
+
+
+<div class="wp-block-buttons is-layout-flex wp-block-buttons-is-layout-flex">
+<div class="wp-block-button is-style-arrow"><a class="wp-block-button__link wp-element-button" href="/topic/public-opinion/">View all Poll Findings</a></div>
+</div>
+</div></div></div></li>
+<li id="menu-item-180551" class="menu-item menu-item-type-custom menu-item-object-custom tray__item menu-item-180551"><a href="http://www.kffhealthnews.org/">Health News</a><div class="tray tray--custom-column"><div class="tray__inner"><button aria-label="Close submenu" class="tray__close">Back</button><hr class="secondary-nav__divider" />
+<h2 class="tray__title">Health News</h2><hr class="secondary-nav__divider" /><div class="tray__template">
+<p class="mp_menu_tray_text has-18-font-size wp-block-paragraph" style="margin-top:0"><a href="https://kffhealthnews.org/">KFF Health News</a> is a national newsroom that produces in-depth journalism about health issues and is one of the organization’s core operating programs.</p>
+
+
+
+<div class="wp-block-buttons is-layout-flex wp-block-buttons-is-layout-flex">
+<div class="wp-block-button is-style-arrow"><a class="wp-block-button__link wp-element-button" href="https://kffhealthnews.org/">Explore KFF Health News</a></div>
+</div>
+</div></div></div></li>
+<li id="menu-item-681989" class="menu-item menu-item-type-custom menu-item-object-custom tray__item menu-item-681989"><a href="#">Data &#038; Features</a><div class="tray tray--custom"><div class="tray__inner"><button aria-label="Close submenu" class="tray__close">Back</button><hr class="secondary-nav__divider" />
+<h2 class="tray__title">Data &amp; Features</h2><hr class="secondary-nav__divider" /><div class="tray__template">
+<div class="wp-block-columns is-layout-flex wp-container-core-columns-is-layout-4b8af773 wp-block-columns-is-layout-flex" style="margin-top:0px;margin-bottom:var(--wp--preset--spacing--d-0);padding-top:0px">
+<div class="wp-block-column is-layout-flow wp-container-core-column-is-layout-e87aaff6 wp-block-column-is-layout-flow" style="padding-bottom:var(--wp--preset--spacing--d-4);padding-left:0;flex-basis:250px">
+<ul class="wp-block-list">
+<li class="wp-block-list-item"><strong>FROM THE CEO</strong></li>
+
+
+
+<li class="wp-block-list-item"><a href="/from-drew-altman/">From Drew Altman</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/series/beyond-the-data/">Beyond the Data</a></li>
+</ul>
+
+
+
+<ul class="wp-block-list">
+<li class="wp-block-list-item"><strong><a href="/content-type/feature/?view=grid" data-type="post" data-id="684558">FEATURES</a></strong></li>
+
+
+
+<li class="wp-block-list-item"><a href="https://www.kff.org/quick-take/">Quick Takes</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="https://www.kff.org/series/the-monitor/">The Monitor</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/other-health/health-policy-101-introduction/">Health Policy 101</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="https://www.kff.org/series/business-of-health/">The Business of Health Podcast with Chip Kahn</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="https://www.kff.org/series/health-wonk-shop/">The Health Wonk Shop</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="https://www.kff.org/interactive/subsidy-calculator/">ACA Health Insurance Marketplace Calculator</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="https://www.kff.org/health-costs/2025-employer-health-benefits-survey/">Employer Health Benefits Survey</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/medicaid/50-state-medicaid-budget-survey-fy-2024-2025/#2b7b5dc2-25f2-4343-9fbe-915b48e0aef5">Medicaid Budget Survey</a></li>
+</ul>
+</div>
+
+
+
+<div class="wp-block-column is-layout-flow wp-container-core-column-is-layout-313692ca wp-block-column-is-layout-flow" style="flex-basis:250px">
+<ul class="wp-block-list">
+<li class="wp-block-list-item"><strong><a href="/topic/public-opinion/">POLLING</a></strong></li>
+
+
+
+<li class="wp-block-list-item"><a href="/series/health-tracking-poll/">KFF Health Tracking Poll</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="https://www.kff.org/affordable-care-act/the-publics-views-on-the-aca-tracker/">Tracking the Public’s Views on the ACA</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="https://www.kff.org/public-opinion/kff-polling-on-health-information-and-trust/">Polling on Health Information and Trust</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="#"></a><a href="#"></a><a href="/womens-health-policy/womens-health-survey/">Women's Health Survey</a></li>
+</ul>
+
+
+
+<ul class="wp-block-list">
+<li class="wp-block-list-item"><strong><a href="https://www.kff.org/faqs/">FAQS</a></strong></li>
+
+
+
+<li class="wp-block-list-item"><a href="#"></a><a href="https://www.kff.org/faqs/faqs-health-insurance-marketplace-and-the-aca/">Health Insurance Marketplace and the ACA</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="#"></a><a href="https://www.kff.org/faqs/medicare-open-enrollment-faqs/">Medicare Open Enrollment</a></li>
+</ul>
+</div>
+
+
+
+<div class="wp-block-column is-layout-flow wp-container-core-column-is-layout-313692ca wp-block-column-is-layout-flow" style="flex-basis:250px">
+<ul class="wp-block-list">
+<li class="wp-block-list-item"><strong><a href="/content-type/tracker/">TRACKERS</a></strong></li>
+
+
+
+<li class="wp-block-list-item"><a href="/affordable-care-act/aca-preventive-services-tracker/">ACA Preventive Services Tracker</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/medicaid/medicaid-waiver-tracker-approved-and-pending-section-1115-waivers-by-state/">Medicaid Waiver Tracker</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="https://www.kff.org/medicaid/medicaid-work-requirements-tracker-overview/">Medicaid Work Requirements Tracker</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/interactive/u-s-global-health-budget-tracker/">Global Health Budget Tracker</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/covid-19/global-covid-19-tracker/">Global COVID-19 Tracker</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="https://www.healthsystemtracker.org/" data-type="link" data-id="https://www.healthsystemtracker.org/" target="_blank" rel="noreferrer noopener">Peterson-KFF Health System Tracker</a></li>
+</ul>
+
+
+
+<ul class="wp-block-list">
+<li class="wp-block-list-item"><strong>DASHBOARDS</strong></li>
+
+
+
+<li class="wp-block-list-item"><a href="/womens-health-policy/abortion-in-the-u-s-dashboard/">Abortion in the U.S.</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/racial-equity-and-health-policy/key-data-on-health-and-health-care-by-race-and-ethnicity/" data-type="post" data-id="624173">Key Data on Health Care by Race and Ethnicity</a></li>
+</ul>
+</div>
+
+
+
+<div class="wp-block-column is-layout-flow wp-container-core-column-is-layout-313692ca wp-block-column-is-layout-flow" style="flex-basis:250px">
+<ul class="wp-block-list">
+<li class="wp-block-list-item"><strong>DATABASES</strong></li>
+
+
+
+<li class="wp-block-list-item"><a href="/state-health-facts/">State Health Facts</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="#"></a><a href="#"></a><a href="/state-health-facts/custom/">Custom State Reports</a></li>
+</ul>
+
+
+
+<ul class="wp-block-list">
+<li class="wp-block-list-item"><strong>STATE FACT SHEETS</strong><a href="#"></a></li>
+
+
+
+<li class="wp-block-list-item"><a href="#"></a><a href="/interactive/medicaid-state-fact-sheets/">Medicaid Fact Sheets</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="#"></a><a href="/interactive/mental-health-and-substance-use-state-fact-sheets/">Mental Health and Substance<br>Use Fact Sheets</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/interactive/election-state-fact-sheets/">State Health Care Snapshots</a></li>
+</ul>
+
+
+
+<ul class="wp-block-list">
+<li class="wp-block-list-item"><strong>STATE PROFILES</strong></li>
+
+
+
+<li class="wp-block-list-item"><a href="#"></a><a href="#"></a><a href="/interactive/state-profiles-for-dual-eligible-individuals/united-states/enrollment-and-spending-for-dual-eligible-individuals/">State Profiles of Dual-Eligible Individuals </a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/womens-health-policy/state-profiles-for-womens-health/">State Profiles of Women’s Health</a></li>
+</ul>
+</div>
+</div>
+
+
+
+<div class="wp-block-group is-layout-constrained wp-container-core-group-is-layout-f45b68ee wp-block-group-is-layout-constrained" style="margin-top:0px;margin-bottom:100px;padding-top:0;padding-bottom:0">
+<div class="wp-block-buttons is-layout-flex wp-block-buttons-is-layout-flex">
+<div class="wp-block-button is-style-arrow"><a class="wp-block-button__link wp-element-button" href="/content-type/feature/?view=grid">View all Features</a></div>
+</div>
+</div>
+</div></div></div></li>
+<li id="menu-item-681990" class="menu-item menu-item-type-custom menu-item-object-custom tray__item menu-item-681990"><a href="#">For Media</a><div class="tray tray--custom"><div class="tray__inner"><button aria-label="Close submenu" class="tray__close">Back</button><hr class="secondary-nav__divider" />
+<h2 class="tray__title">For Media</h2><hr class="secondary-nav__divider" /><div class="tray__template">
+<div class="wp-block-columns is-layout-flex wp-container-core-columns-is-layout-7528fa30 wp-block-columns-is-layout-flex" style="margin-top:0;margin-bottom:0;padding-top:0;padding-bottom:0">
+<div class="wp-block-column is-layout-flow wp-block-column-is-layout-flow" style="flex-basis:948px"></div>
+
+
+
+<div class="wp-block-column is-layout-flow wp-block-column-is-layout-flow" style="flex-basis:332px">
+<ul class="wp-block-list">
+<li class="wp-block-list-item"><a href="/media-resources/#media-contacts">Media Contacts</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/about-us/permissions-citations-reprints/">Citations and Reprints</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/content-type/news-release/">News Releases</a></li>
+</ul>
+
+
+
+<div class="wp-block-buttons is-layout-flex wp-block-buttons-is-layout-flex">
+<div class="wp-block-button is-style-arrow"><a class="wp-block-button__link wp-element-button" href="/about-us/media-resources/">Explore all Media Resources</a></div>
+</div>
+</div>
+</div>
+</div></div></div></li>
+<li id="menu-item-681991" class="menu-item menu-item-type-custom menu-item-object-custom tray__item menu-item-681991"><a href="#">About</a><div class="tray tray--custom"><div class="tray__inner"><button aria-label="Close submenu" class="tray__close">Back</button><hr class="secondary-nav__divider" />
+<h2 class="tray__title">About</h2><hr class="secondary-nav__divider" /><div class="tray__template">
+<div class="wp-block-columns is-layout-flex wp-container-core-columns-is-layout-4db4c9a1 wp-block-columns-is-layout-flex" style="margin-top:0px;margin-bottom:0">
+<div class="wp-block-column is-layout-flow wp-block-column-is-layout-flow" style="flex-basis:195px"></div>
+
+
+
+<div class="wp-block-column is-layout-flow wp-block-column-is-layout-flow" style="flex-basis:195px"></div>
+
+
+
+<div class="wp-block-column is-layout-flow wp-block-column-is-layout-flow" style="padding-bottom:0;flex-basis:195px">
+<ul class="wp-block-list">
+<li class="wp-block-list-item"><a href="https://www.kff.org/about-us/">About Us</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/people/">Our People</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/about-us/our-programs/" data-type="page" data-id="624972">Our Work</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/about-us/board-of-trustees/">Board of Trustees</a></li>
+</ul>
+</div>
+
+
+
+<div class="wp-block-column is-layout-flow wp-block-column-is-layout-flow" style="flex-basis:195px">
+<ul class="wp-block-list">
+<li class="wp-block-list-item"><a href="/about-us/conference-centers/">Conference Centers</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/events/">Events</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/about-us/contact-us/" data-type="post" data-id="257855">Contact Us</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/about-us/employment-opportunities/">Join Our Team</a></li>
+</ul>
+</div>
+
+
+
+<div class="wp-block-column featured-tray is-layout-flow wp-block-column-is-layout-flow">
+<ul class="wp-block-list">
+<li class="wp-block-list-item"><strong>From CEO Drew Altman</strong></li>
+
+
+
+<li class="wp-block-list-item"><a href="https://www.kff.org/about-us/presidents-message/">President's Message</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/from-drew-altman/questions-i-get-about-the-standards-and-practices-for-organizations-in-an-era-of-misinformation-and-declining-trust/">Our Standards &amp; Practices</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="/series/beyond-the-data/">Beyond the Data Columns</a></li>
+
+
+
+<li class="wp-block-list-item"><a href="https://www.kff.org/from-drew-altman/">View All</a></li>
+</ul>
+</div>
+</div>
+
+
+
+<div class="wp-block-columns is-layout-flex wp-container-core-columns-is-layout-5642b425 wp-block-columns-is-layout-flex" style="margin-top:0px;margin-bottom:0;padding-top:0;padding-bottom:0">
+<div class="wp-block-column is-layout-flow wp-block-column-is-layout-flow" style="flex-basis:195px"></div>
+
+
+
+<div class="wp-block-column is-layout-flow wp-block-column-is-layout-flow" style="flex-basis:195px"></div>
+
+
+
+<div class="wp-block-column is-layout-flow wp-block-column-is-layout-flow" style="padding-bottom:0;flex-basis:195px">
+<div class="wp-block-buttons is-layout-flex wp-block-buttons-is-layout-flex">
+<div class="wp-block-button is-style-arrow"><a class="wp-block-button__link wp-element-button" href="/about-us/">About KFF</a></div>
+</div>
+</div>
+
+
+
+<div class="wp-block-column is-layout-flow wp-block-column-is-layout-flow" style="flex-basis:195px"></div>
+
+
+
+<div class="wp-block-column featured-tray is-layout-flow wp-block-column-is-layout-flow"></div>
+</div>
+</div></div></div></li>
+</ul></div>	<hr class="secondary-nav__divider" />
+
+	<div class="secondary-nav__links">
+		<a href="https://www.kff.org/about-us/follow-us/" class="secondary-nav__link">Follow Us</a>
+		<a href="https://www.kff.org/about-us/email/" class="secondary-nav__link">Subscribe</a>
+	</div>
+
+	<div class="secondary-nav__search-wrapper">
+		<button class="secondary-nav__link secondary-nav__link--search" aria-label="Search the site">
+			<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 20 20"><path fill="#000" fill-rule="evenodd" d="M19.18 17.665c.426.42.426 1.103 0 1.523a1.09 1.09 0 0 1-1.526 0L13.296 14.9a8.1 8.1 0 0 1-4.723 1.505C4.122 16.405.5 12.852.5 8.453.5 4.053 4.122.5 8.573.5s8.073 3.553 8.074 7.953a7.83 7.83 0 0 1-1.78 4.967zM2.665 8.453c0 3.199 2.638 5.806 5.908 5.806s5.908-2.607 5.908-5.806c0-3.2-2.638-5.806-5.908-5.806S2.665 5.254 2.665 8.453" clip-rule="evenodd" /></svg>			<span>Search</span>
+		</button>
+		<div class="secondary-nav__search">
+			
+<div itemscope itemtype="http://schema.org/WebSite">
+	<form role="search" id="searchform" class="search-form" method="get" action="https://www.kff.org/">
+		<meta itemprop="target" content="https://www.kff.org/?s={s}" />
+		<label for="search-field">
+			Search for:		</label>
+		<input itemprop="query-input" type="search" id="search-field" value="" placeholder="Search &hellip;" name="s" />
+		<input type="submit" value="Submit">
+	</form>
+</div>
+			<button class="secondary-nav__search-close" aria-label="Close search">
+				<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24"><path fill="#004B88" d="M18.555 4 4 18.213l1.286 1.532L19.84 5.532z" /><path fill="#004B88" d="M12 11h-1v2h1z" /><path fill="#004B88" d="M19.84 18.213 5.286 4 4 5.532l14.555 14.213z" /></svg>			</button>
+		</div>
+	</div>
+
+</div>
+</header>
+							
+		<main id="main" role="main" tabindex="-1">
+
+							<div class="breadcrumbs">
+					<span><span><a href="https://www.kff.org">Home</a></span>  <span><a href="/state-health-facts/">State Health Facts</a></span>  <span><a href="https://www.kff.org/state-category/affordable-care-act/">Affordable Care Act</a></span>  <span><a href="https://www.kff.org/state-category/affordable-care-act/health-insurance-marketplaces/">Health Insurance Marketplaces</a></span></span>				</div>
+			
+			<div class="site-container">
+	<script type="text/javascript">
+		var appJs = appJs || {};
+		appJs = {
+			...appJs,
+			...{"post_type":"state-indicator","itype":"state","geo_url":"https:\/\/www.kff.org\/wp-content\/themes\/kff-org-modern\/static\/medicare_geos.json","is_preview":false,"base":"\/affordable-care-act\/state-indicator\/full-year-average-marketplace-effectuated-enrollment\/","gdocs_key":"1JtIAcYkx2ETDpcI26EBZO1eLmC1N_JiT-VeiVq8YwhA","gdocsObject":[["Notes",[["Timeframe","Distribution","Data Format","Geography","Type","Note"],["any","","","","Notes","Data represent the average monthly number of individuals who had an active Marketplace policy and who paid their premium (thus effectuating their coverage) for each full plan year."],["2024","","","","Sources","[Effectuated Enrollment: Early 2025 Snapshot and Full Year 2024 Average](https:\/\/www.cms.gov\/files\/document\/effectuated-enrollment-early-snapshot-2025-and-full-year-2024-average.pdf), Centers for Medicare and Medicaid Services (CMS), March 15, 2025."],["2023","","","","Sources","[Effectuated Enrollment: Early 2024 Snapshot and Full Year 2023 Average](https:\/\/www.cms.gov\/files\/document\/early-2024-and-full-year-2023-effectuated-enrollment-report.pdf), Centers for Medicare and Medicaid Services (CMS), March 15, 2024."],["2022","","","","Sources","[Effectuated Enrollment: Early 2023 Snapshot and Full Year 2022 Average](https:\/\/www.cms.gov\/files\/document\/early-2023-and-full-year-2022-effectuated-enrollment-report.pdf), Centers for Medicare and Medicaid Services (CMS), March 15, 2023."],["2021","","","","Sources","[Early 2022 Effectuated Enrollment Snapshot](https:\/\/www.cms.gov\/files\/document\/early-2022-and-full-year-2021-effectuated-enrollment-report.pdf), Centers for Medicare and Medicaid Services (CMS), March 15, 2022."],["2020","","","","Sources","[Early 2021 Effectuated Enrollment Snapshot](https:\/\/www.cms.gov\/document\/Early-2021-2020-Effectuated-Enrollment-Report.pdf), Centers for Medicare and Medicaid Services (CMS), June 5, 2021."],["2019","","","","Sources","[Early 2020 Effectuated Enrollment Snapshot](https:\/\/www.cms.gov\/CCIIO\/Resources\/Forms-Reports-and-Other-Resources\/Downloads\/Early-2020-2019-Effectuated-Enrollment-Report.pdf), Centers for Medicare and Medicaid Services (CMS), July 23, 2020."],["2018","","","","Sources","[Early 2019 Effectuated Enrollment Snapshot](https:\/\/www.cms.gov\/sites\/default\/files\/2019-08\/08-12-2019%20TABLE%20Early-2019-2018-Average-Effectuated-Enrollment.pdf), Centers for Medicare and Medicaid Services (CMS), August 13, 2019."],["2017","","","","Sources","[Early 2018 Effectuated Enrollment Snapshot](https:\/\/www.cms.gov\/CCIIO\/Programs-and-Initiatives\/Health-Insurance-Marketplaces\/Downloads\/2018-07-02-Trends-Report-1.pdf), Centers for Medicare and Medicaid Services (CMS), July 2, 2018."],["any","","","","Definitions"],["any","","","","Locked","yes"],["2024","Region","","Minnesota","Footnote","Minnesota operates a Basic Health Program (BHP), MinnesotaCare, which provides coverage to individuals with incomes 138%-200% of the federal poverty level who would otherwise be eligible to purchase subsidized coverage through the state's Health Insurance Marketplace, MNsure. Individuals can enroll in the BHP throughout the year, and as of January 15, 2024, there were 103,638 people enrolled in MinnesotaCare for 2024."],["2024","Region","","New York","Footnote","New York operated a Basic Health Program (BHP), the Essential Plan, through April 2024, which provided coverage to individuals with incomes 138%-200% of the federal poverty level who would otherwise be eligible to purchase subsidized coverage through the federal Health Insurance Marketplace, NY State of Health.\u00a0Beginning in April, the Essential Plan was expanded to cover individuals with incomes 138%-250% of the federal poverty level. Individuals can enroll in the program throughout the year, and as of February 3, 2024, there were 1,198,396 people enrolled in the Essential Plan for 2024."],["2023","Region","","Minnesota","Footnote","Minnesota operates a Basic Health Program (BHP), MinnesotaCare, which provides coverage to individuals with incomes 138%-200% of the federal poverty level who would otherwise be eligible to purchase subsidized coverage through the state's Health Insurance Marketplace, MNsure. Individuals can enroll in the BHP throughout the year, and as of January 15, 2023, there were 94,811 people enrolled in MinnesotaCare for 2023."],["2023","Region","","New York","Footnote","In 2023, New York operated a Basic Health Program (BHP), the Essential Plan, which provided coverage to individuals with incomes 138%-200% of the federal poverty level who would otherwise be eligible to purchase subsidized coverage through the federal Health Insurance Marketplace, NY State of Health.\u00a0Individuals could enroll in the BHP throughout the year, and as of January 31, 2023, there were 1,123,110 people enrolled in the Essential Plan for 2023."],["2022","Region","","Minnesota","Footnote","Minnesota operates a Basic Health Program (BHP), MinnesotaCare, which provides coverage to individuals with incomes 138%-200% of the federal poverty level who would otherwise be eligible to purchase subsidized coverage through the state's Health Insurance Marketplace, MNsure. Individuals can enroll in the BHP throughout the year, and as of January 15, 2022, there were 98,581 people enrolled in MinnesotaCare for 2022."],["2022","Region","","New York","Footnote","In 2022, New York operated a Basic Health Program (BHP), the Essential Plan, which provided coverage to individuals with incomes 138%-200% of the federal poverty level who would otherwise be eligible to purchase subsidized coverage through the federal Health Insurance Marketplace, NY State of Health.\u00a0Individuals could enroll in the BHP throughout the year, and as of January 31, 2022, there were 956,022 people enrolled in the Essential Plan for 2022."],["2021","Region","","Minnesota","Footnote","Minnesota operates a Basic Health Program (BHP), MinnesotaCare, which provides coverage to individuals with incomes 138%-200% of the federal poverty level who would otherwise be eligible to purchase subsidized coverage through the state's Health Insurance Marketplace, MNsure. Individuals can enroll in the BHP throughout the year, and as of December 22, 2020, there were 91,886 people enrolled in MinnesotaCare for 2021."],["2021","Region","","New York","Footnote","In 2021, New York operated a Basic Health Program (BHP), the Essential Plan, which provided coverage to individuals with incomes 138%-200% of the federal poverty level who would otherwise be eligible to purchase subsidized coverage through the federal Health Insurance Marketplace, NY State of Health.\u00a0Individuals could enroll in the BHP throughout the year, and as of January 31, 2021, there were 883,451 people enrolled in the Essential Plan for 2021."],["2020","Region","","Minnesota","Footnote","Minnesota operates a Basic Health Program (BHP), MinnesotaCare, which provides coverage to individuals with incomes 138%-200% of the federal poverty level who would otherwise be eligible to purchase subsidized coverage through the state's Health Insurance Marketplace, MNsure. Individuals can enroll in the BHP throughout the year, and as of December 23, 2019, there were 83,200 people enrolled in MinnesotaCare for 2020."],["2020","Region","","New York","Footnote","In 2020, New York operated a Basic Health Program (BHP), the Essential Plan, which provided coverage to individuals with incomes 138%-200% of the federal poverty level who would otherwise be eligible to purchase subsidized coverage through the federal Health Insurance Marketplace, NY State of Health.\u00a0Individuals could enroll in the BHP throughout the year, and as of February 7, 2020, there were 796,998 people enrolled in the Essential Plan for 2020."],["2019","Region","","Minnesota","Footnote","Minnesota operates a Basic Health Program (BHP), MinnesotaCare, which provides coverage to individuals with incomes 138%-200% of the federal poverty level who would otherwise be eligible to purchase subsidized coverage through the state's Health Insurance Marketplace, MNsure. Individuals can enroll in the BHP throughout the year, and as of January 13, 2019, there were 92,561 people enrolled in MinnesotaCare for 2019."],["2019","Region","","New York","Footnote","In 2019, New York operated a Basic Health Program (BHP), the Essential Plan, which provided coverage to individuals with incomes 138%-200% of the federal poverty level who would otherwise be eligible to purchase subsidized coverage through the federal Health Insurance Marketplace, NY State of Health.\u00a0Individuals could enroll in the BHP throughout the year, and as of January 31, 2019, there were 790,152 people enrolled in the Essential Plan for 2019.\u00a0"],["2018","Region","","Minnesota","Footnote","Minnesota operates a Basic Health Program (BHP), MinnesotaCare, which provides coverage to individuals with incomes 138%-200% of the federal poverty level who would otherwise be eligible to purchase subsidized coverage through the state's Health Insurance Marketplace, MNsure. Individuals can enroll in the BHP throughout the year, and as of January 14, 2018, there were 90,346 people enrolled in MinnesotaCare for 2018."],["2018","Region","","New York","Footnote","In 2018, New York operated a Basic Health Program (BHP), the Essential Plan, which provided coverage to individuals with incomes 138%-200% of the federal poverty level who would otherwise be eligible to purchase subsidized coverage through the federal Health Insurance Marketplace, NY State of Health.\u00a0Individuals could enroll in the BHP throughout the year, and as of January 31, 2018, there were 738,851 people enrolled in the Essential Plan for 2018.\u00a0"],["2017","Region","","Minnesota","Footnote","Minnesota operates a Basic Health Program (BHP), MinnesotaCare, which provides coverage to individuals with incomes 138%-200% of the federal poverty level who would otherwise be eligible to purchase subsidized coverage through the state's Health Insurance Marketplace, MNsure. Individuals can enroll in the BHP throughout the year, and as of January 31, 2017, there were 99,654 people enrolled in MinnesotaCare for 2017."],["2017","Region","","New York","Footnote","In 2017, New York operated a Basic Health Program (BHP), the Essential Plan, which provided coverage to individuals with incomes 138%-200% of the federal poverty level who would otherwise be eligible to purchase subsidized coverage through the federal Health Insurance Marketplace, NY State of Health.\u00a0Individuals could enroll in the BHP throughout the year, and as of January 31, 2017, there were 665,318 people enrolled in the Essential Plan for 2017.\u00a0"]]],["2024",[["","Total Effectuated Marketplace Enrollment"],["","Number"],["United States","20968847"],["Alabama","396750"],["Alaska","25126"],["Arizona","349847"],["Arkansas","134543"],["California","1795695"],["Colorado","229679"],["Connecticut","131600"],["Delaware","43129"],["District of Columbia","11484"],["Florida","4163154"],["Georgia","1259957"],["Hawaii","20486"],["Idaho","102396"],["Illinois","378297"],["Indiana","295264"],["Iowa","113095"],["Kansas","168080"],["Kentucky","74927"],["Louisiana","229588"],["Maine","59136"],["Maryland","208970"],["Massachusetts","310491"],["Michigan","430037"],["Minnesota","132544"],["Mississippi","281548"],["Missouri","356574"],["Montana","65991"],["Nebraska","115949"],["Nevada","92949"],["New Hampshire","62004"],["New Jersey","405257"],["New Mexico","58196"],["New York","226331"],["North Carolina","928561"],["North Dakota","37305"],["Ohio","486216"],["Oklahoma","269554"],["Oregon","132020"],["Pennsylvania","424411"],["Rhode Island","41346"],["South Carolina","543454"],["South Dakota","49533"],["Tennessee","545586"],["Texas","3383171"],["Utah","372832"],["Vermont","29819"],["Virginia","355176"],["Washington","280820"],["West Virginia","52741"],["Wisconsin","267285"],["Wyoming","39943"]]],["2023",[["","Total Effectuated Marketplace Enrollment"],["","Number"],["United States","16153121"],["Alabama","259036"],["Alaska","23308"],["Arizona","234163"],["Arkansas","97040"],["California","1684963"],["Colorado","185447"],["Connecticut","110304"],["Delaware","33053"],["District of Columbia","11512"],["Florida","3188569"],["Georgia","896429"],["Hawaii","19686"],["Idaho","85606"],["Illinois","301622"],["Indiana","189105"],["Iowa","81068"],["Kansas","122871"],["Kentucky","57779"],["Louisiana","126719"],["Maine","59355"],["Maryland","174874"],["Massachusetts","224073"],["Michigan","308216"],["Minnesota","112654"],["Mississippi","181229"],["Missouri","255847"],["Montana","51358"],["Nebraska","94340"],["Nevada","83830"],["New Hampshire","52722"],["New Jersey","316203"],["New Mexico","41749"],["New York","213206"],["North Carolina","798116"],["North Dakota","32411"],["Ohio","309141"],["Oklahoma","201351"],["Oregon","127296"],["Pennsylvania","357402"],["Rhode Island","30091"],["South Carolina","403143"],["South Dakota","45915"],["Tennessee","365541"],["Texas","2439628"],["Utah","296322"],["Vermont","25600"],["Virginia","333752"],["Washington","233961"],["West Virginia","29089"],["Wisconsin","210798"],["Wyoming","35628"]]],["2022",[["","Total Effectuated Marketplace Enrollment"],["","Number"],["United States","13477029"],["Alabama","202847"],["Alaska","21251"],["Arizona","181741"],["Arkansas","77748"],["California","1701375"],["Colorado","180309"],["Connecticut","102608"],["Delaware","29872"],["District of Columbia","13655"],["Florida","2585959"],["Georgia","638596"],["Hawaii","19812"],["Idaho","68792"],["Illinois","288176"],["Indiana","144519"],["Iowa","68290"],["Kansas","98753"],["Kentucky","61618"],["Louisiana","93690"],["Maine","59234"],["Maryland","168097"],["Massachusetts","224613"],["Michigan","276655"],["Minnesota","110310"],["Mississippi","126731"],["Missouri","217196"],["Montana","48626"],["Nebraska","88875"],["Nevada","90397"],["New Hampshire","48316"],["New Jersey","297159"],["New Mexico","34678"],["New York","210523"],["North Carolina","628083"],["North Dakota","29185"],["Ohio","235976"],["Oklahoma","171473"],["Oregon","130283"],["Pennsylvania","338575"],["Rhode Island","30790"],["South Carolina","281301"],["South Dakota","39452"],["Tennessee","254118"],["Texas","1718549"],["Utah","252336"],["Vermont","24588"],["Virginia","287063"],["Washington","223209"],["West Virginia","21108"],["Wisconsin","196848"],["Wyoming","33071"]]],["2021",[["","Total Effectuated Marketplace Enrollment"],["","Number"],["United States","11734931"],["Alabama","169663"],["Alaska","17494"],["Arizona","151183"],["Arkansas","62971"],["California","1621859"],["Colorado","163299"],["Connecticut","100256"],["Delaware","24810"],["District of Columbia","15891"],["Florida","2125588"],["Georgia","514921"],["Hawaii","19905"],["Idaho","66556"],["Illinois","269580"],["Indiana","124920"],["Iowa","56214"],["Kansas","86026"],["Kentucky","71880"],["Louisiana","78291"],["Maine","55961"],["Maryland","158932"],["Massachusetts","263169"],["Michigan","250559"],["Minnesota","107637"],["Mississippi","101706"],["Missouri","207961"],["Montana","42496"],["Nebraska","83918"],["Nevada","81523"],["New Hampshire","44837"],["New Jersey","263680"],["New Mexico","39655"],["New York","208801"],["North Carolina","521835"],["North Dakota","23161"],["Ohio","191727"],["Oklahoma","165636"],["Oregon","127043"],["Pennsylvania","319560"],["Rhode Island","31436"],["South Carolina","225800"],["South Dakota","31762"],["Tennessee","206930"],["Texas","1314188"],["Utah","207438"],["Vermont","23937"],["Virginia","250227"],["Washington","218390"],["West Virginia","16923"],["Wisconsin","180020"],["Wyoming","26776"]]],["2020",[["","Total Effectuated Marketplace Enrollment"],["","Number"],["United States","10408982"],["Alabama","143075"],["Alaska","15544"],["Arizona","135366"],["Arkansas","56071"],["California","1514297"],["Colorado","156196"],["Connecticut","100626"],["Delaware","22338"],["District of Columbia","16195"],["Florida","1757882"],["Georgia","413122"],["Hawaii","18528"],["Idaho","68878"],["Illinois","259519"],["Indiana","125261"],["Iowa","51519"],["Kansas","76702"],["Kentucky","71430"],["Louisiana","75432"],["Maine","55388"],["Maryland","149367"],["Massachusetts","286857"],["Michigan","234780"],["Minnesota","105327"],["Mississippi","86736"],["Missouri","183019"],["Montana","40183"],["Nebraska","82649"],["Nevada","66538"],["New Hampshire","40671"],["New Jersey","215129"],["New Mexico","37176"],["New York","238377"],["North Carolina","452638"],["North Dakota","19976"],["Ohio","174882"],["Oklahoma","143361"],["Oregon","127448"],["Pennsylvania","290571"],["Rhode Island","32754"],["South Carolina","188907"],["South Dakota","27786"],["Tennessee","178195"],["Texas","1010181"],["Utah","185925"],["Vermont","24732"],["Virginia","232867"],["Washington","201436"],["West Virginia","17567"],["Wisconsin","176820"],["Wyoming","22758"]]],["2019",[["","Total Effectuated Marketplace Enrollment"],["","Number"],["United States","9810613"],["Alabama","140678"],["Alaska","15261"],["Arizona","135074"],["Arkansas","55903"],["California","1348547"],["Colorado","142152"],["Connecticut","97272"],["Delaware","19352"],["District of Columbia","15921"],["Florida","1551765"],["Georgia","373049"],["Hawaii","17002"],["Idaho","85926"],["Illinois","262714"],["Indiana","127470"],["Iowa","44799"],["Kansas","77880"],["Kentucky","70936"],["Louisiana","77579"],["Maine","59844"],["Maryland","134775"],["Massachusetts","276808"],["Michigan","234530"],["Minnesota","98009"],["Mississippi","74304"],["Missouri","179171"],["Montana","39684"],["Nebraska","80080"],["Nevada","67052"],["New Hampshire","38889"],["New Jersey","211462"],["New Mexico","37992"],["New York","241576"],["North Carolina","428116"],["North Dakota","19848"],["Ohio","171320"],["Oklahoma","138015"],["Oregon","126846"],["Pennsylvania","303134"],["Rhode Island","32784"],["South Carolina","180113"],["South Dakota","26281"],["Tennessee","174568"],["Texas","902787"],["Utah","179518"],["Vermont","25730"],["Virginia","248688"],["Washington","200205"],["West Virginia","18410"],["Wisconsin","178865"],["Wyoming","21929"]]],["2018",[["","Total Effectuated Marketplace Enrollment"],["","Number"],["United States","9895197"],["Alabama","146065"],["Alaska","15539"],["Arizona","139489"],["Arkansas","55906"],["California","1373061"],["Colorado","135606"],["Connecticut","100685"],["Delaware","19461"],["District of Columbia","17065"],["Florida","1460358"],["Georgia","365269"],["Hawaii","16232"],["Idaho","85505"],["Illinois","278661"],["Indiana","134543"],["Iowa","40541"],["Kansas","80508"],["Kentucky","74060"],["Louisiana","83763"],["Maine","64844"],["Maryland","129817"],["Massachusetts","246917"],["Michigan","244864"],["Minnesota","96940"],["Mississippi","65644"],["Missouri","198472"],["Montana","41197"],["Nebraska","76665"],["Nevada","70615"],["New Hampshire","39203"],["New Jersey","222607"],["New Mexico","41006"],["New York","224957"],["North Carolina","431518"],["North Dakota","19642"],["Ohio","187187"],["Oklahoma","126369"],["Oregon","128677"],["Pennsylvania","336198"],["Rhode Island","31902"],["South Carolina","174881"],["South Dakota","26389"],["Tennessee","194060"],["Texas","895823"],["Utah","169563"],["Vermont","26714"],["Virginia","318776"],["Washington","210892"],["West Virginia","21596"],["Wisconsin","187037"],["Wyoming","21908"]]],["2017",[["","Total Effectuated Marketplace Enrollment"],["","Number"],["United States","9763076"],["Alabama","148937"],["Alaska","14626"],["Arizona","137296"],["Arkansas","54530"],["California","1321234"],["Colorado","140012"],["Connecticut","92697"],["Delaware","21507"],["District of Columbia","17849"],["Florida","1334172"],["Georgia","379408"],["Hawaii","16316"],["Idaho","82517"],["Illinois","281640"],["Indiana","139001"],["Iowa","42630"],["Kansas","81425"],["Kentucky","70652"],["Louisiana","101171"],["Maine","66880"],["Maryland","128809"],["Massachusetts","242020"],["Michigan","262216"],["Minnesota","88562"],["Mississippi","61519"],["Missouri","200767"],["Montana","44369"],["Nebraska","71357"],["Nevada","70801"],["New Hampshire","44297"],["New Jersey","234840"],["New Mexico","42474"],["New York","211693"],["North Carolina","434083"],["North Dakota","19347"],["Ohio","193830"],["Oklahoma","117383"],["Oregon","126528"],["Pennsylvania","344180"],["Rhode Island","29361"],["South Carolina","173549"],["South Dakota","25789"],["Tennessee","189425"],["Texas","897182"],["Utah","165285"],["Vermont","27923"],["Virginia","339387"],["Washington","182365"],["West Virginia","25826"],["Wisconsin","202254"],["Wyoming","21155"]]]],"postBody":""}		};
+
+	</script>
+
+	<script id="results-template" type="text/template">
+		<html>
+		<head>
+									<link rel="stylesheet" href="<%= stylesheet %>" type="text/css"/>
+			<title>Table Viewer</title>
+		</head>
+		<body>
+		<header>
+			<div id="header-inner" class="clearfix">
+				<h1 id="kff-logo">KFF</h1>
+				<h2>Full Year Average Marketplace Effectuated Enrollment, 2017-2024</h2>
+				<h4>Timeframe&#058; <span><%= timeframe %></span></h4>
+			</div>
+		</header>
+		<div class="box">
+			<%= table %>
+		</div>
+				</body>
+		</html>
+	</script>
+	<div class="box">
+		<div class="headline-wrapper">
+			<h2>Full Year Average Marketplace Effectuated Enrollment, 2017-2024</h2>
+		</div>
+		<form id="top-box-search-input" class="search-form"
+				action="/state-indicator/">
+			<input type="text" name="s" id="search-field"
+				placeholder=" Search State Health Facts Data"/>
+			<input type="submit" value="search" id="search-submit"/>
+		</form>
+
+			</div>
+	<div class="clearfix state-indicator--wrapper" kff-datacenter>
+		<div ng-if="false" class="loading-placeholder">
+			<h3>
+				<i class="fa fa-circle-o-notch fa-spin fa-4x"></i>
+				Data are loading			</h3>
+		</div>
+		<div ui-view></div>
+	</div>
+	<div class="right-double-column">
+		<div id="page-taxonomy" class="box primary">
+								<div class="tax-wrapper">
+				<h4>Topics</h4>
+						<ul>
+													<li><a href="https://www.kff.org/topic/affordable-care-act/">Affordable Care Act</a></li>
+							</ul>
+							</div>
+																	<div class="tax-wrapper">
+				<h4>Categories</h4>
+						<ul>
+													<li><a href="https://www.kff.org/state-category/affordable-care-act/health-insurance-marketplaces/">Health Insurance Marketplaces</a></li>
+							</ul>
+							</div>
+							</div>
+	</div>
+			</div>
+		</main>
+		<script type="speculationrules">
+{"prefetch":[{"source":"document","where":{"and":[{"href_matches":"\/*"},{"not":{"href_matches":["\/wp-*.php","\/wp-admin\/*","\/wp-content\/uploads\/sites\/7\/*","\/wp-content\/*","\/wp-content\/plugins\/*","\/wp-content\/themes\/kff-org-modern\/*","\/*\\?(.+)"]}},{"not":{"selector_matches":"a[rel~=\"nofollow\"]"}},{"not":{"selector_matches":".no-prefetch, .no-prefetch a"}}]},"eagerness":"conservative"}]}
+</script>
+<script type="importmap" id="wp-importmap">
+{"imports":{"@wordpress\/interactivity":"https:\/\/www.kff.org\/wp-includes\/js\/dist\/script-modules\/interactivity\/index.min.js?ver=55aebb6e0a16726baffb"}}
+</script>
+<script type="module" src="https://www.kff.org/wp-content/plugins/ui-kit-core/dist/js/cover-block-video-controls.js?ver=5f6bf4f921a78432eb80" id="ui-kit-cover-block-video-controls-js-module"></script>
+<link rel="modulepreload" href="https://www.kff.org/wp-includes/js/dist/script-modules/interactivity/index.min.js?ver=55aebb6e0a16726baffb" id="@wordpress/interactivity-js-modulepreload"><!-- Start of Async HubSpot Analytics Code -->
+<script type="text/javascript">
+(function(d,s,i,r) {
+if (d.getElementById(i)){return;}
+var n=d.createElement(s),e=d.getElementsByTagName(s)[0];
+n.id=i;n.src='//js.hs-analytics.net/analytics/'+(Math.ceil(new Date()/r)*r)+'/292449.js';
+e.parentNode.insertBefore(n, e);
+})(document,"script","hs-analytics",300000);
+</script>
+<!-- End of Async HubSpot Analytics Code -->
+<style id='core-block-supports-inline-css' type='text/css'>
+.wp-container-core-columns-is-layout-744a75a8{flex-wrap:nowrap;gap:2em 42px;}.wp-container-core-column-is-layout-e87aaff6 > *{margin-block-start:0;margin-block-end:0;}.wp-container-core-column-is-layout-e87aaff6 > * + *{margin-block-start:2.8rem;margin-block-end:0;}.wp-container-core-column-is-layout-313692ca > *{margin-block-start:0;margin-block-end:0;}.wp-container-core-column-is-layout-313692ca > * + *{margin-block-start:var(--wp--preset--spacing--d-5);margin-block-end:0;}.wp-container-core-columns-is-layout-4b8af773{flex-wrap:nowrap;gap:0px 80px;}.wp-container-core-group-is-layout-f45b68ee > *{margin-block-start:0;margin-block-end:0;}.wp-container-core-group-is-layout-f45b68ee > * + *{margin-block-start:var(--wp--preset--spacing--d-0);margin-block-end:0;}.wp-container-core-columns-is-layout-7528fa30{flex-wrap:nowrap;gap:2em 0;}.wp-container-core-columns-is-layout-4db4c9a1{flex-wrap:nowrap;gap:2em 42px;}.wp-container-core-columns-is-layout-5642b425{flex-wrap:nowrap;gap:2em 42px;}
+</style>
+<script type="text/javascript" src="https://www.kff.org/wp-content/plugins/kff-shared/dist/js/shared.js?ver=8c5b220bf6f482881a90" id="kff_shared_plugin_shared-js"></script>
+<script type="text/javascript" src="https://www.kff.org/wp-includes/js/dist/vendor/lodash.min.js?ver=4.17.21" id="lodash-js"></script>
+<script type="text/javascript" id="lodash-js-after">
+/* <![CDATA[ */
+window.lodash = _.noConflict();
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://www.kff.org/wp-content/plugins/kff-shared/dist/js/frontend.js?ver=b61d5bda18bb08ee34fa" id="kff_shared_plugin_frontend-js"></script>
+<script type="text/javascript" src="https://www.kff.org/wp-content/themes/kff-org-modern/dist/js/frontend.js?ver=b049b69bd07dc671aa68" id="frontend-js"></script>
+<script type="text/javascript" src="https://www.kff.org/wp-includes/js/jquery/ui/core.min.js?ver=1.13.3" id="jquery-ui-core-js"></script>
+<script type="text/javascript" src="https://www.kff.org/wp-includes/js/jquery/ui/datepicker.min.js?ver=1.13.3" id="jquery-ui-datepicker-js"></script>
+<script type="text/javascript" id="jquery-ui-datepicker-js-after">
+/* <![CDATA[ */
+jQuery(function(jQuery){jQuery.datepicker.setDefaults({"closeText":"Close","currentText":"Today","monthNames":["January","February","March","April","May","June","July","August","September","October","November","December"],"monthNamesShort":["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"nextText":"Next","prevText":"Previous","dayNames":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"dayNamesShort":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"dayNamesMin":["S","M","T","W","T","F","S"],"dateFormat":"M d, yy","firstDay":1,"isRTL":false});});
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://www.kff.org/wp-includes/js/imagesloaded.min.js?ver=5.0.0" id="imagesloaded-js"></script>
+<script type="text/javascript" src="https://www.kff.org/wp-includes/js/masonry.min.js?ver=4.2.2" id="masonry-js"></script>
+<script type="text/javascript" src="https://www.kff.org/wp-includes/js/jquery/jquery.masonry.min.js?ver=3.1.2b" id="jquery-masonry-js"></script>
+<script type="text/javascript" src="https://www.kff.org/wp-content/themes/kff-org-modern/static/js/apps/datacenter/vendor-2.0.87.bundle.js?ver=2.0.87" id="kff-datacenter-vendor-js"></script>
+<script type="text/javascript" id="kff-datacenter-main-js-extra">
+/* <![CDATA[ */
+var dcStrings = {"clearAllSelections":"Clear All Selections","selectAll":"Select All","unselectAll":"Unselect All"};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://www.kff.org/wp-content/themes/kff-org-modern/static/js/apps/datacenter/datacenter-2.0.87.bundle.js?ver=2.0.87" id="kff-datacenter-main-js"></script>
+<script type="text/javascript" id="gforms_recaptcha_recaptcha-js-extra">
+/* <![CDATA[ */
+var gforms_recaptcha_recaptcha_strings = {"nonce":"735f4de3da","disconnect":"Disconnecting","change_connection_type":"Resetting","spinner":"https:\/\/www.kff.org\/wp-content\/plugins\/gravityforms\/images\/spinner.svg","connection_type":"classic","disable_badge":"","change_connection_type_title":"Change Connection Type","change_connection_type_message":"Changing the connection type will delete your current settings.  Do you want to proceed?","disconnect_title":"Disconnect","disconnect_message":"Disconnecting from reCAPTCHA will delete your current settings.  Do you want to proceed?","site_key":"6LdmpmosAAAAAHnQmQZ-y7isyAWF37t2s5Bou6dj"};
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://www.google.com/recaptcha/api.js?render=6LdmpmosAAAAAHnQmQZ-y7isyAWF37t2s5Bou6dj&amp;ver=2.2.1" id="gforms_recaptcha_recaptcha-js" defer="defer" data-wp-strategy="defer"></script>
+<script type="text/javascript" src="https://www.kff.org/wp-content/plugins/gravityformsrecaptcha/js/frontend.min.js?ver=2.2.1" id="gforms_recaptcha_frontend-js" defer="defer" data-wp-strategy="defer"></script>
+<script type="text/javascript" id="jetpack-stats-js-before">
+/* <![CDATA[ */
+_stq = window._stq || [];
+_stq.push([ "view", {"v":"ext","blog":"243654493","post":"706403","tz":"-4","srv":"www.kff.org","hp":"vip","j":"1:15.7"} ]);
+_stq.push([ "clickTrackerInit", "243654493", "706403" ]);
+/* ]]> */
+</script>
+<script type="text/javascript" src="https://stats.wp.com/e-202620.js" id="jetpack-stats-js" defer="defer" data-wp-strategy="defer"></script>
+					
+<nav class="footer-nav">
+	<div class="footer-nav__container">
+		<a href="/" class="footer-nav__logo">
+			<svg xmlns="http://www.w3.org/2000/svg" width="118" height="48" fill="none"><path fill="#fff" d="M27.56 0 13.175 20.703h-.138V0H.298v48h12.74V27.297h.138L27.559 48h15.343L25.227 24 42.902 0zm20.07 0h31.988v9.077H60.37v10.521h18.425v9.078H60.37V48H47.63zm38.085 0h31.988v9.077H98.455v10.521h18.426v9.078H98.455V48h-12.74z" /></svg>		</a>
+					<div class="footer-nav__column">
+				<ul class="footer-nav__list"><li id="menu-item-682619" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-682619"><a href="https://www.kff.org/policy-research/">Policy Research</a></li>
+<li id="menu-item-682620" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-682620"><a href="https://www.kff.org/topic/public-opinion">Polling</a></li>
+<li id="menu-item-682621" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-682621"><a href="https://www.kffhealthnews.org/">Health News</a></li>
+</ul>			</div>
+							<div class="footer-nav__column">
+				<p class="footer-nav__heading">
+					About Us				</p>
+				<ul class="footer-nav__sub-list"><li id="menu-item-682610" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-682610"><a href="/about-us/conference-centers/">Conference Centers</a></li>
+<li id="menu-item-682612" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-682612"><a href="/about-us/employment-opportunities/">Join Our Team</a></li>
+<li id="menu-item-682614" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-682614"><a href="/about-us/contact-us/">Contact Us</a></li>
+<li id="menu-item-682616" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-682616"><a href="/about-us/follow-us/">Follow Us</a></li>
+</ul>			</div>
+									<div class="footer-nav__cta">
+				<h3 class="footer-nav__cta-heading">Sign up for emails</h3>
+				<p class="footer-nav__cta-excerpt">Join our email list for regular updates based on your personal preferences.</p>
+				<a href="https://www.kff.org/about-us/email/" class="button button--md"><span>Sign up</span></a>
+			</div>
+			</div>
+			<div class="footer-nav__legal">
+			<ul class="footer-nav__legal-list"><li id="menu-item-683457" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-683457"><a href="https://www.kff.org/about-us/privacy-policy/">Privacy Policy</a></li>
+<li id="menu-item-682627" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-682627"><a href="https://www.kff.org/about-us/permissions-citations-reprints/">Citations and Reprints</a></li>
+</ul>		</div>
+	</nav>
+
+<div class="print-container">
+	<div class="print-container__inner print-container__inner--footer">
+		<div class="print__logo">
+			<svg class="print__logo-svg print__logo-svg--footer" xmlns="http://www.w3.org/2000/svg" width="59" height="25" viewBox="0 0 59 25" fill="none">
+				<path d="m13.685.5-7.22 10.351h-.07V.5H0v24h6.396V14.149h.069l7.22 10.351h7.701l-8.872-12 8.872-12h-7.701Zm10.074 0h16.058v4.539h-9.662v5.26h9.25v4.54h-9.25V24.5H23.76V.5Zm19.118 0h16.057v4.539h-9.661v5.26h9.249v4.54h-9.25V24.5h-6.395V.5Z" fill="black"/>
+			</svg>
+		</div>
+		<p class="print__tagline">
+			© 2026 KFF		</p>
+	</div>
+</div>
+			</body>
+</html>

--- a/db/data/kff/marketplace_effectuated_enrollment/manifest.yaml
+++ b/db/data/kff/marketplace_effectuated_enrollment/manifest.yaml
@@ -1,0 +1,18 @@
+source_id: kff
+package_id: kff-marketplace-effectuated-enrollment
+dataset: kff_state_health_facts_marketplace_effectuated_enrollment
+source_page: https://www.kff.org/affordable-care-act/state-indicator/full-year-average-marketplace-effectuated-enrollment/
+table: Full Year Average Marketplace Effectuated Enrollment, 2017-2024
+files:
+  2024:
+    filename: full-year-average-marketplace-effectuated-enrollment.html
+    source_url: https://www.kff.org/affordable-care-act/state-indicator/full-year-average-marketplace-effectuated-enrollment/
+    sha256: 26e35115f59ce4dc105d33272784e4b26ec7bd2e5569ebfcecc70f3af08bc748
+    size_bytes: 120020
+    fetched_at: '2026-05-11T22:17:13+00:00'
+    storage:
+      r2:
+        provider: r2
+        bucket: arch-raw
+        key: raw/kff/kff-marketplace-effectuated-enrollment/2024/26e35115f59ce4dc105d33272784e4b26ec7bd2e5569ebfcecc70f3af08bc748/full-year-average-marketplace-effectuated-enrollment.html
+        uri: r2://arch-raw/raw/kff/kff-marketplace-effectuated-enrollment/2024/26e35115f59ce4dc105d33272784e4b26ec7bd2e5569ebfcecc70f3af08bc748/full-year-average-marketplace-effectuated-enrollment.html

--- a/packages/kff/marketplace_effectuated_enrollment/source_package.yaml
+++ b/packages/kff/marketplace_effectuated_enrollment/source_package.yaml
@@ -1,0 +1,711 @@
+schema_version: arch.source_package.v1
+package_id: kff-marketplace-effectuated-enrollment
+label: KFF State Health Facts full-year average marketplace effectuated enrollment
+artifact:
+  source_name: kff
+  source_table: Full Year Average Marketplace Effectuated Enrollment, 2017-2024
+  resource_package: db
+  resource_directory: data/kff/marketplace_effectuated_enrollment
+  manifest: manifest.yaml
+  vintage: 2026_04_09_state_health_facts
+  extracted_at: '2026-05-11'
+  extraction_method: HTML State Health Facts embedded gdocsObject parse with source-row
+    cells
+  parser: kff_state_indicator_gdocs_html_rows
+  sheet_name: indicator
+  artifact_year: 2024
+  selected_rows:
+  - Year: '2024'
+    Geography: Alabama
+  - Year: '2024'
+    Geography: Alaska
+  - Year: '2024'
+    Geography: Arizona
+  - Year: '2024'
+    Geography: Arkansas
+  - Year: '2024'
+    Geography: California
+  - Year: '2024'
+    Geography: Colorado
+  - Year: '2024'
+    Geography: Connecticut
+  - Year: '2024'
+    Geography: Delaware
+  - Year: '2024'
+    Geography: District of Columbia
+  - Year: '2024'
+    Geography: Florida
+  - Year: '2024'
+    Geography: Georgia
+  - Year: '2024'
+    Geography: Hawaii
+  - Year: '2024'
+    Geography: Idaho
+  - Year: '2024'
+    Geography: Illinois
+  - Year: '2024'
+    Geography: Indiana
+  - Year: '2024'
+    Geography: Iowa
+  - Year: '2024'
+    Geography: Kansas
+  - Year: '2024'
+    Geography: Kentucky
+  - Year: '2024'
+    Geography: Louisiana
+  - Year: '2024'
+    Geography: Maine
+  - Year: '2024'
+    Geography: Maryland
+  - Year: '2024'
+    Geography: Massachusetts
+  - Year: '2024'
+    Geography: Michigan
+  - Year: '2024'
+    Geography: Minnesota
+  - Year: '2024'
+    Geography: Mississippi
+  - Year: '2024'
+    Geography: Missouri
+  - Year: '2024'
+    Geography: Montana
+  - Year: '2024'
+    Geography: Nebraska
+  - Year: '2024'
+    Geography: Nevada
+  - Year: '2024'
+    Geography: New Hampshire
+  - Year: '2024'
+    Geography: New Jersey
+  - Year: '2024'
+    Geography: New Mexico
+  - Year: '2024'
+    Geography: New York
+  - Year: '2024'
+    Geography: North Carolina
+  - Year: '2024'
+    Geography: North Dakota
+  - Year: '2024'
+    Geography: Ohio
+  - Year: '2024'
+    Geography: Oklahoma
+  - Year: '2024'
+    Geography: Oregon
+  - Year: '2024'
+    Geography: Pennsylvania
+  - Year: '2024'
+    Geography: Rhode Island
+  - Year: '2024'
+    Geography: South Carolina
+  - Year: '2024'
+    Geography: South Dakota
+  - Year: '2024'
+    Geography: Tennessee
+  - Year: '2024'
+    Geography: Texas
+  - Year: '2024'
+    Geography: Utah
+  - Year: '2024'
+    Geography: Vermont
+  - Year: '2024'
+    Geography: Virginia
+  - Year: '2024'
+    Geography: Washington
+  - Year: '2024'
+    Geography: West Virginia
+  - Year: '2024'
+    Geography: Wisconsin
+  - Year: '2024'
+    Geography: Wyoming
+record_sets:
+- record_set_id: kff.marketplace_effectuated_enrollment.2024.state
+  record_set_spec_id: kff.marketplace_effectuated_enrollment_state.v1
+  source_record_id_prefix: kff.marketplace_effectuated_enrollment.2024.state
+  sheet_name: indicator
+  period_type: calendar_year
+  period: '2024'
+  geography_id: 0100000US
+  geography_level: country
+  geography_name: United States
+  geography_vintage: current
+  entity: person
+  entity_role: aca_marketplace_effectuated_enrollee
+  domain: aca_marketplace_effectuated_enrollment
+  groupby_dimension: kff.state
+  rows:
+  - value_id: al
+    label: Alabama
+    ordinal: 0
+    row_number: 2
+    geography_id: 0400000US01
+    geography_level: state
+    geography_name: Alabama
+    geography_vintage: current
+    expected_row_header: Alabama
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: ak
+    label: Alaska
+    ordinal: 1
+    row_number: 3
+    geography_id: 0400000US02
+    geography_level: state
+    geography_name: Alaska
+    geography_vintage: current
+    expected_row_header: Alaska
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: az
+    label: Arizona
+    ordinal: 2
+    row_number: 4
+    geography_id: 0400000US04
+    geography_level: state
+    geography_name: Arizona
+    geography_vintage: current
+    expected_row_header: Arizona
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: ar
+    label: Arkansas
+    ordinal: 3
+    row_number: 5
+    geography_id: 0400000US05
+    geography_level: state
+    geography_name: Arkansas
+    geography_vintage: current
+    expected_row_header: Arkansas
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: ca
+    label: California
+    ordinal: 4
+    row_number: 6
+    geography_id: 0400000US06
+    geography_level: state
+    geography_name: California
+    geography_vintage: current
+    expected_row_header: California
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: co
+    label: Colorado
+    ordinal: 5
+    row_number: 7
+    geography_id: 0400000US08
+    geography_level: state
+    geography_name: Colorado
+    geography_vintage: current
+    expected_row_header: Colorado
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: ct
+    label: Connecticut
+    ordinal: 6
+    row_number: 8
+    geography_id: 0400000US09
+    geography_level: state
+    geography_name: Connecticut
+    geography_vintage: current
+    expected_row_header: Connecticut
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: de
+    label: Delaware
+    ordinal: 7
+    row_number: 9
+    geography_id: 0400000US10
+    geography_level: state
+    geography_name: Delaware
+    geography_vintage: current
+    expected_row_header: Delaware
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: dc
+    label: District of Columbia
+    ordinal: 8
+    row_number: 10
+    geography_id: 0400000US11
+    geography_level: state
+    geography_name: District of Columbia
+    geography_vintage: current
+    expected_row_header: District of Columbia
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: fl
+    label: Florida
+    ordinal: 9
+    row_number: 11
+    geography_id: 0400000US12
+    geography_level: state
+    geography_name: Florida
+    geography_vintage: current
+    expected_row_header: Florida
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: ga
+    label: Georgia
+    ordinal: 10
+    row_number: 12
+    geography_id: 0400000US13
+    geography_level: state
+    geography_name: Georgia
+    geography_vintage: current
+    expected_row_header: Georgia
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: hi
+    label: Hawaii
+    ordinal: 11
+    row_number: 13
+    geography_id: 0400000US15
+    geography_level: state
+    geography_name: Hawaii
+    geography_vintage: current
+    expected_row_header: Hawaii
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: id
+    label: Idaho
+    ordinal: 12
+    row_number: 14
+    geography_id: 0400000US16
+    geography_level: state
+    geography_name: Idaho
+    geography_vintage: current
+    expected_row_header: Idaho
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: il
+    label: Illinois
+    ordinal: 13
+    row_number: 15
+    geography_id: 0400000US17
+    geography_level: state
+    geography_name: Illinois
+    geography_vintage: current
+    expected_row_header: Illinois
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: in
+    label: Indiana
+    ordinal: 14
+    row_number: 16
+    geography_id: 0400000US18
+    geography_level: state
+    geography_name: Indiana
+    geography_vintage: current
+    expected_row_header: Indiana
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: ia
+    label: Iowa
+    ordinal: 15
+    row_number: 17
+    geography_id: 0400000US19
+    geography_level: state
+    geography_name: Iowa
+    geography_vintage: current
+    expected_row_header: Iowa
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: ks
+    label: Kansas
+    ordinal: 16
+    row_number: 18
+    geography_id: 0400000US20
+    geography_level: state
+    geography_name: Kansas
+    geography_vintage: current
+    expected_row_header: Kansas
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: ky
+    label: Kentucky
+    ordinal: 17
+    row_number: 19
+    geography_id: 0400000US21
+    geography_level: state
+    geography_name: Kentucky
+    geography_vintage: current
+    expected_row_header: Kentucky
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: la
+    label: Louisiana
+    ordinal: 18
+    row_number: 20
+    geography_id: 0400000US22
+    geography_level: state
+    geography_name: Louisiana
+    geography_vintage: current
+    expected_row_header: Louisiana
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: me
+    label: Maine
+    ordinal: 19
+    row_number: 21
+    geography_id: 0400000US23
+    geography_level: state
+    geography_name: Maine
+    geography_vintage: current
+    expected_row_header: Maine
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: md
+    label: Maryland
+    ordinal: 20
+    row_number: 22
+    geography_id: 0400000US24
+    geography_level: state
+    geography_name: Maryland
+    geography_vintage: current
+    expected_row_header: Maryland
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: ma
+    label: Massachusetts
+    ordinal: 21
+    row_number: 23
+    geography_id: 0400000US25
+    geography_level: state
+    geography_name: Massachusetts
+    geography_vintage: current
+    expected_row_header: Massachusetts
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: mi
+    label: Michigan
+    ordinal: 22
+    row_number: 24
+    geography_id: 0400000US26
+    geography_level: state
+    geography_name: Michigan
+    geography_vintage: current
+    expected_row_header: Michigan
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: mn
+    label: Minnesota
+    ordinal: 23
+    row_number: 25
+    geography_id: 0400000US27
+    geography_level: state
+    geography_name: Minnesota
+    geography_vintage: current
+    expected_row_header: Minnesota
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: ms
+    label: Mississippi
+    ordinal: 24
+    row_number: 26
+    geography_id: 0400000US28
+    geography_level: state
+    geography_name: Mississippi
+    geography_vintage: current
+    expected_row_header: Mississippi
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: mo
+    label: Missouri
+    ordinal: 25
+    row_number: 27
+    geography_id: 0400000US29
+    geography_level: state
+    geography_name: Missouri
+    geography_vintage: current
+    expected_row_header: Missouri
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: mt
+    label: Montana
+    ordinal: 26
+    row_number: 28
+    geography_id: 0400000US30
+    geography_level: state
+    geography_name: Montana
+    geography_vintage: current
+    expected_row_header: Montana
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: ne
+    label: Nebraska
+    ordinal: 27
+    row_number: 29
+    geography_id: 0400000US31
+    geography_level: state
+    geography_name: Nebraska
+    geography_vintage: current
+    expected_row_header: Nebraska
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: nv
+    label: Nevada
+    ordinal: 28
+    row_number: 30
+    geography_id: 0400000US32
+    geography_level: state
+    geography_name: Nevada
+    geography_vintage: current
+    expected_row_header: Nevada
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: nh
+    label: New Hampshire
+    ordinal: 29
+    row_number: 31
+    geography_id: 0400000US33
+    geography_level: state
+    geography_name: New Hampshire
+    geography_vintage: current
+    expected_row_header: New Hampshire
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: nj
+    label: New Jersey
+    ordinal: 30
+    row_number: 32
+    geography_id: 0400000US34
+    geography_level: state
+    geography_name: New Jersey
+    geography_vintage: current
+    expected_row_header: New Jersey
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: nm
+    label: New Mexico
+    ordinal: 31
+    row_number: 33
+    geography_id: 0400000US35
+    geography_level: state
+    geography_name: New Mexico
+    geography_vintage: current
+    expected_row_header: New Mexico
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: ny
+    label: New York
+    ordinal: 32
+    row_number: 34
+    geography_id: 0400000US36
+    geography_level: state
+    geography_name: New York
+    geography_vintage: current
+    expected_row_header: New York
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: nc
+    label: North Carolina
+    ordinal: 33
+    row_number: 35
+    geography_id: 0400000US37
+    geography_level: state
+    geography_name: North Carolina
+    geography_vintage: current
+    expected_row_header: North Carolina
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: nd
+    label: North Dakota
+    ordinal: 34
+    row_number: 36
+    geography_id: 0400000US38
+    geography_level: state
+    geography_name: North Dakota
+    geography_vintage: current
+    expected_row_header: North Dakota
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: oh
+    label: Ohio
+    ordinal: 35
+    row_number: 37
+    geography_id: 0400000US39
+    geography_level: state
+    geography_name: Ohio
+    geography_vintage: current
+    expected_row_header: Ohio
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: ok
+    label: Oklahoma
+    ordinal: 36
+    row_number: 38
+    geography_id: 0400000US40
+    geography_level: state
+    geography_name: Oklahoma
+    geography_vintage: current
+    expected_row_header: Oklahoma
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: or
+    label: Oregon
+    ordinal: 37
+    row_number: 39
+    geography_id: 0400000US41
+    geography_level: state
+    geography_name: Oregon
+    geography_vintage: current
+    expected_row_header: Oregon
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: pa
+    label: Pennsylvania
+    ordinal: 38
+    row_number: 40
+    geography_id: 0400000US42
+    geography_level: state
+    geography_name: Pennsylvania
+    geography_vintage: current
+    expected_row_header: Pennsylvania
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: ri
+    label: Rhode Island
+    ordinal: 39
+    row_number: 41
+    geography_id: 0400000US44
+    geography_level: state
+    geography_name: Rhode Island
+    geography_vintage: current
+    expected_row_header: Rhode Island
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: sc
+    label: South Carolina
+    ordinal: 40
+    row_number: 42
+    geography_id: 0400000US45
+    geography_level: state
+    geography_name: South Carolina
+    geography_vintage: current
+    expected_row_header: South Carolina
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: sd
+    label: South Dakota
+    ordinal: 41
+    row_number: 43
+    geography_id: 0400000US46
+    geography_level: state
+    geography_name: South Dakota
+    geography_vintage: current
+    expected_row_header: South Dakota
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: tn
+    label: Tennessee
+    ordinal: 42
+    row_number: 44
+    geography_id: 0400000US47
+    geography_level: state
+    geography_name: Tennessee
+    geography_vintage: current
+    expected_row_header: Tennessee
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: tx
+    label: Texas
+    ordinal: 43
+    row_number: 45
+    geography_id: 0400000US48
+    geography_level: state
+    geography_name: Texas
+    geography_vintage: current
+    expected_row_header: Texas
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: ut
+    label: Utah
+    ordinal: 44
+    row_number: 46
+    geography_id: 0400000US49
+    geography_level: state
+    geography_name: Utah
+    geography_vintage: current
+    expected_row_header: Utah
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: vt
+    label: Vermont
+    ordinal: 45
+    row_number: 47
+    geography_id: 0400000US50
+    geography_level: state
+    geography_name: Vermont
+    geography_vintage: current
+    expected_row_header: Vermont
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: va
+    label: Virginia
+    ordinal: 46
+    row_number: 48
+    geography_id: 0400000US51
+    geography_level: state
+    geography_name: Virginia
+    geography_vintage: current
+    expected_row_header: Virginia
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: wa
+    label: Washington
+    ordinal: 47
+    row_number: 49
+    geography_id: 0400000US53
+    geography_level: state
+    geography_name: Washington
+    geography_vintage: current
+    expected_row_header: Washington
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: wv
+    label: West Virginia
+    ordinal: 48
+    row_number: 50
+    geography_id: 0400000US54
+    geography_level: state
+    geography_name: West Virginia
+    geography_vintage: current
+    expected_row_header: West Virginia
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: wi
+    label: Wisconsin
+    ordinal: 49
+    row_number: 51
+    geography_id: 0400000US55
+    geography_level: state
+    geography_name: Wisconsin
+    geography_vintage: current
+    expected_row_header: Wisconsin
+    expected_row_header_column: B
+    table_record_kind: total
+  - value_id: wy
+    label: Wyoming
+    ordinal: 50
+    row_number: 52
+    geography_id: 0400000US56
+    geography_level: state
+    geography_name: Wyoming
+    geography_vintage: current
+    expected_row_header: Wyoming
+    expected_row_header_column: B
+    table_record_kind: total
+  measures:
+  - measure_id: total_effectuated_marketplace_enrollment
+    label: Total effectuated marketplace enrollment
+    ordinal: 0
+    column: C
+    source_column_id: Total Effectuated Marketplace Enrollment
+    expected_column_header_row: 1
+    expected_column_header: Total Effectuated Marketplace Enrollment
+    concept: cms_aca.marketplace_effectuated_enrollment
+    source_concept: kff.Total Effectuated Marketplace Enrollment
+    concept_relation: source_label
+    concept_authority: kff
+    unit: count
+    aggregation: mean
+    expected_cell_type: number

--- a/tests/test_arch_bundle.py
+++ b/tests/test_arch_bundle.py
@@ -29,26 +29,27 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "aggregate_duplicate_key_count": 0,
         "entity_count": 5,
         "error_count": 0,
-        "fact_count": 2963,
+        "fact_count": 3014,
         "geography_count": 54,
         "period_count": 4,
         "semantic_duplicate_key_count": 3,
         "skipped_source_count": 0,
-        "source_count": 5,
-        "source_package_count": 18,
+        "source_count": 6,
+        "source_package_count": 19,
         "warning_count": 1,
     }
-    assert len(rows) == 2963
+    assert len(rows) == 3014
     assert rows[0]["aggregate_fact_key"].startswith("arch.aggregate_fact.v2:")
     assert rows[0]["semantic_fact_key"].startswith("arch.semantic_fact.v2:")
-    assert source_packages["source_package_count"] == 18
+    assert source_packages["source_package_count"] == 19
     assert source_packages["skipped_source_count"] == 0
     assert not source_packages["skipped_sources"]
-    assert coverage["fact_count"] == 2963
+    assert coverage["fact_count"] == 3014
     assert coverage["counts"]["by_source"] == {
         "census_pep": 988,
         "hhs_acf_tanf": 110,
         "irs_soi": 1643,
+        "kff": 51,
         "ssa": 6,
         "usda_snap": 216,
     }
@@ -86,23 +87,24 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
             "Arrangement (IRA) Plan Contributions, by Size of Contribution and "
             "Age of Taxpayer"
         ): 2,
+        "kff:Full Year Average Marketplace Effectuated Enrollment, 2017-2024": 51,
         "ssa:SSA Annual Statistical Supplement 2025 extracted OASDI and SSI target rows": 6,
         "usda_snap:SNAP Monthly State Participation and Benefit Summary FY69 to current": 216,
     }
     assert coverage["counts"]["by_period"] == {
-        "calendar_year:2024": 994,
+        "calendar_year:2024": 1045,
         "fiscal_year:2024": 326,
         "tax_year:2022": 1244,
         "tax_year:2023": 399,
     }
     assert coverage["counts"]["by_geography"]["country:0100000US"] == 660
-    assert coverage["counts"]["by_geography"]["state:0400000US06"] == 45
+    assert coverage["counts"]["by_geography"]["state:0400000US06"] == 46
     assert len(coverage["counts"]["by_geography"]) == 54
     assert coverage["counts"]["by_entity"] == {
         "family": 107,
         "government": 54,
         "household": 54,
-        "person": 1105,
+        "person": 1156,
         "tax_unit": 1643,
     }
     assert not coverage["duplicates"]["aggregate_fact_keys"]
@@ -138,6 +140,12 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
     ).exists()
     assert (
         output_dir / "sources" / "hhs-acf-tanf-financial-2024" / "consumer_facts.jsonl"
+    ).exists()
+    assert (
+        output_dir
+        / "sources"
+        / "kff-marketplace-effectuated-enrollment"
+        / "consumer_facts.jsonl"
     ).exists()
 
 

--- a/tests/test_arch_source_package.py
+++ b/tests/test_arch_source_package.py
@@ -23,6 +23,7 @@ from arch.source_package import (
     validate_source_package,
 )
 from arch.sources.cells import build_source_cell_key, validate_source_cells
+from arch.sources.rows import validate_source_rows
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -574,3 +575,61 @@ def test_hhs_acf_tanf_caseload_package_builds_fy24_family_and_recipient_facts():
     assert values_by_record[child_recipients].geography.id == "0100000US"
     assert not values_by_record[child_recipients].filters
     assert not values_by_record[child_recipients].constraints
+
+
+def test_kff_marketplace_effectuated_enrollment_alias_validates_fixture_counts():
+    report = validate_source_package(
+        "kff-marketplace-effectuated-enrollment",
+        year=2023,
+    )
+
+    assert report.valid
+    assert report.counts == {
+        "record_set_count": 1,
+        "row_count": 51,
+        "measure_count": 1,
+        "source_record_count": 51,
+        "source_region_count": 1,
+    }
+
+
+def test_kff_marketplace_effectuated_enrollment_builds_2024_state_facts():
+    package = load_source_package("kff-marketplace-effectuated-enrollment")
+    rows = package.build_source_rows(2023)
+    cells = package.build_source_cells(2023, source_rows=rows)
+    records = package.build_source_records(2023, cells=cells, source_rows=rows)
+    facts = package.build_facts(2023, cells=cells, source_rows=rows)
+    records_by_id = {record.source_record_id: record for record in records}
+    values_by_record = {fact.source_record_id: fact for fact in facts}
+
+    assert package.package_id == "kff-marketplace-effectuated-enrollment"
+    assert len(rows) == 416
+    assert validate_source_rows(rows).valid
+    assert rows[0].values == {
+        "Year": 2024,
+        "Geography": "United States",
+        "Total Effectuated Marketplace Enrollment": 20_968_847,
+        "Unit": "Number",
+        "KFF table row": 3,
+    }
+    assert validate_source_cells(cells).valid
+    assert validate_facts(facts).valid
+    assert len(cells) == 260
+    assert len(facts) == 51
+    assert all(fact.source_row_keys for fact in facts)
+    assert all(fact.source.source_name == "kff" for fact in facts)
+    assert all(fact.source.source_file.endswith(".html") for fact in facts)
+    assert all(fact.source.raw_r2_uri for fact in facts)
+
+    al = (
+        "kff.marketplace_effectuated_enrollment.2024.state.al."
+        "total_effectuated_marketplace_enrollment"
+    )
+    ca = (
+        "kff.marketplace_effectuated_enrollment.2024.state.ca."
+        "total_effectuated_marketplace_enrollment"
+    )
+
+    assert records_by_id[al].source_cell_addresses == ("C2", "C1")
+    assert values_by_record[al].value == 396_750
+    assert values_by_record[ca].value == 1_795_695


### PR DESCRIPTION
## Summary
- add the KFF full-year average marketplace effectuated enrollment source package
- pin the package to 2024 facts so the default Arch bundle produces stable 2024 ACA enrollment targets
- wire the source package alias and bundle/source-package coverage tests

## Microplex impact
- increases PE-native broad target coverage from 47/189 to 49/189 after the TANF package
- covers the state ACA/PTC person-count targets from KFF marketplace effectuated enrollment
- leaves ACA PTC amount and return-count cells uncovered because those need direct total amount/return sources, not enrollment counts

## Validation
- uv run ruff check arch db tests/test_arch_bundle.py tests/test_arch_source_package.py
- uv run pytest tests/test_arch_source_package.py::test_kff_marketplace_effectuated_enrollment_alias_validates_fixture_counts tests/test_arch_source_package.py::test_kff_marketplace_effectuated_enrollment_builds_2024_state_facts tests/test_arch_bundle.py::test_build_bundle_writes_merged_consumer_contract -q
- uv run pytest -q
- Microplex coverage probe: 49/189 covered