### PR TITLE
Add state EITC child-count SOI facts

### DIFF
--- a/arch/core.py
+++ b/arch/core.py
@@ -313,6 +313,30 @@ def build_aggregate_constraints(
         "filing_status",
         "income_range",
     }
+    child_count = fact.filters.get("eitc_child_count")
+    if child_count not in (None, "all"):
+        if child_count == "3plus":
+            constraints.append(
+                AggregateConstraint(
+                    variable="us.tax.earned_income_credit_qualifying_children",
+                    operator=">=",
+                    value=3,
+                    unit="count",
+                    label="EITC qualifying children",
+                )
+            )
+        else:
+            constraints.append(
+                AggregateConstraint(
+                    variable="us.tax.earned_income_credit_qualifying_children",
+                    operator="==",
+                    value=child_count,
+                    unit="count",
+                    label="EITC qualifying children",
+                )
+            )
+        handled_filters.add("eitc_child_count")
+
     for key, value in sorted(fact.filters.items()):
         if key in handled_filters or value in (None, "all"):
             continue

--- a/arch/suite.py
+++ b/arch/suite.py
@@ -60,6 +60,16 @@ SOI_HISTORIC_TABLE_2_AGI_STUB_RANGES = {
     9: ("500k_to_1m", 500_000, 1_000_000),
     10: ("1m_plus", 1_000_000, None),
 }
+SOI_EITC_CHILD_COUNT_COLUMN_VALUES = {
+    "N59661": 0,
+    "A59661": 0,
+    "N59662": 1,
+    "A59662": 1,
+    "N59663": 2,
+    "A59663": 2,
+    "N59664": 3,
+    "A59664": 3,
+}
 
 
 @dataclass(frozen=True)
