### PR TITLE
Add SOI rental royalty income facts

### DIFF
--- a/packages/irs_soi/historic_table_2/source_package.yaml
+++ b/packages/irs_soi/historic_table_2/source_package.yaml
@@ -810,3 +810,26 @@ record_sets:
         expected_column_header_row: 1
         expected_column_header: A03270
         value_scale: 1000
+      - measure_id: rental_royalty_income_returns
+        label: Returns with rental and royalty net income less loss
+        ordinal: 49
+        column: AX
+        source_column_id: N25870
+        concept: irs_soi.returns_with_rental_royalty_income
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: N25870
+      - measure_id: rental_royalty_income_amount
+        label: Rental and royalty net income less loss
+        ordinal: 50
+        column: AY
+        source_column_id: A25870
+        concept: irs_soi.rental_royalty_income
+        unit: usd
+        aggregation: sum
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: A25870
+        value_scale: 1000

--- a/packages/irs_soi/historic_table_2_state_broad_2022/source_package.yaml
+++ b/packages/irs_soi/historic_table_2_state_broad_2022/source_package.yaml
@@ -702,6 +702,29 @@ record_sets:
     expected_column_header_row: 1
     expected_column_header: A03270
     value_scale: 1000
+  - measure_id: rental_royalty_income_returns
+    label: Returns with rental and royalty net income less loss
+    ordinal: 47
+    column: AX
+    source_column_id: N25870
+    concept: irs_soi.returns_with_rental_royalty_income
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N25870
+  - measure_id: rental_royalty_income_amount
+    label: Rental and royalty net income less loss
+    ordinal: 48
+    column: AY
+    source_column_id: A25870
+    concept: irs_soi.rental_royalty_income
+    unit: usd
+    aggregation: sum
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A25870
+    value_scale: 1000
 - record_set_id: irs_soi.ty2022.historic_table_2.state_broad.ak
   record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.ak

--- a/tests/test_arch_bundle.py
+++ b/tests/test_arch_bundle.py
@@ -29,7 +29,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "aggregate_duplicate_key_count": 0,
         "entity_count": 5,
         "error_count": 0,
-        "fact_count": 6205,
+        "fact_count": 6329,
         "geography_count": 54,
         "period_count": 5,
         "semantic_duplicate_key_count": 3,
@@ -38,18 +38,18 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "source_package_count": 22,
         "warning_count": 1,
     }
-    assert len(rows) == 6205
+    assert len(rows) == 6329
     assert rows[0]["aggregate_fact_key"].startswith("arch.aggregate_fact.v2:")
     assert rows[0]["semantic_fact_key"].startswith("arch.semantic_fact.v2:")
     assert source_packages["source_package_count"] == 22
     assert source_packages["skipped_source_count"] == 0
     assert not source_packages["skipped_sources"]
-    assert coverage["fact_count"] == 6205
+    assert coverage["fact_count"] == 6329
     assert coverage["counts"]["by_source"] == {
         "census_pep": 988,
         "cms_medicaid": 255,
         "hhs_acf_tanf": 110,
-        "irs_soi": 4579,
+        "irs_soi": 4703,
         "kff": 51,
         "ssa": 6,
         "usda_snap": 216,
@@ -69,9 +69,9 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         ): 255,
         "hhs_acf_tanf:FY 2024 Federal TANF and State MOE Financial Data": 52,
         "hhs_acf_tanf:TANF Caseload Data 2024": 58,
-        "irs_soi:Historic Table 2": 539,
+        "irs_soi:Historic Table 2": 561,
         "irs_soi:Historic Table 2 state AGI facts": 918,
-        "irs_soi:Historic Table 2 state broad totals": 2397,
+        "irs_soi:Historic Table 2 state broad totals": 2499,
         "irs_soi:Historic Table 2 state EITC totals": 102,
         "irs_soi:Publication 1304 Table 1.1": 80,
         "irs_soi:Publication 1304 Table 1.2": 7,
@@ -102,18 +102,18 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "calendar_year:2024": 1045,
         "fiscal_year:2024": 326,
         "month:2024-12": 255,
-        "tax_year:2022": 4180,
+        "tax_year:2022": 4304,
         "tax_year:2023": 399,
     }
-    assert coverage["counts"]["by_geography"]["country:0100000US"] == 1199
-    assert coverage["counts"]["by_geography"]["state:0400000US06"] == 98
+    assert coverage["counts"]["by_geography"]["country:0100000US"] == 1221
+    assert coverage["counts"]["by_geography"]["state:0400000US06"] == 100
     assert len(coverage["counts"]["by_geography"]) == 54
     assert coverage["counts"]["by_entity"] == {
         "family": 107,
         "government": 54,
         "household": 54,
         "person": 1411,
-        "tax_unit": 4579,
+        "tax_unit": 4703,
     }
     assert not coverage["duplicates"]["aggregate_fact_keys"]
     assert len(coverage["duplicates"]["semantic_fact_keys"]) == 3

