### PR TITLE
Expand national SOI Historic Table 2 measures

### DIFF
--- a/packages/irs_soi/historic_table_2/source_package.yaml
+++ b/packages/irs_soi/historic_table_2/source_package.yaml
@@ -356,3 +356,434 @@ record_sets:
         unit: usd
         aggregation: sum
         value_scale: 1000
+
+      - measure_id: total_income_returns
+        label: Returns with total income
+        ordinal: 13
+        column: U
+        source_column_id: N02650
+        concept: irs_soi.returns_with_total_income
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: N02650
+
+      - measure_id: total_income_amount
+        label: Total income
+        ordinal: 14
+        column: V
+        source_column_id: A02650
+        concept: irs_soi.total_income
+        unit: usd
+        aggregation: sum
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: A02650
+        value_scale: 1000
+
+      - measure_id: wages_salaries_returns
+        label: Returns with salaries and wages
+        ordinal: 15
+        column: W
+        source_column_id: N00200
+        concept: irs_soi.returns_with_total_wages
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: N00200
+
+      - measure_id: wages_salaries_amount
+        label: Salaries and wages
+        ordinal: 16
+        column: X
+        source_column_id: A00200
+        concept: us:statutes/26/62#input.wages
+        unit: usd
+        aggregation: sum
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: A00200
+        value_scale: 1000
+        source_concept: irs_soi.total_wages
+        concept_relation: broad_match
+        concept_authority: arch-us
+        concept_evidence_url: https://www.irs.gov/statistics/soi-tax-stats-historic-table-2
+        concept_evidence_notes: IRS SOI Historic Table 2 labels this measure salaries and wages for individual income tax returns. Arch treats the SOI wage measure as a broad match to the wage input of IRC section 62 adjusted gross income.
+        legal_vintage: tax_year_{year}
+
+      - measure_id: taxable_interest_returns
+        label: Returns with taxable interest
+        ordinal: 17
+        column: Y
+        source_column_id: N00300
+        concept: irs_soi.returns_with_taxable_interest
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: N00300
+
+      - measure_id: taxable_interest_amount
+        label: Taxable interest
+        ordinal: 18
+        column: Z
+        source_column_id: A00300
+        concept: irs_soi.taxable_interest
+        unit: usd
+        aggregation: sum
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: A00300
+        value_scale: 1000
+
+      - measure_id: tax_exempt_interest_returns
+        label: Returns with tax-exempt interest
+        ordinal: 19
+        column: AA
+        source_column_id: N00400
+        concept: irs_soi.returns_with_tax_exempt_interest
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: N00400
+
+      - measure_id: tax_exempt_interest_amount
+        label: Tax-exempt interest
+        ordinal: 20
+        column: AB
+        source_column_id: A00400
+        concept: irs_soi.tax_exempt_interest
+        unit: usd
+        aggregation: sum
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: A00400
+        value_scale: 1000
+
+      - measure_id: ordinary_dividends_returns
+        label: Returns with ordinary dividends
+        ordinal: 21
+        column: AC
+        source_column_id: N00600
+        concept: irs_soi.returns_with_ordinary_dividends
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: N00600
+
+      - measure_id: ordinary_dividends_amount
+        label: Ordinary dividends
+        ordinal: 22
+        column: AD
+        source_column_id: A00600
+        concept: irs_soi.ordinary_dividends
+        unit: usd
+        aggregation: sum
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: A00600
+        value_scale: 1000
+
+      - measure_id: qualified_dividends_returns
+        label: Returns with qualified dividends
+        ordinal: 23
+        column: AE
+        source_column_id: N00650
+        concept: irs_soi.returns_with_qualified_dividends
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: N00650
+
+      - measure_id: qualified_dividends_amount
+        label: Qualified dividends
+        ordinal: 24
+        column: AF
+        source_column_id: A00650
+        concept: irs_soi.qualified_dividends
+        unit: usd
+        aggregation: sum
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: A00650
+        value_scale: 1000
+
+      - measure_id: schedule_c_income_returns
+        label: Returns with business or profession net income less loss
+        ordinal: 25
+        column: AI
+        source_column_id: N00900
+        concept: irs_soi.returns_with_schedule_c_income
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: N00900
+
+      - measure_id: schedule_c_income_amount
+        label: Business or profession net income less loss
+        ordinal: 26
+        column: AJ
+        source_column_id: A00900
+        concept: irs_soi.schedule_c_income
+        unit: usd
+        aggregation: sum
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: A00900
+        value_scale: 1000
+
+      - measure_id: net_capital_gains_returns
+        label: Returns with taxable net capital gains
+        ordinal: 27
+        column: AK
+        source_column_id: N01000
+        concept: irs_soi.returns_with_taxable_net_capital_gains
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: N01000
+
+      - measure_id: net_capital_gains_amount
+        label: Taxable net capital gains
+        ordinal: 28
+        column: AL
+        source_column_id: A01000
+        concept: irs_soi.taxable_net_capital_gains
+        unit: usd
+        aggregation: sum
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: A01000
+        value_scale: 1000
+
+      - measure_id: taxable_ira_distributions_returns
+        label: Returns with taxable IRA distributions
+        ordinal: 29
+        column: AM
+        source_column_id: N01400
+        concept: irs_soi.returns_with_taxable_ira_distributions
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: N01400
+
+      - measure_id: taxable_ira_distributions_amount
+        label: Taxable IRA distributions
+        ordinal: 30
+        column: AN
+        source_column_id: A01400
+        concept: irs_soi.taxable_ira_distributions
+        unit: usd
+        aggregation: sum
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: A01400
+        value_scale: 1000
+
+      - measure_id: taxable_pension_income_returns
+        label: Returns with taxable pension income
+        ordinal: 31
+        column: AO
+        source_column_id: N01700
+        concept: irs_soi.returns_with_taxable_pension_income
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: N01700
+
+      - measure_id: taxable_pension_income_amount
+        label: Taxable pension income
+        ordinal: 32
+        column: AP
+        source_column_id: A01700
+        concept: irs_soi.taxable_pension_income
+        unit: usd
+        aggregation: sum
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: A01700
+        value_scale: 1000
+
+      - measure_id: unemployment_compensation_returns
+        label: Returns with unemployment compensation
+        ordinal: 33
+        column: AR
+        source_column_id: N02300
+        concept: irs_soi.returns_with_unemployment_compensation
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: N02300
+
+      - measure_id: unemployment_compensation_amount
+        label: Unemployment compensation
+        ordinal: 34
+        column: AS
+        source_column_id: A02300
+        concept: irs_soi.unemployment_compensation
+        unit: usd
+        aggregation: sum
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: A02300
+        value_scale: 1000
+
+      - measure_id: taxable_social_security_returns
+        label: Returns with taxable Social Security benefits
+        ordinal: 35
+        column: AT
+        source_column_id: N02500
+        concept: irs_soi.returns_with_taxable_social_security_benefits
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: N02500
+
+      - measure_id: taxable_social_security_amount
+        label: Taxable Social Security benefits
+        ordinal: 36
+        column: AU
+        source_column_id: A02500
+        concept: irs_soi.taxable_social_security_benefits
+        unit: usd
+        aggregation: sum
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: A02500
+        value_scale: 1000
+
+      - measure_id: partnership_scorp_income_returns
+        label: Returns with partnership and S corporation net income less loss
+        ordinal: 37
+        column: AV
+        source_column_id: N26270
+        concept: irs_soi.returns_with_partnership_scorp_income
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: N26270
+
+      - measure_id: partnership_scorp_income_amount
+        label: Partnership and S corporation net income less loss
+        ordinal: 38
+        column: AW
+        source_column_id: A26270
+        concept: irs_soi.partnership_scorp_income
+        unit: usd
+        aggregation: sum
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: A26270
+        value_scale: 1000
+
+      - measure_id: itemized_deductions_returns
+        label: Returns with total itemized deductions
+        ordinal: 39
+        column: BR
+        source_column_id: N04470
+        concept: irs_soi.returns_with_itemized_deductions
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: N04470
+
+      - measure_id: itemized_deductions_amount
+        label: Total itemized deductions
+        ordinal: 40
+        column: BS
+        source_column_id: A04470
+        concept: irs_soi.total_itemized_deductions
+        unit: usd
+        aggregation: sum
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: A04470
+        value_scale: 1000
+
+      - measure_id: medical_dental_expense_returns
+        label: Returns with medical and dental expense deductions
+        ordinal: 41
+        column: BT
+        source_column_id: N17000
+        concept: irs_soi.returns_with_medical_dental_expense_deduction
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: N17000
+
+      - measure_id: medical_dental_expense_amount
+        label: Medical and dental expense deductions
+        ordinal: 42
+        column: BU
+        source_column_id: A17000
+        concept: irs_soi.medical_dental_expense_deduction
+        unit: usd
+        aggregation: sum
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: A17000
+        value_scale: 1000
+
+      - measure_id: taxable_income_returns
+        label: Returns with taxable income
+        ordinal: 43
+        column: CV
+        source_column_id: N04800
+        concept: irs_soi.returns_with_taxable_income
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: N04800
+
+      - measure_id: taxable_income_amount
+        label: Taxable income
+        ordinal: 44
+        column: CW
+        source_column_id: A04800
+        concept: irs_soi.taxable_income
+        unit: usd
+        aggregation: sum
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: A04800
+        value_scale: 1000
+
+      - measure_id: income_tax_liability_returns
+        label: Returns with total income tax
+        ordinal: 45
+        column: ER
+        source_column_id: N06500
+        concept: irs_soi.returns_with_total_income_tax
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: N06500
+
+      - measure_id: income_tax_liability_amount
+        label: Total income tax
+        ordinal: 46
+        column: ES
+        source_column_id: A06500
+        concept: irs_soi.total_income_tax
+        unit: usd
+        aggregation: sum
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: A06500
+        value_scale: 1000

