### PR TITLE
Add IRS SOI state broad Historic Table 2 package

### DIFF
--- a/arch/source_package.py
+++ b/arch/source_package.py
@@ -84,6 +84,9 @@ SOURCE_PACKAGE_ALIASES = {
     "soi-historic-table-2-state-agi-2022": Path(
         "irs_soi/historic_table_2_state_agi_2022"
     ),
+    "soi-historic-table-2-state-broad-2022": Path(
+        "irs_soi/historic_table_2_state_broad_2022"
+    ),
     "soi-historic-table-2-state-eitc-2022": Path(
         "irs_soi/historic_table_2_state_eitc_2022"
     ),

--- a/packages/irs_soi/historic_table_2_state_broad_2022/source_package.yaml
+++ b/packages/irs_soi/historic_table_2_state_broad_2022/source_package.yaml
@@ -1,0 +1,2331 @@
+schema_version: arch.source_package.v1
+package_id: soi-historic-table-2-state-broad-2022
+label: IRS SOI Historic Table 2 state broad totals for 2022
+artifact:
+  source_name: irs_soi
+  source_table: Historic Table 2 state broad totals
+  resource_package: db
+  resource_directory: data/irs_soi/historic_table_2
+  manifest: manifest.yaml
+  vintage: tax_year_2022
+  extracted_at: '2026-05-28'
+  extraction_method: full CSV row parse with selected state all-return source-record cells
+  parser: delimited_text_full_rows
+  sheet_name: in55cmcsv
+  artifact_year: 2022
+  selected_rows:
+  - STATE: AL
+    AGI_STUB: 0
+  - STATE: AK
+    AGI_STUB: 0
+  - STATE: AZ
+    AGI_STUB: 0
+  - STATE: AR
+    AGI_STUB: 0
+  - STATE: CA
+    AGI_STUB: 0
+  - STATE: CO
+    AGI_STUB: 0
+  - STATE: CT
+    AGI_STUB: 0
+  - STATE: DE
+    AGI_STUB: 0
+  - STATE: DC
+    AGI_STUB: 0
+  - STATE: FL
+    AGI_STUB: 0
+  - STATE: GA
+    AGI_STUB: 0
+  - STATE: HI
+    AGI_STUB: 0
+  - STATE: ID
+    AGI_STUB: 0
+  - STATE: IL
+    AGI_STUB: 0
+  - STATE: IN
+    AGI_STUB: 0
+  - STATE: IA
+    AGI_STUB: 0
+  - STATE: KS
+    AGI_STUB: 0
+  - STATE: KY
+    AGI_STUB: 0
+  - STATE: LA
+    AGI_STUB: 0
+  - STATE: ME
+    AGI_STUB: 0
+  - STATE: MD
+    AGI_STUB: 0
+  - STATE: MA
+    AGI_STUB: 0
+  - STATE: MI
+    AGI_STUB: 0
+  - STATE: MN
+    AGI_STUB: 0
+  - STATE: MS
+    AGI_STUB: 0
+  - STATE: MO
+    AGI_STUB: 0
+  - STATE: MT
+    AGI_STUB: 0
+  - STATE: NE
+    AGI_STUB: 0
+  - STATE: NV
+    AGI_STUB: 0
+  - STATE: NH
+    AGI_STUB: 0
+  - STATE: NJ
+    AGI_STUB: 0
+  - STATE: NM
+    AGI_STUB: 0
+  - STATE: NY
+    AGI_STUB: 0
+  - STATE: NC
+    AGI_STUB: 0
+  - STATE: ND
+    AGI_STUB: 0
+  - STATE: OH
+    AGI_STUB: 0
+  - STATE: OK
+    AGI_STUB: 0
+  - STATE: OR
+    AGI_STUB: 0
+  - STATE: PA
+    AGI_STUB: 0
+  - STATE: RI
+    AGI_STUB: 0
+  - STATE: SC
+    AGI_STUB: 0
+  - STATE: SD
+    AGI_STUB: 0
+  - STATE: TN
+    AGI_STUB: 0
+  - STATE: TX
+    AGI_STUB: 0
+  - STATE: UT
+    AGI_STUB: 0
+  - STATE: VT
+    AGI_STUB: 0
+  - STATE: VA
+    AGI_STUB: 0
+  - STATE: WA
+    AGI_STUB: 0
+  - STATE: WV
+    AGI_STUB: 0
+  - STATE: WI
+    AGI_STUB: 0
+  - STATE: WY
+    AGI_STUB: 0
+record_sets:
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.al
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.al
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US01
+  geography_level: state
+  geography_name: Alabama
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Alabama all returns
+    ordinal: 0
+    row_number: 2
+    expected_row_header_column: A
+    expected_row_header: AL
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: AL
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: &id001
+  - measure_id: return_count
+    label: Number of returns
+    ordinal: 0
+    column: C
+    source_column_id: N1
+    concept: irs_soi.individual_income_tax_returns
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N1
+  - measure_id: tax_filer_individual_count
+    label: Number of individuals
+    ordinal: 1
+    column: L
+    source_column_id: N2
+    concept: irs_soi.tax_filer_individuals
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N2
+  - measure_id: adjusted_gross_income
+    label: Adjusted gross income
+    ordinal: 2
+    column: T
+    source_column_id: A00100
+    concept: us:statutes/26/62#adjusted_gross_income
+    unit: usd
+    aggregation: sum
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A00100
+    value_scale: 1000
+    source_concept: irs_soi.adjusted_gross_income
+    concept_relation: exact
+    concept_authority: arch-us
+    concept_evidence_url: https://uscode.house.gov/view.xhtml?req=(title:26%20section:62%20edition:prelim)
+    concept_evidence_notes: IRS SOI Historic Table 2 reports adjusted gross income for individual income tax returns; IRC section 62 defines adjusted gross income. This Arch assertion treats the SOI AGI column as exactly adopting that legal concept for the tax-year source record.
+    legal_vintage: tax_year_{year}
+  - measure_id: total_income_returns
+    label: Returns with total income
+    ordinal: 3
+    column: U
+    source_column_id: N02650
+    concept: irs_soi.returns_with_total_income
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N02650
+  - measure_id: total_income_amount
+    label: Total income
+    ordinal: 4
+    column: V
+    source_column_id: A02650
+    concept: irs_soi.total_income
+    unit: usd
+    aggregation: sum
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A02650
+    value_scale: 1000
+  - measure_id: wages_salaries_returns
+    label: Returns with salaries and wages
+    ordinal: 5
+    column: W
+    source_column_id: N00200
+    concept: irs_soi.returns_with_total_wages
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N00200
+  - measure_id: wages_salaries_amount
+    label: Salaries and wages
+    ordinal: 6
+    column: X
+    source_column_id: A00200
+    concept: us:statutes/26/62#input.wages
+    unit: usd
+    aggregation: sum
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A00200
+    value_scale: 1000
+    source_concept: irs_soi.total_wages
+    concept_relation: broad_match
+    concept_authority: arch-us
+    concept_evidence_url: https://www.irs.gov/statistics/soi-tax-stats-historic-table-2
+    concept_evidence_notes: IRS SOI Historic Table 2 labels this measure salaries and wages for individual income tax returns. Arch treats the SOI wage measure as a broad match to the wage input of IRC section 62 adjusted gross income.
+    legal_vintage: tax_year_{year}
+  - measure_id: taxable_interest_returns
+    label: Returns with taxable interest
+    ordinal: 7
+    column: Y
+    source_column_id: N00300
+    concept: irs_soi.returns_with_taxable_interest
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N00300
+  - measure_id: taxable_interest_amount
+    label: Taxable interest
+    ordinal: 8
+    column: Z
+    source_column_id: A00300
+    concept: irs_soi.taxable_interest
+    unit: usd
+    aggregation: sum
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A00300
+    value_scale: 1000
+  - measure_id: tax_exempt_interest_returns
+    label: Returns with tax-exempt interest
+    ordinal: 9
+    column: AA
+    source_column_id: N00400
+    concept: irs_soi.returns_with_tax_exempt_interest
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N00400
+  - measure_id: tax_exempt_interest_amount
+    label: Tax-exempt interest
+    ordinal: 10
+    column: AB
+    source_column_id: A00400
+    concept: irs_soi.tax_exempt_interest
+    unit: usd
+    aggregation: sum
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A00400
+    value_scale: 1000
+  - measure_id: ordinary_dividends_returns
+    label: Returns with ordinary dividends
+    ordinal: 11
+    column: AC
+    source_column_id: N00600
+    concept: irs_soi.returns_with_ordinary_dividends
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N00600
+  - measure_id: ordinary_dividends_amount
+    label: Ordinary dividends
+    ordinal: 12
+    column: AD
+    source_column_id: A00600
+    concept: irs_soi.ordinary_dividends
+    unit: usd
+    aggregation: sum
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A00600
+    value_scale: 1000
+  - measure_id: qualified_dividends_returns
+    label: Returns with qualified dividends
+    ordinal: 13
+    column: AE
+    source_column_id: N00650
+    concept: irs_soi.returns_with_qualified_dividends
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N00650
+  - measure_id: qualified_dividends_amount
+    label: Qualified dividends
+    ordinal: 14
+    column: AF
+    source_column_id: A00650
+    concept: irs_soi.qualified_dividends
+    unit: usd
+    aggregation: sum
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A00650
+    value_scale: 1000
+  - measure_id: schedule_c_income_returns
+    label: Returns with business or profession net income less loss
+    ordinal: 15
+    column: AI
+    source_column_id: N00900
+    concept: irs_soi.returns_with_schedule_c_income
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N00900
+  - measure_id: schedule_c_income_amount
+    label: Business or profession net income less loss
+    ordinal: 16
+    column: AJ
+    source_column_id: A00900
+    concept: irs_soi.schedule_c_income
+    unit: usd
+    aggregation: sum
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A00900
+    value_scale: 1000
+  - measure_id: net_capital_gains_returns
+    label: Returns with taxable net capital gains
+    ordinal: 17
+    column: AK
+    source_column_id: N01000
+    concept: irs_soi.returns_with_taxable_net_capital_gains
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N01000
+  - measure_id: net_capital_gains_amount
+    label: Taxable net capital gains
+    ordinal: 18
+    column: AL
+    source_column_id: A01000
+    concept: irs_soi.taxable_net_capital_gains
+    unit: usd
+    aggregation: sum
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A01000
+    value_scale: 1000
+  - measure_id: taxable_ira_distributions_returns
+    label: Returns with taxable IRA distributions
+    ordinal: 19
+    column: AM
+    source_column_id: N01400
+    concept: irs_soi.returns_with_taxable_ira_distributions
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N01400
+  - measure_id: taxable_ira_distributions_amount
+    label: Taxable IRA distributions
+    ordinal: 20
+    column: AN
+    source_column_id: A01400
+    concept: irs_soi.taxable_ira_distributions
+    unit: usd
+    aggregation: sum
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A01400
+    value_scale: 1000
+  - measure_id: taxable_pension_income_returns
+    label: Returns with taxable pension income
+    ordinal: 21
+    column: AO
+    source_column_id: N01700
+    concept: irs_soi.returns_with_taxable_pension_income
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N01700
+  - measure_id: taxable_pension_income_amount
+    label: Taxable pension income
+    ordinal: 22
+    column: AP
+    source_column_id: A01700
+    concept: irs_soi.taxable_pension_income
+    unit: usd
+    aggregation: sum
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A01700
+    value_scale: 1000
+  - measure_id: unemployment_compensation_returns
+    label: Returns with unemployment compensation
+    ordinal: 23
+    column: AR
+    source_column_id: N02300
+    concept: irs_soi.returns_with_unemployment_compensation
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N02300
+  - measure_id: unemployment_compensation_amount
+    label: Unemployment compensation
+    ordinal: 24
+    column: AS
+    source_column_id: A02300
+    concept: irs_soi.unemployment_compensation
+    unit: usd
+    aggregation: sum
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A02300
+    value_scale: 1000
+  - measure_id: taxable_social_security_returns
+    label: Returns with taxable Social Security benefits
+    ordinal: 25
+    column: AT
+    source_column_id: N02500
+    concept: irs_soi.returns_with_taxable_social_security_benefits
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N02500
+  - measure_id: taxable_social_security_amount
+    label: Taxable Social Security benefits
+    ordinal: 26
+    column: AU
+    source_column_id: A02500
+    concept: irs_soi.taxable_social_security_benefits
+    unit: usd
+    aggregation: sum
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A02500
+    value_scale: 1000
+  - measure_id: partnership_scorp_income_returns
+    label: Returns with partnership and S corporation net income less loss
+    ordinal: 27
+    column: AV
+    source_column_id: N26270
+    concept: irs_soi.returns_with_partnership_scorp_income
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N26270
+  - measure_id: partnership_scorp_income_amount
+    label: Partnership and S corporation net income less loss
+    ordinal: 28
+    column: AW
+    source_column_id: A26270
+    concept: irs_soi.partnership_scorp_income
+    unit: usd
+    aggregation: sum
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A26270
+    value_scale: 1000
+  - measure_id: itemized_deductions_returns
+    label: Returns with total itemized deductions
+    ordinal: 29
+    column: BR
+    source_column_id: N04470
+    concept: irs_soi.returns_with_itemized_deductions
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N04470
+  - measure_id: itemized_deductions_amount
+    label: Total itemized deductions
+    ordinal: 30
+    column: BS
+    source_column_id: A04470
+    concept: irs_soi.total_itemized_deductions
+    unit: usd
+    aggregation: sum
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A04470
+    value_scale: 1000
+  - measure_id: medical_dental_expense_returns
+    label: Returns with medical and dental expense deductions
+    ordinal: 31
+    column: BT
+    source_column_id: N17000
+    concept: irs_soi.returns_with_medical_dental_expense_deduction
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N17000
+  - measure_id: medical_dental_expense_amount
+    label: Medical and dental expense deductions
+    ordinal: 32
+    column: BU
+    source_column_id: A17000
+    concept: irs_soi.medical_dental_expense_deduction
+    unit: usd
+    aggregation: sum
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A17000
+    value_scale: 1000
+  - measure_id: real_estate_taxes_claims
+    label: Returns with real estate taxes
+    ordinal: 33
+    column: BZ
+    source_column_id: N18500
+    concept: irs_soi.returns_with_real_estate_taxes
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N18500
+  - measure_id: real_estate_taxes_amount
+    label: Real estate taxes
+    ordinal: 34
+    column: CA
+    source_column_id: A18500
+    concept: irs_soi.real_estate_taxes
+    unit: usd
+    aggregation: sum
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A18500
+    value_scale: 1000
+  - measure_id: limited_state_local_taxes_returns
+    label: Returns with limited state and local taxes
+    ordinal: 35
+    column: CB
+    source_column_id: N18460
+    concept: irs_soi.returns_with_limited_state_local_taxes
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N18460
+  - measure_id: limited_state_local_taxes_amount
+    label: Limited state and local taxes
+    ordinal: 36
+    column: CC
+    source_column_id: A18460
+    concept: irs_soi.limited_state_local_taxes
+    unit: usd
+    aggregation: sum
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A18460
+    value_scale: 1000
+  - measure_id: taxable_income_returns
+    label: Returns with taxable income
+    ordinal: 37
+    column: CV
+    source_column_id: N04800
+    concept: irs_soi.returns_with_taxable_income
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N04800
+  - measure_id: taxable_income_amount
+    label: Taxable income
+    ordinal: 38
+    column: CW
+    source_column_id: A04800
+    concept: irs_soi.taxable_income
+    unit: usd
+    aggregation: sum
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A04800
+    value_scale: 1000
+  - measure_id: income_tax_before_credits_returns
+    label: Returns with income tax before credits
+    ordinal: 39
+    column: CX
+    source_column_id: N05800
+    concept: irs_soi.returns_with_income_tax_before_credits
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N05800
+  - measure_id: income_tax_before_credits_amount
+    label: Income tax before credits
+    ordinal: 40
+    column: CY
+    source_column_id: A05800
+    concept: irs_soi.income_tax_before_credits
+    unit: usd
+    aggregation: sum
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A05800
+    value_scale: 1000
+  - measure_id: income_tax_liability_returns
+    label: Returns with total income tax
+    ordinal: 41
+    column: ER
+    source_column_id: N06500
+    concept: irs_soi.returns_with_total_income_tax
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N06500
+  - measure_id: income_tax_liability_amount
+    label: Total income tax
+    ordinal: 42
+    column: ES
+    source_column_id: A06500
+    concept: irs_soi.total_income_tax
+    unit: usd
+    aggregation: sum
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A06500
+    value_scale: 1000
+  - measure_id: premium_tax_credit_returns
+    label: Returns with premium tax credit
+    ordinal: 43
+    column: DT
+    source_column_id: N85770
+    concept: irs_soi.returns_with_premium_tax_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N85770
+  - measure_id: premium_tax_credit_amount
+    label: Premium tax credit
+    ordinal: 44
+    column: DU
+    source_column_id: A85770
+    concept: irs_soi.premium_tax_credit
+    unit: usd
+    aggregation: sum
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A85770
+    value_scale: 1000
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.ak
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.ak
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US02
+  geography_level: state
+  geography_name: Alaska
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Alaska all returns
+    ordinal: 0
+    row_number: 3
+    expected_row_header_column: A
+    expected_row_header: AK
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: AK
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.az
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.az
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US04
+  geography_level: state
+  geography_name: Arizona
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Arizona all returns
+    ordinal: 0
+    row_number: 4
+    expected_row_header_column: A
+    expected_row_header: AZ
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: AZ
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.ar
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.ar
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US05
+  geography_level: state
+  geography_name: Arkansas
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Arkansas all returns
+    ordinal: 0
+    row_number: 5
+    expected_row_header_column: A
+    expected_row_header: AR
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: AR
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.ca
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.ca
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US06
+  geography_level: state
+  geography_name: California
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: California all returns
+    ordinal: 0
+    row_number: 6
+    expected_row_header_column: A
+    expected_row_header: CA
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: CA
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.co
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.co
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US08
+  geography_level: state
+  geography_name: Colorado
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Colorado all returns
+    ordinal: 0
+    row_number: 7
+    expected_row_header_column: A
+    expected_row_header: CO
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: CO
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.ct
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.ct
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US09
+  geography_level: state
+  geography_name: Connecticut
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Connecticut all returns
+    ordinal: 0
+    row_number: 8
+    expected_row_header_column: A
+    expected_row_header: CT
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: CT
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.de
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.de
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US10
+  geography_level: state
+  geography_name: Delaware
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Delaware all returns
+    ordinal: 0
+    row_number: 9
+    expected_row_header_column: A
+    expected_row_header: DE
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: DE
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.dc
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.dc
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US11
+  geography_level: state
+  geography_name: District of Columbia
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: District of Columbia all returns
+    ordinal: 0
+    row_number: 10
+    expected_row_header_column: A
+    expected_row_header: DC
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: DC
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.fl
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.fl
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US12
+  geography_level: state
+  geography_name: Florida
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Florida all returns
+    ordinal: 0
+    row_number: 11
+    expected_row_header_column: A
+    expected_row_header: FL
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: FL
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.ga
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.ga
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US13
+  geography_level: state
+  geography_name: Georgia
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Georgia all returns
+    ordinal: 0
+    row_number: 12
+    expected_row_header_column: A
+    expected_row_header: GA
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: GA
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.hi
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.hi
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US15
+  geography_level: state
+  geography_name: Hawaii
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Hawaii all returns
+    ordinal: 0
+    row_number: 13
+    expected_row_header_column: A
+    expected_row_header: HI
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: HI
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.id
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.id
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US16
+  geography_level: state
+  geography_name: Idaho
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Idaho all returns
+    ordinal: 0
+    row_number: 14
+    expected_row_header_column: A
+    expected_row_header: ID
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: ID
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.il
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.il
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US17
+  geography_level: state
+  geography_name: Illinois
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Illinois all returns
+    ordinal: 0
+    row_number: 15
+    expected_row_header_column: A
+    expected_row_header: IL
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: IL
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.in
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.in
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US18
+  geography_level: state
+  geography_name: Indiana
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Indiana all returns
+    ordinal: 0
+    row_number: 16
+    expected_row_header_column: A
+    expected_row_header: IN
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: IN
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.ia
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.ia
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US19
+  geography_level: state
+  geography_name: Iowa
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Iowa all returns
+    ordinal: 0
+    row_number: 17
+    expected_row_header_column: A
+    expected_row_header: IA
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: IA
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.ks
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.ks
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US20
+  geography_level: state
+  geography_name: Kansas
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Kansas all returns
+    ordinal: 0
+    row_number: 18
+    expected_row_header_column: A
+    expected_row_header: KS
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: KS
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.ky
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.ky
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US21
+  geography_level: state
+  geography_name: Kentucky
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Kentucky all returns
+    ordinal: 0
+    row_number: 19
+    expected_row_header_column: A
+    expected_row_header: KY
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: KY
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.la
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.la
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US22
+  geography_level: state
+  geography_name: Louisiana
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Louisiana all returns
+    ordinal: 0
+    row_number: 20
+    expected_row_header_column: A
+    expected_row_header: LA
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: LA
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.me
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.me
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US23
+  geography_level: state
+  geography_name: Maine
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Maine all returns
+    ordinal: 0
+    row_number: 21
+    expected_row_header_column: A
+    expected_row_header: ME
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: ME
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.md
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.md
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US24
+  geography_level: state
+  geography_name: Maryland
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Maryland all returns
+    ordinal: 0
+    row_number: 22
+    expected_row_header_column: A
+    expected_row_header: MD
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: MD
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.ma
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.ma
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US25
+  geography_level: state
+  geography_name: Massachusetts
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Massachusetts all returns
+    ordinal: 0
+    row_number: 23
+    expected_row_header_column: A
+    expected_row_header: MA
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: MA
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.mi
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.mi
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US26
+  geography_level: state
+  geography_name: Michigan
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Michigan all returns
+    ordinal: 0
+    row_number: 24
+    expected_row_header_column: A
+    expected_row_header: MI
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: MI
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.mn
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.mn
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US27
+  geography_level: state
+  geography_name: Minnesota
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Minnesota all returns
+    ordinal: 0
+    row_number: 25
+    expected_row_header_column: A
+    expected_row_header: MN
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: MN
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.ms
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.ms
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US28
+  geography_level: state
+  geography_name: Mississippi
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Mississippi all returns
+    ordinal: 0
+    row_number: 26
+    expected_row_header_column: A
+    expected_row_header: MS
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: MS
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.mo
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.mo
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US29
+  geography_level: state
+  geography_name: Missouri
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Missouri all returns
+    ordinal: 0
+    row_number: 27
+    expected_row_header_column: A
+    expected_row_header: MO
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: MO
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.mt
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.mt
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US30
+  geography_level: state
+  geography_name: Montana
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Montana all returns
+    ordinal: 0
+    row_number: 28
+    expected_row_header_column: A
+    expected_row_header: MT
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: MT
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.ne
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.ne
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US31
+  geography_level: state
+  geography_name: Nebraska
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Nebraska all returns
+    ordinal: 0
+    row_number: 29
+    expected_row_header_column: A
+    expected_row_header: NE
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: NE
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.nv
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.nv
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US32
+  geography_level: state
+  geography_name: Nevada
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Nevada all returns
+    ordinal: 0
+    row_number: 30
+    expected_row_header_column: A
+    expected_row_header: NV
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: NV
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.nh
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.nh
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US33
+  geography_level: state
+  geography_name: New Hampshire
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: New Hampshire all returns
+    ordinal: 0
+    row_number: 31
+    expected_row_header_column: A
+    expected_row_header: NH
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: NH
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.nj
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.nj
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US34
+  geography_level: state
+  geography_name: New Jersey
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: New Jersey all returns
+    ordinal: 0
+    row_number: 32
+    expected_row_header_column: A
+    expected_row_header: NJ
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: NJ
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.nm
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.nm
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US35
+  geography_level: state
+  geography_name: New Mexico
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: New Mexico all returns
+    ordinal: 0
+    row_number: 33
+    expected_row_header_column: A
+    expected_row_header: NM
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: NM
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.ny
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.ny
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US36
+  geography_level: state
+  geography_name: New York
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: New York all returns
+    ordinal: 0
+    row_number: 34
+    expected_row_header_column: A
+    expected_row_header: NY
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: NY
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.nc
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.nc
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US37
+  geography_level: state
+  geography_name: North Carolina
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: North Carolina all returns
+    ordinal: 0
+    row_number: 35
+    expected_row_header_column: A
+    expected_row_header: NC
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: NC
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.nd
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.nd
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US38
+  geography_level: state
+  geography_name: North Dakota
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: North Dakota all returns
+    ordinal: 0
+    row_number: 36
+    expected_row_header_column: A
+    expected_row_header: ND
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: ND
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.oh
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.oh
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US39
+  geography_level: state
+  geography_name: Ohio
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Ohio all returns
+    ordinal: 0
+    row_number: 37
+    expected_row_header_column: A
+    expected_row_header: OH
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: OH
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.ok
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.ok
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US40
+  geography_level: state
+  geography_name: Oklahoma
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Oklahoma all returns
+    ordinal: 0
+    row_number: 38
+    expected_row_header_column: A
+    expected_row_header: OK
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: OK
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.or
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.or
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US41
+  geography_level: state
+  geography_name: Oregon
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Oregon all returns
+    ordinal: 0
+    row_number: 39
+    expected_row_header_column: A
+    expected_row_header: OR
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: OR
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.pa
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.pa
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US42
+  geography_level: state
+  geography_name: Pennsylvania
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Pennsylvania all returns
+    ordinal: 0
+    row_number: 40
+    expected_row_header_column: A
+    expected_row_header: PA
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: PA
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.ri
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.ri
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US44
+  geography_level: state
+  geography_name: Rhode Island
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Rhode Island all returns
+    ordinal: 0
+    row_number: 41
+    expected_row_header_column: A
+    expected_row_header: RI
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: RI
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.sc
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.sc
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US45
+  geography_level: state
+  geography_name: South Carolina
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: South Carolina all returns
+    ordinal: 0
+    row_number: 42
+    expected_row_header_column: A
+    expected_row_header: SC
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: SC
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.sd
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.sd
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US46
+  geography_level: state
+  geography_name: South Dakota
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: South Dakota all returns
+    ordinal: 0
+    row_number: 43
+    expected_row_header_column: A
+    expected_row_header: SD
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: SD
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.tn
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.tn
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US47
+  geography_level: state
+  geography_name: Tennessee
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Tennessee all returns
+    ordinal: 0
+    row_number: 44
+    expected_row_header_column: A
+    expected_row_header: TN
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: TN
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.tx
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.tx
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US48
+  geography_level: state
+  geography_name: Texas
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Texas all returns
+    ordinal: 0
+    row_number: 45
+    expected_row_header_column: A
+    expected_row_header: TX
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: TX
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.ut
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.ut
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US49
+  geography_level: state
+  geography_name: Utah
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Utah all returns
+    ordinal: 0
+    row_number: 46
+    expected_row_header_column: A
+    expected_row_header: UT
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: UT
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.vt
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.vt
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US50
+  geography_level: state
+  geography_name: Vermont
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Vermont all returns
+    ordinal: 0
+    row_number: 47
+    expected_row_header_column: A
+    expected_row_header: VT
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: VT
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.va
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.va
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US51
+  geography_level: state
+  geography_name: Virginia
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Virginia all returns
+    ordinal: 0
+    row_number: 48
+    expected_row_header_column: A
+    expected_row_header: VA
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: VA
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.wa
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.wa
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US53
+  geography_level: state
+  geography_name: Washington
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Washington all returns
+    ordinal: 0
+    row_number: 49
+    expected_row_header_column: A
+    expected_row_header: WA
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: WA
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.wv
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.wv
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US54
+  geography_level: state
+  geography_name: West Virginia
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: West Virginia all returns
+    ordinal: 0
+    row_number: 50
+    expected_row_header_column: A
+    expected_row_header: WV
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: WV
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.wi
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.wi
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US55
+  geography_level: state
+  geography_name: Wisconsin
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Wisconsin all returns
+    ordinal: 0
+    row_number: 51
+    expected_row_header_column: A
+    expected_row_header: WI
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: WI
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001
+- record_set_id: irs_soi.ty2022.historic_table_2.state_broad.wy
+  record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
+  source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.wy
+  sheet_name: in55cmcsv
+  period_type: tax_year
+  period: 2022
+  geography_id: 0400000US56
+  geography_level: state
+  geography_name: Wyoming
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: state
+  rows:
+  - value_id: all
+    label: Wyoming all returns
+    ordinal: 0
+    row_number: 52
+    expected_row_header_column: A
+    expected_row_header: WY
+    filters:
+      filing_status: all
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: WY
+      label: State abbreviation
+    - column: B
+      expected_value: 0
+      label: all AGI stub
+    table_record_kind: total
+  measures: *id001

--- a/tests/test_arch_bundle.py
+++ b/tests/test_arch_bundle.py
@@ -29,27 +29,27 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "aggregate_duplicate_key_count": 0,
         "entity_count": 5,
         "error_count": 0,
-        "fact_count": 3412,
+        "fact_count": 5707,
         "geography_count": 54,
         "period_count": 5,
         "semantic_duplicate_key_count": 3,
         "skipped_source_count": 0,
         "source_count": 7,
-        "source_package_count": 21,
+        "source_package_count": 22,
         "warning_count": 1,
     }