@@ -941,6 +951,8 @@ def _row_semantic_evidence_issues(
             continue
         matched_values = _source_row_values(rows, variable)
         if not matched_values:
+            if _filter_evidenced_by_source_cells(cells, variable, value):
+                continue
             issues.append(
                 AgentAcceptanceIssue(
                     code="row_filter_not_evidenced",
@@ -1006,6 +1018,12 @@ def _constraint_evidenced_by_source_cells(
     cells: list[SourceCell],
     constraint: Any,
 ) -> bool:
+    if _is_eitc_qualifying_children_variable(str(constraint.variable)):
+        return _eitc_child_count_constraint_matches_cells(
+            cells,
+            constraint.operator,
+            constraint.value,
+        )
     if not _is_age_variable(str(constraint.variable)):
         return False
     ranges = [
@@ -1225,6 +1243,55 @@ def _age_band_constraint_range_matches(
     return False
 
 
+def _filter_evidenced_by_source_cells(
+    cells: list[SourceCell],
+    variable: str,
+    expected: Any,
+) -> bool:
+    if _normalize_semantic_name(variable) != "eitcchildcount":
+        return False
+    expected_count = _eitc_child_count_filter_value(expected)
+    if expected_count is None:
+        return False
+    return any(
+        source_count == expected_count
+        for source_count in _source_cell_eitc_child_count_values(cells)
+    )
+
+
+def _eitc_child_count_constraint_matches_cells(
+    cells: list[SourceCell],
+    operator: str,
+    expected: Any,
+) -> bool:
+    values = _source_cell_eitc_child_count_values(cells)
+    return bool(values) and any(
+        _constraint_matches_source_value(value, operator, expected)
+        for value in values
+    )
+
+
+def _source_cell_eitc_child_count_values(cells: list[SourceCell]) -> list[int]:
+    values = []
+    for cell in cells:
+        for value in (cell.raw_value, cell.display_value):
+            if value is None:
+                continue
+            code = str(value).strip().upper()
+            if code in SOI_EITC_CHILD_COUNT_COLUMN_VALUES:
+                values.append(SOI_EITC_CHILD_COUNT_COLUMN_VALUES[code])
+    return values
+
+
+def _eitc_child_count_filter_value(value: Any) -> int | None:
+    if isinstance(value, str) and value.strip().lower() in {"3plus", "3+"}:
+        return 3
+    number = _number_or_none(value)
+    if number is None:
+        return None
+    return int(number)
+
+
 def _source_cell_age_range(cell: SourceCell) -> tuple[int, int | None] | None:
     for value in (cell.raw_value, cell.display_value):
         if value is None:
@@ -1320,6 +1387,13 @@ def _is_age_variable(variable: str) -> bool:
     return any(candidate in {
         "age",
         "personage",
+    } for candidate in _semantic_name_candidates(variable))
+
+
+def _is_eitc_qualifying_children_variable(variable: str) -> bool:
+    return any(candidate in {
+        "earnedincomecreditqualifyingchildren",
+        "eitcqualifyingchildren",
     } for candidate in _semantic_name_candidates(variable))
 
 

--- a/packages/irs_soi/historic_table_2_state_eitc_2022/source_package.yaml
+++ b/packages/irs_soi/historic_table_2_state_eitc_2022/source_package.yaml
@@ -173,6 +173,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.ak
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.ak
@@ -229,6 +385,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.az
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.az
@@ -285,6 +597,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.ar
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.ar
@@ -341,6 +809,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.ca
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.ca
@@ -397,6 +1021,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.co
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.co
@@ -453,6 +1233,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.ct
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.ct
@@ -509,6 +1445,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.de
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.de
@@ -565,6 +1657,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.dc
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.dc
@@ -621,6 +1869,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.fl
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.fl
@@ -677,6 +2081,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.ga
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.ga
@@ -733,6 +2293,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.hi
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.hi
@@ -789,6 +2505,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.id
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.id
@@ -845,6 +2717,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.il
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.il
@@ -901,6 +2929,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.in
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.in
@@ -957,6 +3141,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.ia
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.ia
@@ -1013,6 +3353,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.ks
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.ks
@@ -1069,6 +3565,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.ky
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.ky
@@ -1125,6 +3777,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.la
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.la
@@ -1181,6 +3989,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.me
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.me
@@ -1237,6 +4201,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.md
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.md
@@ -1293,6 +4413,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.ma
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.ma
@@ -1349,6 +4625,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.mi
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.mi
@@ -1405,6 +4837,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.mn
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.mn
@@ -1461,6 +5049,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.ms
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.ms
@@ -1517,6 +5261,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.mo
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.mo
@@ -1573,6 +5473,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.mt
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.mt
@@ -1629,6 +5685,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.ne
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.ne
@@ -1685,6 +5897,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.nv
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.nv
@@ -1741,6 +6109,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.nh
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.nh
@@ -1797,6 +6321,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.nj
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.nj
@@ -1853,6 +6533,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.nm
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.nm
@@ -1909,6 +6745,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.ny
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.ny
@@ -1965,6 +6957,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.nc
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.nc
@@ -2021,6 +7169,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.nd
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.nd
@@ -2077,6 +7381,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.oh
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.oh
@@ -2133,6 +7593,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.ok
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.ok
@@ -2189,6 +7805,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.or
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.or
@@ -2245,6 +8017,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.pa
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.pa
@@ -2301,6 +8229,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.ri
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.ri
@@ -2357,6 +8441,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.sc
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.sc
@@ -2413,6 +8653,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.sd
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.sd
@@ -2469,6 +8865,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.tn
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.tn
@@ -2525,6 +9077,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.tx
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.tx
@@ -2581,6 +9289,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.ut
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.ut
@@ -2637,6 +9501,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.vt
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.vt
@@ -2693,6 +9713,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.va
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.va
@@ -2749,6 +9925,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.wa
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.wa
@@ -2805,6 +10137,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.wv
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.wv
@@ -2861,6 +10349,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.wi
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.wi
@@ -2917,6 +10561,162 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
 - record_set_id: irs_soi.ty2022.historic_table_2.state_eitc.wy
   record_set_spec_id: irs_soi.historic_table_2.state_eitc.v1
   source_record_id_prefix: irs_soi.ty2022.historic_table_2.state_eitc.wy
@@ -2973,3 +10773,159 @@ record_sets:
     expected_cell_type: number
     expected_column_header_row: 1
     expected_column_header: A59660
+  - measure_id: eitc_no_children_claims
+    label: Returns with earned income credit and no qualifying children
+    ordinal: 2
+    column: EB
+    source_column_id: N59661
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_no_children_amount
+    label: Earned income credit amount with no qualifying children
+    ordinal: 3
+    column: EC
+    source_column_id: A59661
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59661
+    filters:
+      eitc_child_count: '0'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 0
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_claims
+    label: Returns with earned income credit and one qualifying child
+    ordinal: 4
+    column: ED
+    source_column_id: N59662
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_one_child_amount
+    label: Earned income credit amount with one qualifying child
+    ordinal: 5
+    column: EE
+    source_column_id: A59662
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59662
+    filters:
+      eitc_child_count: '1'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 1
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_claims
+    label: Returns with earned income credit and two qualifying children
+    ordinal: 6
+    column: EF
+    source_column_id: N59663
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_two_children_amount
+    label: Earned income credit amount with two qualifying children
+    ordinal: 7
+    column: EG
+    source_column_id: A59663
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59663
+    filters:
+      eitc_child_count: '2'
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: ==
+      value: 2
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_claims
+    label: Returns with earned income credit and three or more qualifying children
+    ordinal: 8
+    column: EH
+    source_column_id: N59664
+    concept: irs_soi.returns_with_earned_income_credit
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: N59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children
+  - measure_id: eitc_three_or_more_children_amount
+    label: Earned income credit amount with three or more qualifying children
+    ordinal: 9
+    column: EI
+    source_column_id: A59664
+    concept: irs_soi.earned_income_credit
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: A59664
+    filters:
+      eitc_child_count: 3plus
+    constraints:
+    - variable: us.tax.earned_income_credit_qualifying_children
+      operator: '>='
+      value: 3
+      unit: count
+      label: EITC qualifying children

--- a/tests/test_arch_bundle.py
+++ b/tests/test_arch_bundle.py
@@ -29,7 +29,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "aggregate_duplicate_key_count": 0,
         "entity_count": 5,
         "error_count": 0,
-        "fact_count": 6585,
+        "fact_count": 6993,
         "geography_count": 54,
         "period_count": 5,
         "semantic_duplicate_key_count": 3,
@@ -38,18 +38,18 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "source_package_count": 22,
         "warning_count": 1,
     }
-    assert len(rows) == 6585
+    assert len(rows) == 6993
     assert rows[0]["aggregate_fact_key"].startswith("arch.aggregate_fact.v2:")
     assert rows[0]["semantic_fact_key"].startswith("arch.semantic_fact.v2:")
     assert source_packages["source_package_count"] == 22
     assert source_packages["skipped_source_count"] == 0
     assert not source_packages["skipped_sources"]
-    assert coverage["fact_count"] == 6585
+    assert coverage["fact_count"] == 6993
     assert coverage["counts"]["by_source"] == {
         "census_pep": 988,
         "cms_medicaid": 255,
         "hhs_acf_tanf": 110,
-        "irs_soi": 4959,
+        "irs_soi": 5367,
         "kff": 51,
         "ssa": 6,
         "usda_snap": 216,
@@ -72,7 +72,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "irs_soi:Historic Table 2": 605,
         "irs_soi:Historic Table 2 state AGI facts": 918,
         "irs_soi:Historic Table 2 state broad totals": 2703,
-        "irs_soi:Historic Table 2 state EITC totals": 102,
+        "irs_soi:Historic Table 2 state EITC totals": 510,
         "irs_soi:Publication 1304 Table 1.1": 80,
         "irs_soi:Publication 1304 Table 1.2": 7,
         "irs_soi:Publication 1304 Table 1.4": 260,
@@ -102,18 +102,18 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "calendar_year:2024": 1045,
         "fiscal_year:2024": 326,
         "month:2024-12": 255,
-        "tax_year:2022": 4560,
+        "tax_year:2022": 4968,
         "tax_year:2023": 399,
     }
     assert coverage["counts"]["by_geography"]["country:0100000US"] == 1273
-    assert coverage["counts"]["by_geography"]["state:0400000US06"] == 104
+    assert coverage["counts"]["by_geography"]["state:0400000US06"] == 112
     assert len(coverage["counts"]["by_geography"]) == 54
     assert coverage["counts"]["by_entity"] == {
         "family": 107,
         "government": 54,
         "household": 54,
         "person": 1411,
-        "tax_unit": 4959,
+        "tax_unit": 5367,
     }
     assert not coverage["duplicates"]["aggregate_fact_keys"]
     assert len(coverage["duplicates"]["semantic_fact_keys"]) == 3

--- a/tests/test_arch_source_package.py
+++ b/tests/test_arch_source_package.py
@@ -316,8 +316,8 @@ def test_national_soi_source_package_aliases_validate_fixture_counts():
         "soi-historic-table-2-state-eitc-2022": {
             "record_set_count": 51,
             "row_count": 51,
-            "measure_count": 102,
-            "source_record_count": 102,
+            "measure_count": 510,
+            "source_record_count": 510,
             "source_region_count": 51,
         },
         "soi-w2-statistics-2020": {
@@ -666,6 +666,45 @@ def test_soi_historic_table_2_state_broad_package_builds_2022_state_facts():
     assert ca_actc.value == 3_605_628_000
     assert ca_returns.geography.id == "0400000US06"
     assert ca_partnership.layout.source_column_id == "A26270"
+
+
+def test_soi_historic_table_2_state_eitc_package_builds_child_count_facts():
+    package = load_source_package("soi-historic-table-2-state-eitc-2022")
+    rows = package.build_source_rows(2023)
+    cells = package.build_source_cells(2023, source_rows=rows)
+    facts = package.build_facts(2023, cells=cells, source_rows=rows)
+    values_by_record = {fact.source_record_id: fact for fact in facts}
+
+    assert package.package_id == "soi-historic-table-2-state-eitc-2022"
+    assert validate_source_rows(rows).valid
+    assert validate_source_cells(cells).valid
+    assert validate_facts(facts).valid
+    assert len(facts) == 510
+
+    ca_one_child_amount = values_by_record[
+        "irs_soi.ty2022.historic_table_2.state_eitc.ca.ca."
+        "eitc_one_child_amount"
+    ]
+    ca_two_children_claims = values_by_record[
+        "irs_soi.ty2022.historic_table_2.state_eitc.ca.ca."
+        "eitc_two_children_claims"
+    ]
+    ca_three_or_more_amount = values_by_record[
+        "irs_soi.ty2022.historic_table_2.state_eitc.ca.ca."
+        "eitc_three_or_more_children_amount"
+    ]
+
+    assert ca_one_child_amount.value == 2_117_692_000
+    assert ca_two_children_claims.value == 550_910
+    assert ca_three_or_more_amount.value == 1_266_651_000
+    assert ca_one_child_amount.filters["eitc_child_count"] == 1
+    assert {
+        constraint.variable for constraint in ca_one_child_amount.constraints
+    } == {"us.tax.earned_income_credit_qualifying_children"}
+    assert {
+        constraint.operator for constraint in ca_three_or_more_amount.constraints
+    } == {">="}
+    assert ca_one_child_amount.geography.id == "0400000US06"
 
 
 def test_usda_snap_source_package_builds_fy24_national_and_state_facts():


### PR DESCRIPTION
## Summary
- add state-level SOI Historic Table 2 EITC child-count claim and amount facts
- teach Arch constraint fallback and source-suite evidence checks about EITC child-count column-coded categories
- update bundle coverage expectations for the additional IRS SOI facts

## Verification
- uv run ruff check arch/core.py arch/suite.py tests/test_arch_source_package.py tests/test_arch_bundle.py tests/test_arch_consumer_contract.py
- uv run pytest tests/test_arch_source_package.py::test_national_soi_source_package_aliases_validate_fixture_counts tests/test_arch_source_package.py::test_soi_historic_table_2_state_eitc_package_builds_child_count_facts tests/test_arch_bundle.py::test_build_bundle_writes_merged_consumer_contract tests/test_arch_consumer_contract.py -q
- built bundle artifact: /Users/maxghenis/CosilicoAI/microplex-us/artifacts/arch_soi_state_eitc_child_coverage_20260528/arch_bundle
- Microplex PR-9 coverage: 154 / 189 cells covered; EITC 4 / 4; state 66 / 73