### PR TITLE
Add SOI child tax credit facts

### DIFF
--- a/packages/irs_soi/historic_table_2/source_package.yaml
+++ b/packages/irs_soi/historic_table_2/source_package.yaml
@@ -833,3 +833,49 @@ record_sets:
         expected_column_header_row: 1
         expected_column_header: A25870
         value_scale: 1000
+      - measure_id: ctc_claims
+        label: Returns with child tax credit
+        ordinal: 51
+        column: DN
+        source_column_id: N07225
+        concept: irs_soi.returns_with_child_tax_credit
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: N07225
+      - measure_id: ctc_amount
+        label: Child tax credit
+        ordinal: 52
+        column: DO
+        source_column_id: A07225
+        concept: irs_soi.child_tax_credit
+        unit: usd
+        aggregation: sum
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: A07225
+        value_scale: 1000
+      - measure_id: actc_claims
+        label: Returns with additional child tax credit
+        ordinal: 53
+        column: EL
+        source_column_id: N11070
+        concept: irs_soi.returns_with_additional_child_tax_credit
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: N11070
+      - measure_id: actc_amount
+        label: Additional child tax credit
+        ordinal: 54
+        column: EM
+        source_column_id: A11070
+        concept: irs_soi.additional_child_tax_credit
+        unit: usd
+        aggregation: sum
+        expected_cell_type: number
+        expected_column_header_row: 1
+        expected_column_header: A11070
+        value_scale: 1000

--- a/packages/irs_soi/historic_table_2_state_broad_2022/source_package.yaml
+++ b/packages/irs_soi/historic_table_2_state_broad_2022/source_package.yaml
@@ -725,6 +725,52 @@ record_sets:
     expected_column_header_row: 1
     expected_column_header: A25870
     value_scale: 1000
+  - measure_id: ctc_claims
+    label: Returns with child tax credit
+    ordinal: 49
+    column: DN
+    source_column_id: N07225
+    concept: irs_soi.returns_with_child_tax_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N07225
+  - measure_id: ctc_amount
+    label: Child tax credit
+    ordinal: 50
+    column: DO
+    source_column_id: A07225
+    concept: irs_soi.child_tax_credit
+    unit: usd
+    aggregation: sum
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A07225
+    value_scale: 1000
+  - measure_id: actc_claims
+    label: Returns with additional child tax credit
+    ordinal: 51
+    column: EL
+    source_column_id: N11070
+    concept: irs_soi.returns_with_additional_child_tax_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N11070
+  - measure_id: actc_amount
+    label: Additional child tax credit
+    ordinal: 52
+    column: EM
+    source_column_id: A11070
+    concept: irs_soi.additional_child_tax_credit
+    unit: usd
+    aggregation: sum
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A11070
+    value_scale: 1000
 - record_set_id: irs_soi.ty2022.historic_table_2.state_broad.ak
   record_set_spec_id: irs_soi.historic_table_2.state_broad_totals.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_broad.ak

--- a/tests/test_arch_bundle.py
+++ b/tests/test_arch_bundle.py
@@ -29,7 +29,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "aggregate_duplicate_key_count": 0,
         "entity_count": 5,
         "error_count": 0,
-        "fact_count": 6329,
+        "fact_count": 6577,
         "geography_count": 54,
         "period_count": 5,
         "semantic_duplicate_key_count": 3,
@@ -38,18 +38,18 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "source_package_count": 22,
         "warning_count": 1,
     }
-    assert len(rows) == 6329
+    assert len(rows) == 6577
     assert rows[0]["aggregate_fact_key"].startswith("arch.aggregate_fact.v2:")
     assert rows[0]["semantic_fact_key"].startswith("arch.semantic_fact.v2:")
     assert source_packages["source_package_count"] == 22
     assert source_packages["skipped_source_count"] == 0
     assert not source_packages["skipped_sources"]
-    assert coverage["fact_count"] == 6329
+    assert coverage["fact_count"] == 6577
     assert coverage["counts"]["by_source"] == {
         "census_pep": 988,
         "cms_medicaid": 255,
         "hhs_acf_tanf": 110,
-        "irs_soi": 4703,
+        "irs_soi": 4951,
         "kff": 51,
         "ssa": 6,
         "usda_snap": 216,
@@ -69,9 +69,9 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         ): 255,
         "hhs_acf_tanf:FY 2024 Federal TANF and State MOE Financial Data": 52,
         "hhs_acf_tanf:TANF Caseload Data 2024": 58,
-        "irs_soi:Historic Table 2": 561,
+        "irs_soi:Historic Table 2": 605,
         "irs_soi:Historic Table 2 state AGI facts": 918,
-        "irs_soi:Historic Table 2 state broad totals": 2499,
+        "irs_soi:Historic Table 2 state broad totals": 2703,
         "irs_soi:Historic Table 2 state EITC totals": 102,
         "irs_soi:Publication 1304 Table 1.1": 80,
         "irs_soi:Publication 1304 Table 1.2": 7,
@@ -102,18 +102,18 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "calendar_year:2024": 1045,
         "fiscal_year:2024": 326,
         "month:2024-12": 255,
-        "tax_year:2022": 4304,
+        "tax_year:2022": 4552,
         "tax_year:2023": 399,
     }