--- a/tests/test_arch_source_package.py
+++ b/tests/test_arch_source_package.py
@@ -309,8 +309,8 @@ def test_national_soi_source_package_aliases_validate_fixture_counts():
         "soi-historic-table-2-state-broad-2022": {
             "record_set_count": 51,
             "row_count": 51,
-            "measure_count": 2397,
-            "source_record_count": 2397,
+            "measure_count": 2499,
+            "source_record_count": 2499,
             "source_region_count": 51,
         },
         "soi-historic-table-2-state-eitc-2022": {
@@ -489,8 +489,8 @@ def test_soi_historic_table_2_source_package_alias_validates_fixture_counts():
     assert report.counts == {
         "record_set_count": 1,
         "row_count": 11,
-        "measure_count": 49,
-        "source_record_count": 539,
+        "measure_count": 51,
+        "source_record_count": 561,
         "source_region_count": 1,
     }
 
@@ -510,7 +510,7 @@ def test_soi_historic_table_2_package_builds_2022_national_facts():
     assert validate_source_cells(cells).valid
     assert validate_facts(facts).valid
     assert len(cells) == 1_956
-    assert len(facts) == 539
+    assert len(facts) == 561
     assert all(fact.source_row_keys for fact in facts)
 
     tax_filers = values_by_record[
@@ -540,6 +540,9 @@ def test_soi_historic_table_2_package_builds_2022_national_facts():
     qbi = values_by_record[
         "irs_soi.ty2022.historic_table_2.us.all.qbi_amount"
     ]
+    rental = values_by_record[
+        "irs_soi.ty2022.historic_table_2.us.all.rental_royalty_income_amount"
+    ]
     agi_bracket_eitc_claims = values_by_record[
         "irs_soi.ty2022.historic_table_2.us.1_to_10k.eitc_claims"
     ]
@@ -553,6 +556,7 @@ def test_soi_historic_table_2_package_builds_2022_national_facts():
     assert partnership_scorp.value == 1_033_254_282_000
     assert medical_dental.value == 80_235_875_000
     assert qbi.value == 31_307_205_000
+    assert rental.value == 85_642_801_000
     assert agi_bracket_eitc_claims.value == 5_013_220
     assert {constraint.operator for constraint in agi_bracket_eitc_claims.constraints} == {
         "<",
@@ -573,7 +577,7 @@ def test_soi_historic_table_2_state_broad_package_builds_2022_state_facts():
     assert validate_source_cells(cells).valid
     assert validate_facts(facts).valid
     assert len(cells) == 8_476
-    assert len(facts) == 2_397
+    assert len(facts) == 2_499
 
     ca_returns = values_by_record[
         "irs_soi.ty2022.historic_table_2.state_broad.ca.all.return_count"
@@ -593,6 +597,9 @@ def test_soi_historic_table_2_state_broad_package_builds_2022_state_facts():
     ca_qbi = values_by_record[
         "irs_soi.ty2022.historic_table_2.state_broad.ca.all.qbi_amount"
     ]
+    ca_rental = values_by_record[
+        "irs_soi.ty2022.historic_table_2.state_broad.ca.all.rental_royalty_income_amount"
+    ]
 
     assert ca_returns.value == 18_487_690
     assert ca_agi.value == 1_987_000_701_000
@@ -600,6 +607,7 @@ def test_soi_historic_table_2_state_broad_package_builds_2022_state_facts():
     assert ca_partnership.value == 125_930_370_000
     assert ca_medical.value == 11_456_144_000
     assert ca_qbi.value == 4_400_400_000
+    assert ca_rental.value == 14_331_993_000
     assert ca_returns.geography.id == "0400000US06"
     assert ca_partnership.layout.source_column_id == "A26270"
 


### PR DESCRIPTION
## Summary

- adds IRS SOI Historic Table 2 rental and royalty net income less loss claims and amount measures (`N25870` / `A25870`)
- exports those measures for national AGI rows and state all-return broad rows
- updates source-package and merged-bundle count assertions

## Validation

- `uv run ruff check tests/test_arch_source_package.py tests/test_arch_bundle.py`
- `uv run pytest tests/test_arch_source_package.py::test_soi_historic_table_2_package_builds_2022_national_facts tests/test_arch_source_package.py::test_soi_historic_table_2_state_broad_package_builds_2022_state_facts tests/test_arch_bundle.py::test_build_bundle_writes_merged_consumer_contract -q`

## Microplex impact

Microplex already treats `rental_royalty_income_amount` as `rental_income` and expects `rental_royalty_income_returns` for the rental count domain; a companion Microplex mapping PR will add the new Arch consumer-fact concepts.