-    assert len(rows) == 3412
+    assert len(rows) == 5707
     assert rows[0]["aggregate_fact_key"].startswith("arch.aggregate_fact.v2:")
     assert rows[0]["semantic_fact_key"].startswith("arch.semantic_fact.v2:")
-    assert source_packages["source_package_count"] == 21
+    assert source_packages["source_package_count"] == 22
     assert source_packages["skipped_source_count"] == 0
     assert not source_packages["skipped_sources"]
-    assert coverage["fact_count"] == 3412
+    assert coverage["fact_count"] == 5707
     assert coverage["counts"]["by_source"] == {
         "census_pep": 988,
         "cms_medicaid": 255,
         "hhs_acf_tanf": 110,
-        "irs_soi": 1786,
+        "irs_soi": 4081,
         "kff": 51,
         "ssa": 6,
         "usda_snap": 216,
@@ -71,6 +71,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "hhs_acf_tanf:TANF Caseload Data 2024": 58,
         "irs_soi:Historic Table 2": 143,
         "irs_soi:Historic Table 2 state AGI facts": 918,
+        "irs_soi:Historic Table 2 state broad totals": 2295,
         "irs_soi:Historic Table 2 state EITC totals": 102,
         "irs_soi:Publication 1304 Table 1.1": 80,
         "irs_soi:Publication 1304 Table 1.2": 7,
@@ -101,18 +102,18 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "calendar_year:2024": 1045,
         "fiscal_year:2024": 326,
         "month:2024-12": 255,
-        "tax_year:2022": 1387,
+        "tax_year:2022": 3682,
         "tax_year:2023": 399,
     }
     assert coverage["counts"]["by_geography"]["country:0100000US"] == 803