--- a/tests/test_arch_bundle.py
+++ b/tests/test_arch_bundle.py
@@ -29,7 +29,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "aggregate_duplicate_key_count": 0,
         "entity_count": 5,
         "error_count": 0,
-        "fact_count": 5707,
+        "fact_count": 6081,
         "geography_count": 54,
         "period_count": 5,
         "semantic_duplicate_key_count": 3,
@@ -38,18 +38,18 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "source_package_count": 22,
         "warning_count": 1,
     }
-    assert len(rows) == 5707
+    assert len(rows) == 6081
     assert rows[0]["aggregate_fact_key"].startswith("arch.aggregate_fact.v2:")
     assert rows[0]["semantic_fact_key"].startswith("arch.semantic_fact.v2:")
     assert source_packages["source_package_count"] == 22
     assert source_packages["skipped_source_count"] == 0
     assert not source_packages["skipped_sources"]
-    assert coverage["fact_count"] == 5707
+    assert coverage["fact_count"] == 6081
     assert coverage["counts"]["by_source"] == {
         "census_pep": 988,
         "cms_medicaid": 255,
         "hhs_acf_tanf": 110,
-        "irs_soi": 4081,
+        "irs_soi": 4455,
         "kff": 51,
         "ssa": 6,
         "usda_snap": 216,
@@ -69,7 +69,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         ): 255,
         "hhs_acf_tanf:FY 2024 Federal TANF and State MOE Financial Data": 52,
         "hhs_acf_tanf:TANF Caseload Data 2024": 58,
