### PR TITLE
Add SOI EITC child-count total facts

### DIFF
--- a/packages/irs_soi/table_2_5_eitc_agi_children_2022/source_package.yaml
+++ b/packages/irs_soi/table_2_5_eitc_agi_children_2022/source_package.yaml
@@ -1081,6 +1081,34 @@ record_sets:
 
         income credit'
       label: EITC measure group
+  - value_id: total
+    label: Total
+    ordinal: 99
+    row_number: 9
+    expected_row_header_column: A
+    expected_row_header: Total
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: Total
+      label: AGI bracket label
+    - column: A
+      row: 1
+      expected_value: "Table 2.5.  Returns with Earned Income Credit, by Size of Adjusted\
+        \ \nGross Income and Number of Qualifying Children, \nTax Year 2022 (Filing Year 2023)"
+      label: table title
+    - column: R
+      row: 3
+      expected_value: Returns with no qualifying children
+      label: qualifying-child column group
+    - column: Z
+      row: 4
+      expected_value: 'Total earned
+
+        income credit'
+      label: EITC measure group
+    table_record_kind: total
   measures:
   - measure_id: eitc_returns
     label: Returns with total earned income credit
@@ -2188,6 +2216,34 @@ record_sets:
 
         income credit'
       label: EITC measure group
+  - value_id: total
+    label: Total
+    ordinal: 99
+    row_number: 9
+    expected_row_header_column: A
+    expected_row_header: Total
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: Total
+      label: AGI bracket label
+    - column: A
+      row: 1
+      expected_value: "Table 2.5.  Returns with Earned Income Credit, by Size of Adjusted\
+        \ \nGross Income and Number of Qualifying Children, \nTax Year 2022 (Filing Year 2023)"
+      label: table title
+    - column: AH
+      row: 3
+      expected_value: Returns with one qualifying child
+      label: qualifying-child column group
+    - column: AP
+      row: 4
+      expected_value: 'Total earned
+
+        income credit'
+      label: EITC measure group
+    table_record_kind: total
   measures:
   - measure_id: eitc_returns
     label: Returns with total earned income credit
@@ -3295,6 +3351,34 @@ record_sets:
 
         income credit'
       label: EITC measure group
+  - value_id: total
+    label: Total
+    ordinal: 99
+    row_number: 9
+    expected_row_header_column: A
+    expected_row_header: Total
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: Total
+      label: AGI bracket label
+    - column: A
+      row: 1
+      expected_value: "Table 2.5.  Returns with Earned Income Credit, by Size of Adjusted\
+        \ \nGross Income and Number of Qualifying Children, \nTax Year 2022 (Filing Year 2023)"
+      label: table title
+    - column: AX
+      row: 3
+      expected_value: Returns with two qualifying children
+      label: qualifying-child column group
+    - column: BF
+      row: 4
+      expected_value: 'Total earned
+
+        income credit'
+      label: EITC measure group
+    table_record_kind: total
   measures:
   - measure_id: eitc_returns
     label: Returns with total earned income credit
@@ -4402,6 +4486,34 @@ record_sets:
 
         income credit'
       label: EITC measure group
+  - value_id: total
+    label: Total
+    ordinal: 99
+    row_number: 9
+    expected_row_header_column: A
+    expected_row_header: Total
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      expected_value: Total
+      label: AGI bracket label
+    - column: A
+      row: 1
+      expected_value: "Table 2.5.  Returns with Earned Income Credit, by Size of Adjusted\
+        \ \nGross Income and Number of Qualifying Children, \nTax Year 2022 (Filing Year 2023)"
+      label: table title
+    - column: BN
+      row: 3
+      expected_value: Returns with three or more qualifying children
+      label: qualifying-child column group
+    - column: BV
+      row: 4
+      expected_value: 'Total earned
+
+        income credit'
+      label: EITC measure group
+    table_record_kind: total
   measures:
   - measure_id: eitc_returns
     label: Returns with total earned income credit

--- a/tests/test_arch_bundle.py
+++ b/tests/test_arch_bundle.py
@@ -29,7 +29,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "aggregate_duplicate_key_count": 0,
         "entity_count": 5,
         "error_count": 0,
-        "fact_count": 6577,
+        "fact_count": 6585,
         "geography_count": 54,
         "period_count": 5,
         "semantic_duplicate_key_count": 3,
@@ -38,18 +38,18 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "source_package_count": 22,
         "warning_count": 1,
     }
-    assert len(rows) == 6577
+    assert len(rows) == 6585
     assert rows[0]["aggregate_fact_key"].startswith("arch.aggregate_fact.v2:")
     assert rows[0]["semantic_fact_key"].startswith("arch.semantic_fact.v2:")
     assert source_packages["source_package_count"] == 22
     assert source_packages["skipped_source_count"] == 0
     assert not source_packages["skipped_sources"]