-    assert coverage["counts"]["by_geography"]["country:0100000US"] == 1221
-    assert coverage["counts"]["by_geography"]["state:0400000US06"] == 100
+    assert coverage["counts"]["by_geography"]["country:0100000US"] == 1265
+    assert coverage["counts"]["by_geography"]["state:0400000US06"] == 104
     assert len(coverage["counts"]["by_geography"]) == 54
     assert coverage["counts"]["by_entity"] == {
         "family": 107,
         "government": 54,
         "household": 54,
         "person": 1411,
-        "tax_unit": 4703,
+        "tax_unit": 4951,
     }
     assert not coverage["duplicates"]["aggregate_fact_keys"]
     assert len(coverage["duplicates"]["semantic_fact_keys"]) == 3

--- a/tests/test_arch_source_package.py
+++ b/tests/test_arch_source_package.py
@@ -489,8 +489,8 @@ def test_soi_historic_table_2_source_package_alias_validates_fixture_counts():
     assert report.counts == {
         "record_set_count": 1,
         "row_count": 11,
-        "measure_count": 51,
-        "source_record_count": 561,
+        "measure_count": 55,
+        "source_record_count": 605,
         "source_region_count": 1,
     }
 
@@ -510,7 +510,7 @@ def test_soi_historic_table_2_package_builds_2022_national_facts():
     assert validate_source_cells(cells).valid
     assert validate_facts(facts).valid
     assert len(cells) == 1_956
-    assert len(facts) == 561
+    assert len(facts) == 605
     assert all(fact.source_row_keys for fact in facts)
 
     tax_filers = values_by_record[
@@ -543,6 +543,12 @@ def test_soi_historic_table_2_package_builds_2022_national_facts():
     rental = values_by_record[
         "irs_soi.ty2022.historic_table_2.us.all.rental_royalty_income_amount"
     ]
+    ctc = values_by_record[
+        "irs_soi.ty2022.historic_table_2.us.all.ctc_amount"
+    ]
+    actc = values_by_record[
+        "irs_soi.ty2022.historic_table_2.us.all.actc_amount"
+    ]
     agi_bracket_eitc_claims = values_by_record[
         "irs_soi.ty2022.historic_table_2.us.1_to_10k.eitc_claims"
     ]
@@ -557,6 +563,8 @@ def test_soi_historic_table_2_package_builds_2022_national_facts():
     assert medical_dental.value == 80_235_875_000
     assert qbi.value == 31_307_205_000
     assert rental.value == 85_642_801_000
+    assert ctc.value == 82_862_736_000
+    assert actc.value == 33_857_987_000
     assert agi_bracket_eitc_claims.value == 5_013_220
     assert {constraint.operator for constraint in agi_bracket_eitc_claims.constraints} == {
         "<",
@@ -577,7 +585,7 @@ def test_soi_historic_table_2_state_broad_package_builds_2022_state_facts():
     assert validate_source_cells(cells).valid
     assert validate_facts(facts).valid
     assert len(cells) == 8_476
-    assert len(facts) == 2_499
+    assert len(facts) == 2_703
 
     ca_returns = values_by_record[
         "irs_soi.ty2022.historic_table_2.state_broad.ca.all.return_count"
@@ -600,6 +608,12 @@ def test_soi_historic_table_2_state_broad_package_builds_2022_state_facts():
     ca_rental = values_by_record[
         "irs_soi.ty2022.historic_table_2.state_broad.ca.all.rental_royalty_income_amount"
     ]
+    ca_ctc = values_by_record[
+        "irs_soi.ty2022.historic_table_2.state_broad.ca.all.ctc_amount"
+    ]
+    ca_actc = values_by_record[
+        "irs_soi.ty2022.historic_table_2.state_broad.ca.all.actc_amount"
+    ]
 
     assert ca_returns.value == 18_487_690
     assert ca_agi.value == 1_987_000_701_000
@@ -608,6 +622,8 @@ def test_soi_historic_table_2_state_broad_package_builds_2022_state_facts():
     assert ca_medical.value == 11_456_144_000
     assert ca_qbi.value == 4_400_400_000
     assert ca_rental.value == 14_331_993_000
+    assert ca_ctc.value == 9_724_583_000
+    assert ca_actc.value == 3_605_628_000
     assert ca_returns.geography.id == "0400000US06"
     assert ca_partnership.layout.source_column_id == "A26270"
 


### PR DESCRIPTION
## Summary
- add SOI Historic Table 2 child tax credit and additional child tax credit measures for national AGI rows
- add the same CTC/ACTC measures to the 2022 state-broad Historic Table 2 package
- update source-package and bundle count/value assertions for the new CTC/ACTC facts

## Validation
- `uv run ruff check tests/test_arch_source_package.py tests/test_arch_bundle.py`
- `uv run pytest tests/test_arch_source_package.py::test_soi_historic_table_2_source_package_alias_validates_fixture_counts tests/test_arch_source_package.py::test_soi_historic_table_2_package_builds_2022_national_facts tests/test_arch_source_package.py::test_soi_historic_table_2_state_broad_package_builds_2022_state_facts tests/test_arch_bundle.py::test_build_bundle_writes_merged_consumer_contract -q`