-        "irs_soi:Historic Table 2": 143,
+        "irs_soi:Historic Table 2": 517,
         "irs_soi:Historic Table 2 state AGI facts": 918,
         "irs_soi:Historic Table 2 state broad totals": 2295,
         "irs_soi:Historic Table 2 state EITC totals": 102,
@@ -102,10 +102,10 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "calendar_year:2024": 1045,
         "fiscal_year:2024": 326,
         "month:2024-12": 255,
-        "tax_year:2022": 3682,
+        "tax_year:2022": 4056,
         "tax_year:2023": 399,
     }
-    assert coverage["counts"]["by_geography"]["country:0100000US"] == 803
+    assert coverage["counts"]["by_geography"]["country:0100000US"] == 1177
     assert coverage["counts"]["by_geography"]["state:0400000US06"] == 96
     assert len(coverage["counts"]["by_geography"]) == 54
     assert coverage["counts"]["by_entity"] == {
@@ -113,7 +113,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "government": 54,
         "household": 54,
         "person": 1411,
-        "tax_unit": 4081,
+        "tax_unit": 4455,
     }
     assert not coverage["duplicates"]["aggregate_fact_keys"]
     assert len(coverage["duplicates"]["semantic_fact_keys"]) == 3

--- a/tests/test_arch_source_package.py
+++ b/tests/test_arch_source_package.py
@@ -489,8 +489,8 @@ def test_soi_historic_table_2_source_package_alias_validates_fixture_counts():
     assert report.counts == {
         "record_set_count": 1,
         "row_count": 11,
-        "measure_count": 13,
-        "source_record_count": 143,
+        "measure_count": 47,
+        "source_record_count": 517,
         "source_region_count": 1,
     }
 