-    assert coverage["fact_count"] == 6577
+    assert coverage["fact_count"] == 6585
     assert coverage["counts"]["by_source"] == {
         "census_pep": 988,
         "cms_medicaid": 255,
         "hhs_acf_tanf": 110,
-        "irs_soi": 4951,
+        "irs_soi": 4959,
         "kff": 51,
         "ssa": 6,
         "usda_snap": 216,
@@ -78,7 +78,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "irs_soi:Publication 1304 Table 1.4": 260,
         "irs_soi:Publication 1304 Table 2.1": 17,
         "irs_soi:Publication 1304 Table 2.5": 8,
-        "irs_soi:Publication 1304 Table 2.5 EITC by AGI and qualifying children": 224,
+        "irs_soi:Publication 1304 Table 2.5 EITC by AGI and qualifying children": 232,
         "irs_soi:Publication 1304 Table 4.3": 18,
         (
             "irs_soi:Table 4.B. Summary of Items for Taxpayers with Form W-2, "
@@ -102,10 +102,10 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "calendar_year:2024": 1045,
         "fiscal_year:2024": 326,
         "month:2024-12": 255,
-        "tax_year:2022": 4552,
+        "tax_year:2022": 4560,
         "tax_year:2023": 399,
     }
-    assert coverage["counts"]["by_geography"]["country:0100000US"] == 1265
+    assert coverage["counts"]["by_geography"]["country:0100000US"] == 1273
     assert coverage["counts"]["by_geography"]["state:0400000US06"] == 104
     assert len(coverage["counts"]["by_geography"]) == 54
     assert coverage["counts"]["by_entity"] == {
@@ -113,7 +113,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "government": 54,
         "household": 54,
         "person": 1411,
-        "tax_unit": 4951,
+        "tax_unit": 4959,
     }
     assert not coverage["duplicates"]["aggregate_fact_keys"]
     assert len(coverage["duplicates"]["semantic_fact_keys"]) == 3

--- a/tests/test_arch_source_package.py
+++ b/tests/test_arch_source_package.py
@@ -287,9 +287,9 @@ def test_national_soi_source_package_aliases_validate_fixture_counts():
         },
         "soi-table-2-5-eitc-agi-children-2022": {
             "record_set_count": 4,
-            "row_count": 112,
+            "row_count": 116,
             "measure_count": 8,
-            "source_record_count": 224,
+            "source_record_count": 232,
             "source_region_count": 4,
         },
         "soi-table-4-3": {
@@ -309,8 +309,8 @@ def test_national_soi_source_package_aliases_validate_fixture_counts():
         "soi-historic-table-2-state-broad-2022": {
             "record_set_count": 51,
             "row_count": 51,
-            "measure_count": 2499,
-            "source_record_count": 2499,
+            "measure_count": 2703,
+            "source_record_count": 2703,
             "source_region_count": 51,
         },
         "soi-historic-table-2-state-eitc-2022": {
@@ -348,6 +348,46 @@ def test_national_soi_source_package_aliases_validate_fixture_counts():
 
         assert report.valid, package_id
         assert report.counts == counts
+
+
+def test_soi_table_2_5_eitc_child_totals_build_2022_facts():
+    package = load_source_package("soi-table-2-5-eitc-agi-children-2022")
+    cells = package.build_source_cells(2023)
+    facts = package.build_facts(2023, cells=cells)
+    values_by_record = {fact.source_record_id: fact for fact in facts}
+
+    assert validate_source_cells(cells).valid
+    assert validate_facts(facts).valid
+
+    no_child_returns = values_by_record[
+        "irs_soi.ty2022.table_2_5.eitc_by_agi_children."
+        "no_qualifying_children.total.eitc_returns"
+    ]
+    one_child_amount = values_by_record[
+        "irs_soi.ty2022.table_2_5.eitc_by_agi_children."
+        "one_qualifying_child.total.eitc_total"
+    ]
+    two_child_returns = values_by_record[
+        "irs_soi.ty2022.table_2_5.eitc_by_agi_children."
+        "two_qualifying_children.total.eitc_returns"
+    ]
+    three_child_amount = values_by_record[
+        "irs_soi.ty2022.table_2_5.eitc_by_agi_children."
+        "three_or_more_qualifying_children.total.eitc_total"
+    ]
+
+    assert no_child_returns.value == 6_878_342
+    assert one_child_amount.value == 21_182_747_000
+    assert two_child_returns.value == 5_628_089
+    assert three_child_amount.value == 14_000_930_000
+    assert no_child_returns.filters == {"income_range": "all"}
+    assert no_child_returns.layout.table_record_kind == "total"
+    assert {
+        constraint.variable for constraint in no_child_returns.constraints
+    } == {"us.tax.earned_income_credit_qualifying_children"}
+    assert {
+        constraint.operator for constraint in three_child_amount.constraints
+    } == {">="}
 
 
 def test_ssa_supplement_source_package_alias_validates_fixture_counts():


### PR DESCRIPTION
## Summary
- add Table 2.5 total rows for EITC returns and EITC amount by qualifying-child count
- validate the new total facts and refresh bundle fixture counts

## Validation
- uv run ruff check tests/test_arch_source_package.py tests/test_arch_bundle.py
- uv run pytest tests/test_arch_source_package.py::test_national_soi_source_package_aliases_validate_fixture_counts tests/test_arch_source_package.py::test_soi_table_2_5_eitc_child_totals_build_2022_facts tests/test_arch_bundle.py::test_build_bundle_writes_merged_consumer_contract -q