-    assert coverage["counts"]["by_geography"]["state:0400000US06"] == 51
+    assert coverage["counts"]["by_geography"]["state:0400000US06"] == 96
     assert len(coverage["counts"]["by_geography"]) == 54
     assert coverage["counts"]["by_entity"] == {
         "family": 107,
         "government": 54,
         "household": 54,
         "person": 1411,
-        "tax_unit": 1786,
+        "tax_unit": 4081,
     }
     assert not coverage["duplicates"]["aggregate_fact_keys"]
     assert len(coverage["duplicates"]["semantic_fact_keys"]) == 3
@@ -155,6 +156,12 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         output_dir
         / "sources"
         / "cms-medicaid-chip-monthly-enrollment-december-2024"
+        / "consumer_facts.jsonl"
+    ).exists()
+    assert (
+        output_dir
+        / "sources"
+        / "soi-historic-table-2-state-broad-2022"
         / "consumer_facts.jsonl"
     ).exists()
     assert (

--- a/tests/test_arch_source_package.py
+++ b/tests/test_arch_source_package.py
@@ -306,6 +306,13 @@ def test_national_soi_source_package_aliases_validate_fixture_counts():
             "source_record_count": 918,
             "source_region_count": 51,
         },
+        "soi-historic-table-2-state-broad-2022": {
+            "record_set_count": 51,
+            "row_count": 51,
+            "measure_count": 2295,
+            "source_record_count": 2295,
+            "source_region_count": 51,
+        },
         "soi-historic-table-2-state-eitc-2022": {
             "record_set_count": 51,
             "row_count": 51,
@@ -531,6 +538,46 @@ def test_soi_historic_table_2_package_builds_2022_national_facts():
         "<",
         ">=",
     }
