### PR TITLE
Add SOI qualified business income deduction facts

### DIFF
--- a/packages/irs_soi/historic_table_2/source_package.yaml
+++ b/packages/irs_soi/historic_table_2/source_package.yaml
@@ -787,3 +787,26 @@ record_sets:
         expected_column_header_row: 1
         expected_column_header: A06500
         value_scale: 1000
+      - measure_id: qbi_claims
+        label: Returns with qualified business income deduction
+        ordinal: 47
+        column: BF
+        source_column_id: N03270
+        concept: irs_soi.returns_with_qualified_business_income_deduction
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: N03270
+      - measure_id: qbi_amount
+        label: Qualified business income deduction
+        ordinal: 48
+        column: BG
+        source_column_id: A03270
+        concept: irs_soi.qualified_business_income_deduction
+        unit: usd
+        aggregation: sum
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: A03270
+        value_scale: 1000

--- a/packages/irs_soi/historic_table_2_state_broad_2022/source_package.yaml
+++ b/packages/irs_soi/historic_table_2_state_broad_2022/source_package.yaml
@@ -679,6 +679,29 @@ record_sets:
     expected_column_header_row: 1
     expected_column_header: A85770
     value_scale: 1000
+  - measure_id: qbi_claims
+    label: Returns with qualified business income deduction
+    ordinal: 45
+    column: BF
+    source_column_id: N03270
+    concept: irs_soi.returns_with_qualified_business_income_deduction
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N03270
+  - measure_id: qbi_amount
+    label: Qualified business income deduction
+    ordinal: 46
+    column: BG
+    source_column_id: A03270
+    concept: irs_soi.qualified_business_income_deduction
+    unit: usd
+    aggregation: sum
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A03270
+    value_scale: 1000
 - record_set_id: irs_soi.ty2022.historic_table_2.state_broad.ak
   record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.ak

--- a/tests/test_arch_bundle.py
+++ b/tests/test_arch_bundle.py
@@ -29,7 +29,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "aggregate_duplicate_key_count": 0,
         "entity_count": 5,
         "error_count": 0,
-        "fact_count": 6081,
+        "fact_count": 6205,
         "geography_count": 54,
         "period_count": 5,
         "semantic_duplicate_key_count": 3,
@@ -38,18 +38,18 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "source_package_count": 22,
         "warning_count": 1,
     }
-    assert len(rows) == 6081
+    assert len(rows) == 6205
     assert rows[0]["aggregate_fact_key"].startswith("arch.aggregate_fact.v2:")
     assert rows[0]["semantic_fact_key"].startswith("arch.semantic_fact.v2:")
     assert source_packages["source_package_count"] == 22
     assert source_packages["skipped_source_count"] == 0
     assert not source_packages["skipped_sources"]
-    assert coverage["fact_count"] == 6081
+    assert coverage["fact_count"] == 6205
     assert coverage["counts"]["by_source"] == {
         "census_pep": 988,
         "cms_medicaid": 255,
         "hhs_acf_tanf": 110,
-        "irs_soi": 4455,
+        "irs_soi": 4579,
         "kff": 51,
         "ssa": 6,
         "usda_snap": 216,
@@ -69,9 +69,9 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         ): 255,
         "hhs_acf_tanf:FY 2024 Federal TANF and State MOE Financial Data": 52,
         "hhs_acf_tanf:TANF Caseload Data 2024": 58,
-        "irs_soi:Historic Table 2": 517,
+        "irs_soi:Historic Table 2": 539,
         "irs_soi:Historic Table 2 state AGI facts": 918,
-        "irs_soi:Historic Table 2 state broad totals": 2295,
+        "irs_soi:Historic Table 2 state broad totals": 2397,
         "irs_soi:Historic Table 2 state EITC totals": 102,
         "irs_soi:Publication 1304 Table 1.1": 80,
         "irs_soi:Publication 1304 Table 1.2": 7,
@@ -102,18 +102,18 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "calendar_year:2024": 1045,
         "fiscal_year:2024": 326,
         "month:2024-12": 255,
-        "tax_year:2022": 4056,
+        "tax_year:2022": 4180,
         "tax_year:2023": 399,
     }
-    assert coverage["counts"]["by_geography"]["country:0100000US"] == 1177
-    assert coverage["counts"]["by_geography"]["state:0400000US06"] == 96
+    assert coverage["counts"]["by_geography"]["country:0100000US"] == 1199
+    assert coverage["counts"]["by_geography"]["state:0400000US06"] == 98
     assert len(coverage["counts"]["by_geography"]) == 54
     assert coverage["counts"]["by_entity"] == {
         "family": 107,
         "government": 54,
         "household": 54,
         "person": 1411,
-        "tax_unit": 4455,
+        "tax_unit": 4579,
     }
     assert not coverage["duplicates"]["aggregate_fact_keys"]
     assert len(coverage["duplicates"]["semantic_fact_keys"]) == 3