@@ -510,7 +510,7 @@ def test_soi_historic_table_2_package_builds_2022_national_facts():
     assert validate_source_cells(cells).valid
     assert validate_facts(facts).valid
     assert len(cells) == 1_956
-    assert len(facts) == 143
+    assert len(facts) == 517
     assert all(fact.source_row_keys for fact in facts)
 
     tax_filers = values_by_record[
@@ -525,6 +525,18 @@ def test_soi_historic_table_2_package_builds_2022_national_facts():
     real_estate_taxes = values_by_record[
         "irs_soi.ty2022.historic_table_2.us.all.real_estate_taxes_amount"
     ]
+    qualified_dividends = values_by_record[
+        "irs_soi.ty2022.historic_table_2.us.all.qualified_dividends_amount"
+    ]
+    schedule_c_returns = values_by_record[
+        "irs_soi.ty2022.historic_table_2.us.all.schedule_c_income_returns"
+    ]
+    partnership_scorp = values_by_record[
+        "irs_soi.ty2022.historic_table_2.us.all.partnership_scorp_income_amount"
+    ]
+    medical_dental = values_by_record[
+        "irs_soi.ty2022.historic_table_2.us.all.medical_dental_expense_amount"
+    ]
     agi_bracket_eitc_claims = values_by_record[
         "irs_soi.ty2022.historic_table_2.us.1_to_10k.eitc_claims"
     ]
@@ -533,6 +545,10 @@ def test_soi_historic_table_2_package_builds_2022_national_facts():
     assert ptc_returns.value == 7_841_370
     assert eitc_amount.value == 59_204_588_000
     assert real_estate_taxes.value == 106_195_956_000
+    assert qualified_dividends.value == 309_355_739_000
+    assert schedule_c_returns.value == 30_354_680
+    assert partnership_scorp.value == 1_033_254_282_000
+    assert medical_dental.value == 80_235_875_000
     assert agi_bracket_eitc_claims.value == 5_013_220
     assert {constraint.operator for constraint in agi_bracket_eitc_claims.constraints} == {
         "<",


### PR DESCRIPTION
## Summary
- expand the national IRS SOI Historic Table 2 package from 13 to 47 measures
- add national all-return and AGI-stub facts for wages, interest, dividends, Schedule C, partnership/S-corp, pensions, unemployment, itemized deduction lines, taxable income, and total income tax
- update source-package and bundle tests for the 517 national Table 2 facts and 6,081 total bundle facts

## Validation
- uv run ruff check tests/test_arch_source_package.py tests/test_arch_bundle.py
- uv run pytest tests/test_arch_source_package.py::test_soi_historic_table_2_source_package_alias_validates_fixture_counts tests/test_arch_source_package.py::test_soi_historic_table_2_package_builds_2022_national_facts tests/test_arch_bundle.py::test_build_bundle_writes_merged_consumer_contract -q

## Microplex impact
With merged Arch PR #18, this expansion, and the Microplex medical itemized mapping fix, PE-native broad target coverage rises from 106/189 to 128/189 cells.