+
+
+def test_soi_historic_table_2_state_broad_package_builds_2022_state_facts():
+    package = load_source_package("soi-historic-table-2-state-broad-2022")
+    rows = package.build_source_rows(2023)
+    cells = package.build_source_cells(2023, source_rows=rows)
+    facts = package.build_facts(2023, cells=cells, source_rows=rows)
+    values_by_record = {fact.source_record_id: fact for fact in facts}
+
+    assert package.package_id == "soi-historic-table-2-state-broad-2022"
+    assert len(rows) == 594
+    assert validate_source_rows(rows).valid
+    assert validate_source_cells(cells).valid
+    assert validate_facts(facts).valid
+    assert len(cells) == 8_476
+    assert len(facts) == 2_295
+
+    ca_returns = values_by_record[
+        "irs_soi.ty2022.historic_table_2.state_broad.ca.all.return_count"
+    ]
+    ca_agi = values_by_record[
+        "irs_soi.ty2022.historic_table_2.state_broad.ca.all.adjusted_gross_income"
+    ]
+    ca_ptc = values_by_record[
+        "irs_soi.ty2022.historic_table_2.state_broad.ca.all.premium_tax_credit_amount"
+    ]
+    ca_partnership = values_by_record[
+        "irs_soi.ty2022.historic_table_2.state_broad.ca.all.partnership_scorp_income_amount"
+    ]
+    ca_medical = values_by_record[
+        "irs_soi.ty2022.historic_table_2.state_broad.ca.all.medical_dental_expense_amount"
+    ]
+
+    assert ca_returns.value == 18_487_690
+    assert ca_agi.value == 1_987_000_701_000
+    assert ca_ptc.value == 6_379_623_000
+    assert ca_partnership.value == 125_930_370_000
+    assert ca_medical.value == 11_456_144_000
+    assert ca_returns.geography.id == "0400000US06"
+    assert ca_partnership.layout.source_column_id == "A26270"
 
 
 def test_usda_snap_source_package_builds_fy24_national_and_state_facts():


### PR DESCRIPTION
## Summary
- add a fast IRS SOI Historic Table 2 state broad source package from the 2022 CSV fixture
- expose all-return state totals for 45 SOI measures across 50 states plus DC
- update full bundle and source package tests for the new 2,295 state facts

## Validation
- uv run ruff check arch/source_package.py tests/test_arch_source_package.py tests/test_arch_bundle.py
- uv run pytest tests/test_arch_source_package.py::test_soi_historic_table_2_state_broad_package_builds_2022_state_facts tests/test_arch_source_package.py::test_national_soi_source_package_aliases_validate_fixture_counts tests/test_arch_bundle.py::test_build_bundle_writes_merged_consumer_contract -q

## Microplex impact
- With the corresponding Microplex Arch concept mappings, PE-native broad target coverage increases from 61/189 to 106/189 cells.