--- a/tests/test_arch_source_package.py
+++ b/tests/test_arch_source_package.py
@@ -309,8 +309,8 @@ def test_national_soi_source_package_aliases_validate_fixture_counts():
         "soi-historic-table-2-state-broad-2022": {
             "record_set_count": 51,
             "row_count": 51,
-            "measure_count": 2295,
-            "source_record_count": 2295,
+            "measure_count": 2397,
+            "source_record_count": 2397,
             "source_region_count": 51,
         },
         "soi-historic-table-2-state-eitc-2022": {
@@ -489,8 +489,8 @@ def test_soi_historic_table_2_source_package_alias_validates_fixture_counts():
     assert report.counts == {
         "record_set_count": 1,
         "row_count": 11,
-        "measure_count": 47,
-        "source_record_count": 517,
+        "measure_count": 49,
+        "source_record_count": 539,
         "source_region_count": 1,
     }
 
@@ -510,7 +510,7 @@ def test_soi_historic_table_2_package_builds_2022_national_facts():
     assert validate_source_cells(cells).valid
     assert validate_facts(facts).valid
     assert len(cells) == 1_956
-    assert len(facts) == 517
+    assert len(facts) == 539
     assert all(fact.source_row_keys for fact in facts)
 
     tax_filers = values_by_record[
@@ -537,6 +537,9 @@ def test_soi_historic_table_2_package_builds_2022_national_facts():
     medical_dental = values_by_record[
         "irs_soi.ty2022.historic_table_2.us.all.medical_dental_expense_amount"
     ]
+    qbi = values_by_record[
+        "irs_soi.ty2022.historic_table_2.us.all.qbi_amount"
+    ]
     agi_bracket_eitc_claims = values_by_record[
         "irs_soi.ty2022.historic_table_2.us.1_to_10k.eitc_claims"
     ]
@@ -549,6 +552,7 @@ def test_soi_historic_table_2_package_builds_2022_national_facts():
     assert schedule_c_returns.value == 30_354_680
     assert partnership_scorp.value == 1_033_254_282_000
     assert medical_dental.value == 80_235_875_000
+    assert qbi.value == 31_307_205_000
     assert agi_bracket_eitc_claims.value == 5_013_220
     assert {constraint.operator for constraint in agi_bracket_eitc_claims.constraints} == {
         "<",
@@ -569,7 +573,7 @@ def test_soi_historic_table_2_state_broad_package_builds_2022_state_facts():
     assert validate_source_cells(cells).valid
     assert validate_facts(facts).valid
     assert len(cells) == 8_476
-    assert len(facts) == 2_295
+    assert len(facts) == 2_397
 
     ca_returns = values_by_record[
         "irs_soi.ty2022.historic_table_2.state_broad.ca.all.return_count"
@@ -586,12 +590,16 @@ def test_soi_historic_table_2_state_broad_package_builds_2022_state_facts():
     ca_medical = values_by_record[
         "irs_soi.ty2022.historic_table_2.state_broad.ca.all.medical_dental_expense_amount"
     ]
+    ca_qbi = values_by_record[
+        "irs_soi.ty2022.historic_table_2.state_broad.ca.all.qbi_amount"
+    ]
 
     assert ca_returns.value == 18_487_690
     assert ca_agi.value == 1_987_000_701_000
     assert ca_ptc.value == 6_379_623_000
     assert ca_partnership.value == 125_930_370_000
     assert ca_medical.value == 11_456_144_000
+    assert ca_qbi.value == 4_400_400_000
     assert ca_returns.geography.id == "0400000US06"
     assert ca_partnership.layout.source_column_id == "A26270"
 


### PR DESCRIPTION
## Summary

- adds IRS SOI Historic Table 2 qualified business income deduction claims and amount measures (`N03270` / `A03270`)
- exports the same QBI measures for national AGI rows and state all-return broad rows
- updates bundle and source-package count assertions

## Validation

- `uv run ruff check tests/test_arch_source_package.py tests/test_arch_bundle.py`
- `uv run pytest tests/test_arch_source_package.py::test_soi_historic_table_2_package_builds_2022_national_facts tests/test_arch_source_package.py::test_soi_historic_table_2_state_broad_package_builds_2022_state_facts tests/test_arch_bundle.py::test_build_bundle_writes_merged_consumer_contract -q`

## Microplex impact

Microplex already maps `qbi_amount` to `qualified_business_income_deduction` and `qbi_claims` to the corresponding tax-unit count domain, so this should close the QBI source gap without another adapter change.