### PR TITLE
Add Federal Reserve Z.1 net worth source package

### DIFF
--- a/arch/source_package.py
+++ b/arch/source_package.py
@@ -74,6 +74,9 @@ SOURCE_PACKAGE_ALIASES = {
     "cms-medicaid-chip-monthly-enrollment-december-2024": Path(
         "cms_medicaid/chip_monthly_enrollment_december_2024"
     ),
+    "federal-reserve-z1-household-net-worth": Path(
+        "federal_reserve/z1_household_net_worth"
+    ),
     "soi-table-1-1": Path("irs_soi/table_1_1"),
     "soi-table-1-2": Path("irs_soi/table_1_2"),
     "soi-table-1-4": Path("irs_soi/table_1_4"),

--- a/db/data/federal_reserve/z1_household_net_worth_2026/federal_reserve_z1_20260319_b101.html
+++ b/db/data/federal_reserve/z1_household_net_worth_2026/federal_reserve_z1_20260319_b101.html
@@ -1,0 +1,1407 @@
+<!doctype html>
+<html lang="en" class="no-js">
+    <head>
+        <meta charset="utf-8"/>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0 maximum-scale=1.6, user-scalable=1"/>
+        <meta name="keywords" content="Board of Governors of the Federal Reserve System, Federal Reserve Board of Governors, Federal Reserve Board, Federal Reserve" />
+        <meta name="description" content="The Federal Reserve Board of Governors in Washington DC." />
+        <meta property="og:type" content="article" /> 
+        <meta property="og:image"  content="/images/Social_Default_Image.jpg" /> 
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:image" content="/images/Social_Default_Image.jpg" />
+        
+        <title>The Fed - </title>
+        
+        <link href="/css/bootstrap.css" rel="stylesheet" type="text/css">
+        <link href="/css/bluesteel-theme.css" rel="stylesheet" type="text/css">
+        <link rel="stylesheet" href="/assets/main.css">
+        <script src="/assets/main.js" defer type="module"></script>
+        <script src="/js/modernizr-latest.js" type="text/javascript"></script>
+        <link href="/css/icons.data.svg.css" rel="stylesheet">           
+        <script src="/js/angular.min.js" type="text/javascript"></script>
+        <script src="/js/app.js" type="text/javascript"></script>
+        
+        <!-- For Linear Gradients in IE9 or greater -->
+        <!--[if gte IE 9]>
+            <style type="text/css">
+              .gradient {
+                 filter: none;
+              }
+            </style>
+        <![endif]-->
+
+ 
+    </head>
+    <body data-ng-app="pubwebApp">
+        <a href="#content" class="globalskip">Skip to main content</a>
+<nav class="nav-primary-mobile" id="nav-primary-mobile"></nav>
+<div id='top-banner' data-hydrate='true'><link rel="preload" as="image" href="/images/icon-us-flag.svg"/><link rel="preload" as="image" href="/images/expand_more.svg"/><link rel="preload" as="image" href="https://designsystem.digital.gov/assets/img/icon-dot-gov.svg"/><link rel="preload" as="image" href="https://designsystem.digital.gov/assets/img/icon-https.svg"/><div class="custom-banner"><div class="custom-banner__header"><div class="custom-banner__left"><img class="custom-banner__flag" src="/images/icon-us-flag.svg" width="20" height="20" alt="US Flag"/><p class="custom-banner__text">An official website of the United States Government</p></div><button type="button" class="custom-banner__button"><span class="custom-banner__button-text">Here&#x27;s how you know</span><img id="banner-caret-_R_0_" class="custom-banner__caret " src="/images/expand_more.svg" alt="Expand More"/></button></div><div class="custom-banner__content " id="banner-content-_R_0_"><div class="custom-banner__info"><div class="info-block"><img src="https://designsystem.digital.gov/assets/img/icon-dot-gov.svg" alt=".gov icon"/><p><strong>Official websites use .gov</strong><br/>A <strong>.gov</strong> website belongs to an official government organization in the United States.</p></div><div class="info-block"><img src="https://designsystem.digital.gov/assets/img/icon-https.svg" alt="HTTPS icon"/><p><strong>Secure .gov websites use HTTPS</strong><br/>A <strong>lock</strong> (<span class="icon-lock"><svg xmlns="http://www.w3.org/2000/svg" width="52" height="64" viewBox="0 0 52 64" role="img" aria-labelledby="banner-lock-description-_R_0_" focusable="false"><title id="banner-lock-title-_R_0_">Lock</title><desc id="banner-lock-description-_R_0_">Locked padlock icon</desc><path fill="#000000" fill-rule="evenodd" d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"></path></svg></span>) or <strong>https://</strong> means you&#x27;ve safely connected to the .gov website. Share sensitive information only on official, secure websites.</p></div></div></div></div></div><div class="t1_nav navbar navbar-default navbar-fixed-top" role="navigation">
+    <div class="t1_container clearfix">
+        <a id="logo" class="btn btn-default icon-FRB_logo-bw visible-xs-table-cell t1__btnlogo" href="/default.htm" role="button"><span class="sr-only">Back to Home</span></a>
+        <a href="/default.htm" id="banner" class="visible-xs-table-cell t1__banner" title="Link to Home Page" role="button">Board of Governors of the Federal Reserve System</a>
+        <ul class="nav navbar-nav visible-md visible-lg t1_toplinks">
+            <li class="navbar-text navbar-text__social">
+                <span class="navbar-link" tabindex="0">Stay Connected</span>
+            <ul class="nav navbar-nav t1_social social_ten">
+              <li class="social__item">
+                <a
+                  data-icon="facebook"
+                  href="https://www.facebook.com/federalreserve"
+                  class="noIcon"
+                >
+                  <div class="icon-facebook-color icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve Facebook Page</span
+                  ></a
+                >
+              </li>
+              <li class="social__item">
+                <a
+                  data-icon="instagram"
+                  href="https://www.instagram.com/federalreserveboard/"
+                  class="noIcon"
+                >
+                  <div class="icon-instagram icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve Instagram Page</span
+                  ></a
+                >
+              </li>
+
+              <li class="social__item">
+                <a
+                  data-icon="youtube"
+                  href="https://www.youtube.com/federalreserve"
+                  class="noIcon"
+                >
+                  <div class="icon-youtube-color icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve YouTube Page</span
+                  ></a
+                >
+              </li>
+
+              <li class="social__item">
+                <a
+                  data-icon="flickr"
+                  href="https://www.flickr.com/photos/federalreserve/"
+                  class="noIcon"
+                >
+                  <div class="icon-flickr-color icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve Flickr Page</span
+                  ></a
+                >
+              </li>
+
+              <li class="social__item">
+                <a
+                  data-icon="linkedin"
+                  href="https://www.linkedin.com/company/federal-reserve-board"
+                  class="noIcon"
+                >
+                  <div class="icon-linkedin-color icon icon__sm"></div>
+                  <span class="sr-only">Federal Reserve LinkedIn Page</span></a
+                >
+              </li>
+              <li class="social__item">
+                <a data-icon="threads" href="https://www.threads.net/@federalreserveboard" class="noIcon">
+                  <div class="icon-threads icon icon__sm"></div>
+                  <span class="sr-only">Federal Reserve Threads Page</span></a
+                >
+              </li>
+              <li class="social__item">
+                <a
+                  data-icon="twitter"
+                  href="https://x.com/federalreserve"
+                  class="noIcon"
+                >
+                  <div class="icon-social-x icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve X Page</span
+                  ></a
+                >
+              </li>
+              <li class="social__item">
+                <a
+                  data-icon="bluesky"
+                  href="https://bsky.app/profile/federalreserve.gov"
+                  class="noIcon"
+                >
+                  <div class="icon-bluesky icon icon__sm"></div>
+                  <span class="sr-only"
+                    >Federal Reserve Bluesky Page</span
+                  ></a
+                >
+              </li>
+              <li class="social__item">
+                <a data-icon="rss" href="/feeds/feeds.htm" class="noIcon">
+                  <div class="icon-rss-color icon icon__sm"></div>
+                  <span class="sr-only">Subscribe to RSS</span></a
+                >
+              </li>
+
+              <li class="social__item">
+                <a data-icon="email" href="/subscribe.htm" class="noIcon">
+                  <div class="icon-email-color icon icon__sm"></div>
+                  <span class="sr-only">Subscribe to Email</span></a
+                >
+              </li>
+                </ul>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/recentpostings.htm">Recent Postings</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/newsevents/calendar.htm">Calendar</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/publications.htm">Publications</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/sitemap.htm">Site Map</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/azindex.htm">A-Z index</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/careers.htm">Careers</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/faqs.htm">FAQs</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/videos.htm">Videos</a>
+            </li>
+
+            <li class="navbar-text">
+                <a class="navbar-link" href="/aboutthefed/contact-us-topics.htm">Contact</a>
+            </li>
+        </ul>
+        <form class="nav navbar-form hidden-xs nav__search" role="search" action="//www.fedsearch.org/board_public/search"  method="get">
+            <div class="form-group input-group input-group-sm">
+                <label for="t1search" class="sr-only">Search</label>
+                <input id="t1search" class="nav__input form-control" name="text" placeholder="Search" type="text" />
+                <span class="input-group-btn">
+                    <button type="submit" class="nav__button btn btn-default" id="headerTopLinksSearchFormSubmit" name="Search">
+                        <span class="sr-only">Submit Search Button</span>
+                        <span class="icon-magnifying-glass icon icon__xs icon--right"></span>
+                    </button>
+                </span>
+            </div>
+            <div class="nav__advanced">
+                <a class="noIcon" href="//www.fedsearch.org/board_public/">Advanced</a>
+            </div>
+        </form>
+        <div class="btn-group visible-xs-table-cell visible-sm-table-cell t1__dropdown">
+            <span class="icon icon__md icon--right dropdown-toggle icon-options-nav" data-toggle="dropdown">
+                <span class="sr-only">Toggle Dropdown Menu</span>
+            </span>
+        </div>
+    </div>
+</div>
+<header class="jumbotron hidden-xs">
+    <a class="jumbotron__link" href="/default.htm" title="Link to Home Page">
+        <div class="container-fluid">
+            <h1 class="jumbotron__heading">Board of Governors of the Federal Reserve System
+            </h1>
+            <p class="jumbotron__content">
+                <em>The Federal Reserve, the central bank of the United States, provides
+          the nation with a safe, flexible, and stable monetary and financial
+          system.</em>
+            </p>
+        </div>
+    </a>
+</header>
+<div class="t2__offcanvas visible-xs-block">
+    <div class="navbar-header">
+        <button type="button" class="offcanvas__toggle icon-offcanvas-nav" data-toggle="offcanvas" data-target="#offcanvasT2Menu" data-canvas="body">
+            <span class="sr-only">Main Menu Toggle Button</span>
+        </button>
+        <span class="navbar-brand offcanvas__title">Sections</span>
+        <button type="button" class="offcanvas__search icon-search-nav" data-toggle="collapse" data-target="#navbar-collapse">
+            <span class="sr-only">Search Toggle Button</span>
+        </button>
+    </div>
+    <div class="navbar-collapse collapse mobile-form" id="navbar-collapse">
+        <form method="get" class="navbar-form" role="search" action="//www.fedsearch.org/board_public/search">
+            <div class="form-group input-group mobileSearch">
+                <label class="sr-only" for="t2search">Search</label>
+                <input id="t2search" name="text" class="form-control" placeholder="Search" type="text" />
+                <span class="input-group-btn">
+                    <span class="sr-only">Search Submit Button</span>
+                    <button type="submit" class="btn btn-default">Submit</button>
+                </span>
+            </div>
+        </form>
+    </div>
+</div>
+<nav class="nav-primary navbar hidden-xs nav-nine" id="nav-primary" role="navigation">
+    <ul class="nav navbar-nav" role="menubar">
+        <li role="menuitem" class="dropdown nav-about dropdown--3Col">
+            <a href="/aboutthefed.htm" class="sr-only-focusable" aria-haspopup="true" id="aboutMenu">About<br />the Fed</a>
+            <ul aria-labelledby="aboutMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-4 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/fedexplained/who-we-are.htm">Structure of the Federal Reserve System</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/the-fed-explained.htm">The Fed Explained</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/bios/board/default.htm">Board Members</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/advisorydefault.htm">Advisory Councils</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/federal-reserve-system.htm">Federal Reserve Banks</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/directors/about.htm">Federal Reserve Bank and Branch Directors</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/fract.htm">Federal Reserve Act</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/currency.htm">Currency</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-4 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/boardmeetings/meetingdates.htm">Board Meetings</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/boardvotes.htm">Board Votes</a>
+                            </li>
+
+                            
+
+                            <li>
+                                <a class="sr-only-focusable" href="/careers.htm">Careers</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/procurement/tips.htm">Do Business with the Board</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/k8.htm">Holidays Observed - K.8</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/ethics-values.htm">Ethics & Values</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-4 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/contact-us-topics.htm">Contact</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/foia/about_foia.htm">Requesting Information (FOIA)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/faqs.htm">FAQs</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/educational-tools/default.htm">Economic Education</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/fed-financial-statements.htm">Fed Financial Statements</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/financial-innovation.htm">Financial Innovation</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-news dropdown--1Col">
+            <a href="/newsevents.htm" class="sr-only-focusable" aria-haspopup="true" id="newsMenu">News<br />& Events</a>
+            <ul aria-labelledby="newsMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <a class="sr-only-focusable" href="/newsevents/pressreleases.htm">Press Releases</a>
+                </li>
+                <li>
+                    <a class="sr-only-focusable" href="/newsevents/speeches-testimony.htm">Speeches & Testimony</a>
+                </li>
+                <li>
+                    <a class="sr-only-focusable" href="/newsevents/calendar.htm">Calendar</a>
+                </li>
+                <li>
+                    <a class="sr-only-focusable" href="/videos.htm">Videos</a>
+                </li>
+                <li>
+                    <a class="sr-only-focusable" href="/photogallery.htm">Photo Gallery</a>
+                </li>
+                <li>
+                    <a class="sr-only-focusable" href="/conferences.htm">Conferences</a>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-monetary dropdown--2Col">
+            <a href="/monetarypolicy.htm" class="sr-only-focusable" aria-haspopup="true" id="monetaryMenu">Monetary<br />Policy</a>
+            <ul aria-labelledby="monetaryMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-6 list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Federal Open Market Committee</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/fomc.htm">About the FOMC</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/fomccalendars.htm">Meeting calendars and information</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/fomc_historical.htm">Transcripts and other historical materials</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/fomc_projectionsfaqs.htm">FAQs</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Monetary Policy Principles and Practice</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/monetary-policy-principles-and-practice.htm">Notes</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-6 list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Policy Implementation</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/policy-normalization.htm">Policy Normalization</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/policytools.htm">Policy Tools</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Reports</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/publications/mpr_default.htm">Monetary Policy Report</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/publications/beige-book-default.htm">Beige Book</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/publications/balance-sheet-developments-report.htm">Federal Reserve Balance Sheet Developments</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Review of Monetary Policy Strategy, Tools, and Communications</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/monetarypolicy/review-of-monetary-policy-strategy-tools-and-communications-2025.htm">Overview</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-supervision dropdown--fw">
+    <a href="/supervisionreg.htm" class="sr-only-focusable" id="supervisionMenu"
+        aria-haspopup="true">Supervision<br />& Regulation</a>
+    <ul aria-labelledby="supervisionMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+        <li>
+            <div class="row">
+                <ul class="col-sm-3 col-nav list-unstyled">
+                    <li class="nav__header">
+                        <p>
+                            <strong>Supervision</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/community-banks.htm">
+                            Community Banks</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/regional-and-small-foreign-banks.htm">
+                            Regional Banks and Foreign Banks with U.S. Assets < &dollar;100 Billion</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/large-banks-and-large-foreign-banks.htm">
+                            Large Banks and Large Foreign Banks</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/global-systemically-important-banks.htm">
+                            Global Systemically Important Banks</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/financial-market-utility-supervision.htm">Financial Market
+                            Utilities</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/consumer-compliance.htm">Consumer
+                            Compliance</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/resources-for-supervised-institutions.htm">
+                            Resources for Supervised Institutions</a>
+                    </li>
+
+                    
+
+                    <li class="nav__header">
+                        <p>
+                            <strong>Reports</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/publications/supervision-and-regulation-report.htm">Federal Reserve
+                            Supervision and Regulation Report</a>
+                    </li>
+                </ul>
+                <ul class="col-sm-3 list-unstyled col-nav">
+                    <li class="nav__header">
+                        <p>
+                            <strong>Reporting Forms</strong>
+                        </p>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/apps/reportingforms/recentupdates">Recent Reporting Form Updates</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/apps/reportingforms/home/review">Information Collections
+                            Under Review</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/ReportingForms/?reportTypesIdsJson=["1"]'>Financial
+                            Statements</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/ReportingForms/?reportTypesIdsJson=["7"]'>Securities Exchange Act of 1934</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable"
+                            href='/apps/ReportingForms/?reportTypesIdsJson=["2"]'>Applications/Structure Change</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/ReportingForms/?reportTypesIdsJson=["3"]'>FFIEC</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/ReportingForms/?reportTypesIdsJson=["8"]'>Municipal and
+                            Government Securities</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/ReportingForms/?reportTypesIdsJson=["9"]'>Activities Monitoring</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href='/apps/mdrm/'>Micro Data Reference Manual</a>
+                    </li>
+
+                     
+
+                </ul>
+
+
+
+
+                <ul class="col-sm-3 list-unstyled col-nav">
+
+<li class="nav__header">
+                        <p>
+                            <strong>Legal Developments</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/legal-developments.htm">Enforcement Actions and
+                            Legal Developments</a>
+                    </li>
+
+
+                     <li class="nav__header">
+                        <p>
+                            <strong>Mergers, Acquisitions, and Other Applications</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/application-process.htm">Process</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/afi/afi.htm">Filing
+                            Information</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/board-and-reserve-bank-actions.htm">Board and Reserve
+                            Bank Actions</a>
+                    </li>
+
+                
+                    
+                    
+                    
+                </ul>
+
+                <ul class="col-sm-3 list-unstyled col-nav">
+
+<li class="nav__header">
+                        <p>
+                            <strong>Supervision and Regulation Letters</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/srletters/srletters.htm">By Year</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/topics/topics.htm">By Topic</a>
+                    </li>
+
+
+                    <li class="nav__header">
+                        <p>
+                            <strong>Regulatory and Policy Resources</strong>
+                        </p>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/aboutthefed/fract.htm">Federal Reserve Act</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/frrs/regulations/bank-holding-company-act-of-1956.htm">Bank Holding Company Act</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/reglisting.htm">Regulations</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/publications/supmanual.htm">Supervision Manuals</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/frrs/federal-reserve-regulatory-service.htm">Federal Reserve Regulatory Service</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/disaster-preparedness-and-recovery-resources.htm">Disaster Preparedness and Recovery Resources
+     </a>
+                    </li>
+
+
+                    
+                </ul>
+                <ul class="col-sm-3 list-unstyled col-nav">
+                    <li class="nav__header">
+                        <p>
+                            <strong>Banking and Data Structure</strong>
+                        </p>
+                    </li>
+
+                    
+
+                    <li>
+                        <a class="sr-only-focusable" href="/apps/reportforms/insider.aspx">Beneficial Ownership
+                            Reports</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/releases/lbr/">Large Commercial Banks</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/minority-depository-institutions.htm">Minority Depository
+                            Institutions</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/releases/iba/">U.S. Offices of Foreign Entities</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/fhc.htm">Financial Holding
+                            Companies</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/isb-default.htm">Interstate
+                            Branching</a>
+                    </li>
+
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/suds.htm">Securities
+                            Underwriting and Dealing Subsidiaries</a>
+                    </li>
+                    <li>
+                        <a class="sr-only-focusable" href="/supervisionreg/state-member-banks-supervised-federal-reserve.htm">State Member Banks Supervised by the Federal Reserve</a>
+                    </li>
+
+                    
+                </ul>
+            </div>
+        </li>
+    </ul>
+</li>
+
+
+
+
+
+
+        <li role="menuitem" class="dropdown nav-stability dropdown--2Col">
+            <a href="/financial-stability.htm" class="sr-only-focusable" aria-haspopup="true" id="stabilityMenu">Financial<br />Stability</a>
+            <ul aria-labelledby="stabilityMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <div class="row">
+                    <ul class="col-sm-6 list-unstyled">
+                        <li class="nav__header">
+                            <p>
+                                <strong>Financial Stability Assessments </strong>
+                            </p>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/what-is-financial-stability.htm">About Financial Stability</a>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/types-of-financial-system-vulnerabilities-and-risks.htm">Types of Financial System Vulnerabilities & Risks</a>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/monitoring-risk-across-the-financial-system.htm">Monitoring Risk Across the Financial System</a>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/proactive-monitoring-of-markets-and-institutions.htm">Proactive Monitoring of Markets & Institutions</a>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/financial-stability-and-stress-testing.htm">Financial Stability & Stress Testing</a>
+                        </li>
+                    </ul>
+                    <ul class="col-sm-6 list-unstyled">
+                        <li class="nav__header">
+                            <p>
+                                <strong>Financial Stability Coordination & Actions</strong>
+                            </p>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/responding-to-financial-system-emergencies.htm">Responding to Financial System Emergencies</a>
+                        </li>
+                        <li>
+                            <a class="sr-only-focusable" href="/financial-stability/cooperation-on-financial-stability.htm">Cooperation on Financial Stability</a>
+                        </li>
+                        <li class="nav__header">
+                            <p>
+                                <strong>Reports</strong>
+                            </p>
+                        </li>
+
+                        <li>
+                            <a class="sr-only-focusable" href="/publications/financial-stability-report.htm">Financial Stability Report</a>
+                        </li>
+                    </ul>
+                </div>
+            </ul>
+        </li>
+        <li role="menuitem" class="dropdown nav-payment dropdown--fw">
+            <a href="/paymentsystems.htm" class="sr-only-focusable" id="paymentMenu" aria-haspopup="true">Payment<br />Systems</a>
+            <ul aria-labelledby="paymentMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-3 col-nav list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Regulations & Statutes</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/regcc-about.htm">Regulation CC (Availability of Funds and Collection of Checks)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/regii-about.htm">Regulation II (Debit Card Interchange Fees and Routing)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/reghh-about.htm">Regulation HH (Financial Market Utilities)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/other-regulations.htm">Other Regulations and Statutes</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Payment Policies</strong>
+                                </p>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/pfs_about.htm">Federal Reserve's Key Policies for the Provision of Financial Services</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/joint_requests.htm">Guidelines for Evaluating Joint Account Requests</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/oo_about.htm">Overnight Overdrafts</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/psr_about.htm">Payment System Risk</a>
+                            </li>
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/telecomm.htm">Sponsorship for Priority Telecommunication Services</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Reserve Bank Payment Services & Data</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fedach_about.htm">Automated Clearinghouse Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/check_about.htm">Check Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/coin_about.htm">Currency and Coin Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/psr_data.htm">Daylight Overdrafts and Fees</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fednow_about.htm">FedNow<sup>&reg;</sup> Service</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fedfunds_about.htm">Fedwire Funds Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fedsecs_about.htm">Fedwire Securities Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fisagy_about.htm">Fiscal Agency Services</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/master-account-and-services-database-about.htm">Master Account and Services Database</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/natl_about.htm">National Settlement Service</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Financial Market Utilities & Infrastructures</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/over_about.htm">Supervision & Oversight of Financial Market Infrastructures</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/designated_fmu_about.htm">Designated Financial Market Utilities</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/int_standards.htm">International Standards for Financial Market Infrastructures</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Research, Reports, & Committees</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/fr-payments-study.htm">Federal Reserve Payments Study (FRPS)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/payres_about.htm">Payments Research</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/reports.htm">Reports</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/paymentsystems/pspa_committee.htm">Payments System Policy Advisory Committee</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-econ dropdown--right dropdown--2Col">
+            <a href="/econres.htm" class="sr-only-focusable" aria-haspopup="true" id="econMenu">Economic<br />Research</a>
+            <ul aria-labelledby="econMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-6 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/researchers.htm">Meet the Researchers</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Working Papers and Notes</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/feds/index.htm">Finance and Economics Discussion Series (FEDS)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/notes/feds-notes/default.htm">FEDS Notes</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/ifdp/index.htm">International Finance Discussion Papers (IFDP)</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-6 list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Data, Models and Tools</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/economic-research-data.htm">Economic Research Data</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/us-models-about.htm">FRB/US Model</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/edo-models-about.htm">Estimated Dynamic Optimization (EDO) Model</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/scfindex.htm">Survey of Consumer Finances (SCF)</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-data dropdown--right dropdown--fw">
+            <a href="/data.htm" class="sr-only-focusable" id="dataMenu" aria-haspopup="true">Data</a>
+            <ul aria-labelledby="dataMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-3 col-nav list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/datadownload"><span class="icon icon-ddp icon__sm"></span>Data Download Program</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Bank Assets and Liabilities</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h3/current/default.htm">Aggregate Reserves of Depository Institutions and the Monetary Base - H.3</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h8/current/default.htm">Assets and Liabilities of Commercial Banks in the U.S. - H.8</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/assetliab/current.htm">Assets and Liabilities of U.S. Branches and Agencies of Foreign Banks</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/chargeoff/">Charge-Off and Delinquency Rates on Loans and Leases at Commercial Banks</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/sfos/sfos.htm">Senior Financial Officer Survey</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/sloos.htm">Senior Loan Officer Opinion Survey on Bank Lending Practices</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Bank Structure Data</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/lbr/">Large Commercial Banks</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/supervisionreg/minority-depository-institutions.htm">Minority Depository Institutions</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/iba/default.htm">Structure and Share Data for the U.S. Offices of Foreign Banks</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Business Finance</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/cp/">Commercial Paper</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/g20/current/default.htm">Finance Companies - G.20</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/govsecure/current.htm">New Security Issues, State and Local Governments</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/corpsecure/current.htm">New Security Issues, U.S. Corporations</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Dealer Financing Terms</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/scoos.htm">Senior Credit Officer Opinion Survey on Dealer Financing Terms</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Exchange Rates and International Data</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h10/current/">Foreign Exchange Rates - H.10/G.5</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/intlsumm/current.htm">International Summary Statistics</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/secholdtrans/current.htm">Securities Holdings and Transactions</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/statbanksus/current.htm">Statistics Reported by Banks and Other Financial Firms in the United States</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/iba/default.htm">Structure and Share Data for U.S. Offices of Foreign Banks</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Financial Accounts</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/z1/default.htm">Financial Accounts of the United States - Z.1</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Household Finance</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/g19/current/default.htm">Consumer Credit - G.19</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/DSR">Household Debt Service Ratios</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/mortoutstand/current.htm">Mortgage Debt Outstanding</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/econres/scfindex.htm">Survey of Consumer Finances (SCF)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/shed.htm">Survey of Household Economics and Decisionmaking</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Industrial Activity</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/g17/current/default.htm">Industrial Production and Capacity Utilization - G.17</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Interest Rates</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h15/">Selected Interest Rates - H.15</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled col-nav">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Micro Data Reference Manual (MDRM)</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/mdrm.htm">Micro and Macro Data Collections</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Money Stock and Reserve Balances</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h41/">Factors Affecting Reserve Balances - H.4.1</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/releases/h6/current/default.htm">Money Stock Measures - H.6</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Other</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/data/yield-curve-models.htm">Yield Curve Models and Data</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+
+        <li role="menuitem" class="dropdown nav-consumer dropdown--right dropdown--4Col">
+            <a href="/consumerscommunities.htm" class="sr-only-focusable" aria-haspopup="true" id="consumerMenu">Consumers<br /> & Communities</a>
+            <ul aria-labelledby="consumerMenu" role="menu" class="dropdown-menu sub-nav-group navmenu-nav">
+                <li>
+                    <div class="row">
+                        <ul class="col-sm-3 list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Regulations</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/cra_about.htm">Community Reinvestment Act (CRA)</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/supervisionreg/reglisting.htm">All Regulations</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Supervision & Enforcement</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/supervisionreg/caletters/caletters.htm">CA Letters</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/apps/enforcementactions/default.aspx">Enforcement Actions</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/independent-foreclosure-review.htm">Independent Foreclosure Review</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled">
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Community Development</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/neighborhood-revitalization.htm">Housing and Neighborhood Revitalization</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/small-business-and-entrepreneurship.htm">Small Business and Entrepreneurship</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/workforce.htm">Employment and Workforce Development</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/cdf.htm">Community Development Finance</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/rural-community-economic-development.htm">Rural Community and Economic Development</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/conferences.htm">Conferences</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Research & Analysis</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/shed.htm">Survey of Household Economics and Decisionmaking</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/community-development-publications.htm">Research Publications & Data Analysis</a>
+                            </li>
+                        </ul>
+                        <ul class="col-sm-3 list-unstyled">
+                            <li>
+                                <a class="sr-only-focusable" href="/aboutthefed/cac.htm">Community Advisory Council</a>
+                            </li>
+
+                            <li class="nav__header">
+                                <p>
+                                    <strong>Resources for Consumers</strong>
+                                </p>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/fraud-scams.htm">Frauds and Scams</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/foreclosure.htm">Mortgage and Foreclosure Resources</a>
+                            </li>
+
+                            <li>
+                                <a class="sr-only-focusable" href="/consumerscommunities/comm-dev-system-map.htm">Federal Reserve Community Development Resources</a>
+                            </li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        </li>
+    </ul>
+</nav>
+        <div id="content" class="container container__main" role="main">
+            <div class="row">
+                <div class="page-header">
+                    <ol id="t3_nav" class="breadcrumb">
+                        
+                    </ol>
+                    <div class="btn-group header-group">
+                        <div id="page-title" class="btn-group pull-left">
+                            <h2>Financial Accounts of the United States - Z.1</h2>
+                        </div>
+                    </div>
+                </div>
+            </div>
+               
+
+
+       <!-- t4 -->
+        <div id="t4_nav" class="t4_nav t4_nav--horizontal sticky affix-top">
+            <ul class="" data-ng-controller="t4NavController" data-expandable-t4="" style="max-height: 200px;">
+                <li><a title="Current Release" class="active" href="/releases/z1/default.htm">Current Release</a></li>
+                <li><a title="Release Dates" href="/releases/z1/release-dates.htm"> Release Dates</a></li>
+                <li><a href="/releases/efa/enhanced-financial-accounts.htm">Enhanced Financial Accounts</a></li>
+                <li><a href="/apps/fof/">Financial Accounts Guide</a></li>
+                <li><a class="" href="/releases/z1/z1_technical_qa.htm">Technical Q&amp;As</a></li>
+                <li><a title="Announcements" class="" href="/feeds/z1.html">Announcements</a></li>
+            <li class="nav-expander ng-scope" data-ng-click="toggleNavExpansion($event)"><span class="icon icon__sm icon--centered icon-T4-expand"></span><div class="ng-binding">Show More<div></div></div></li></ul>
+        </div>
+        <!-- / End t4 -->
+        <!-- BEGIN DATA HERE -->
+
+           <div id="data-table-1" class="data-table" data-table-popout="" data-table-popout="">
+           <h5 class="tablehead" id="B101">B.101 Households and nonprofit organizations<sup><a href="#footnote-1" title="Footnote 1: Sector includes domestic hedge funds, private equity funds, and personal trusts. Supplementary balance sheet tables B.101.h and B.101.n show estimates of annual year-end outstandings of households and nonprofit organizations, respectively. Detail on the sector's indirect holdings of debt securities and equity is shown on table B.101.e.">1</a></sup></h5>
+           <p><span class="tableunit">Billions of dollars; amounts outstanding end of period, not seasonally adjusted</span> <table id="b101" title="Households and nonprofit organizations" data-sticky-columns="3" data-sticky-rows="1" class="pubtables" > <thead> <tr> <th id="r0" class="colhead">Line</th> <th id="d0" class="colhead">Description</th> <th id="s0" class="colhead">Series</th> <th id="t1" class="colhead">2023</th> <th id="t2" class="colhead">2024</th> <th id="t3" class="colhead">2025</th> <th id="t4" class="colhead">2024:Q3</th> <th id="t5" class="colhead">2024:Q4</th> <th id="t6" class="colhead">2025:Q1</th> <th id="t7" class="colhead">2025:Q2</th> <th id="t8" class="colhead">2025:Q3</th> <th id="t9" class="colhead">2025:Q4</th> </tr> </thead> <tbody> <tr> <th id="r1" headers="r0" class="stub sticky sticky-column-cell total" style="font-weight: bold; "><span class="globalskip">Line </span> 1</th> <th id="d1" headers="d0  r1" class="stub sticky sticky-column-cell total" style="font-weight: bold; ">Assets</th> <th id="s1" headers="s0 r1 d1" class="stub sticky sticky-column-cell total" style="font-weight: bold; "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL152000005&t=" title="Go to documentation for this series, FL152000005">FL152000005</a></th> <td id="x1t1" headers="t1 r1  d1 s1" class="totaldata" style="font-weight: bold; ">176573.6</td> <td id="x1t2" headers="t2 r1  d1 s1" class="totaldata" style="font-weight: bold; ">190464.4</td> <td id="x1t3" headers="t3 r1  d1 s1" class="totaldata" style="font-weight: bold; ">205613.3</td> <td id="x1t4" headers="t4 r1  d1 s1" class="totaldata" style="font-weight: bold; ">189742.8</td> <td id="x1t5" headers="t5 r1  d1 s1" class="totaldata" style="font-weight: bold; ">190464.4</td> <td id="x1t6" headers="t6 r1  d1 s1" class="totaldata" style="font-weight: bold; ">189620.3</td> <td id="x1t7" headers="t7 r1  d1 s1" class="totaldata" style="font-weight: bold; ">196729.5</td> <td id="x1t8" headers="t8 r1  d1 s1" class="totaldata" style="font-weight: bold; ">203202.0</td> <td id="x1t9" headers="t9 r1  d1 s1" class="totaldata" style="font-weight: bold; ">205613.3</td> </tr> <tr> <th id="r2" headers="r0" class="stub sticky sticky-column-cell" style="font-weight: bold; "><span class="globalskip">Line </span> 2</th> <th id="d2" headers="d0 d1 r2" class="stub sticky sticky-column-cell in1" style="font-weight: bold; ">Nonfinancial assets</th> <th id="s2" headers="s0 r2 d2" class="stub sticky sticky-column-cell" style="font-weight: bold; "><a href="/apps/fof/SeriesAnalyzer.aspx?s=LM152010005&t=" title="Go to documentation for this series, LM152010005">LM152010005</a></th> <td id="x2t1" headers="t1 r2 d1 d2 s2" class="data" style="font-weight: bold; ">57671.9</td> <td id="x2t2" headers="t2 r2 d1 d2 s2" class="data" style="font-weight: bold; ">60083.1</td> <td id="x2t3" headers="t3 r2 d1 d2 s2" class="data" style="font-weight: bold; ">61747.4</td> <td id="x2t4" headers="t4 r2 d1 d2 s2" class="data" style="font-weight: bold; ">60333.3</td> <td id="x2t5" headers="t5 r2 d1 d2 s2" class="data" style="font-weight: bold; ">60083.1</td> <td id="x2t6" headers="t6 r2 d1 d2 s2" class="data" style="font-weight: bold; ">60707.3</td> <td id="x2t7" headers="t7 r2 d1 d2 s2" class="data" style="font-weight: bold; ">62000.1</td> <td id="x2t8" headers="t8 r2 d1 d2 s2" class="data" style="font-weight: bold; ">61953.4</td> <td id="x2t9" headers="t9 r2 d1 d2 s2" class="data" style="font-weight: bold; ">61747.4</td> </tr> <tr> <th id="r3" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 3</th> <th id="d3" headers="d0 d1 d2 r3" class="stub sticky sticky-column-cell in2" style=" ">Real estate</th> <th id="s3" headers="s0 r3 d3" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=LM155035005&t=" title="Go to documentation for this series, LM155035005">LM155035005</a></th> <td id="x3t1" headers="t1 r3 d1 d2 d3 s3" class="data" style=" ">48903.5</td> <td id="x3t2" headers="t2 r3 d1 d2 d3 s3" class="data" style=" ">51014.6</td> <td id="x3t3" headers="t3 r3 d1 d2 d3 s3" class="data" style=" ">52066.9</td> <td id="x3t4" headers="t4 r3 d1 d2 d3 s3" class="data" style=" ">51372.6</td> <td id="x3t5" headers="t5 r3 d1 d2 d3 s3" class="data" style=" ">51014.6</td> <td id="x3t6" headers="t6 r3 d1 d2 d3 s3" class="data" style=" ">51499.1</td> <td id="x3t7" headers="t7 r3 d1 d2 d3 s3" class="data" style=" ">52601.3</td> <td id="x3t8" headers="t8 r3 d1 d2 d3 s3" class="data" style=" ">52413.6</td> <td id="x3t9" headers="t9 r3 d1 d2 d3 s3" class="data" style=" ">52066.9</td> </tr> <tr> <th id="r4" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 4</th> <th id="d4" headers="d0 d1 d2 d3 r4" class="stub sticky sticky-column-cell in3" style=" ">Households<sup><a href="#footnote-2" title="Footnote 2: All types of owner-occupied housing including farm houses and mobile homes, as well as second homes that are not rented, vacant homes for sale, and vacant land. At market value.">2</a></sup></th> <th id="s4" headers="s0 r4 d4" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=LM155035015&t=" title="Go to documentation for this series, LM155035015">LM155035015</a></th> <td id="x4t1" headers="t1 r4 d1 d2 d3 d4 s4" class="data" style=" ">44796.5</td> <td id="x4t2" headers="t2 r4 d1 d2 d3 d4 s4" class="data" style=" ">46928.3</td> <td id="x4t3" headers="t3 r4 d1 d2 d3 d4 s4" class="data" style=" ">47915.6</td> <td id="x4t4" headers="t4 r4 d1 d2 d3 d4 s4" class="data" style=" ">47315.5</td> <td id="x4t5" headers="t5 r4 d1 d2 d3 d4 s4" class="data" style=" ">46928.3</td> <td id="x4t6" headers="t6 r4 d1 d2 d3 d4 s4" class="data" style=" ">47490.6</td> <td id="x4t7" headers="t7 r4 d1 d2 d3 d4 s4" class="data" style=" ">48637.9</td> <td id="x4t8" headers="t8 r4 d1 d2 d3 d4 s4" class="data" style=" ">48269.9</td> <td id="x4t9" headers="t9 r4 d1 d2 d3 d4 s4" class="data" style=" ">47915.6</td> </tr> <tr> <th id="r5" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 5</th> <th id="d5" headers="d0 d1 d2 d3 r5" class="stub sticky sticky-column-cell in3" style=" ">Nonprofit organizations</th> <th id="s5" headers="s0 r5 d5" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=LM165035005&t=" title="Go to documentation for this series, LM165035005">LM165035005</a></th> <td id="x5t1" headers="t1 r5 d1 d2 d3 d5 s5" class="data" style=" ">4107.0</td> <td id="x5t2" headers="t2 r5 d1 d2 d3 d5 s5" class="data" style=" ">4086.3</td> <td id="x5t3" headers="t3 r5 d1 d2 d3 d5 s5" class="data" style=" ">4151.3</td> <td id="x5t4" headers="t4 r5 d1 d2 d3 d5 s5" class="data" style=" ">4057.1</td> <td id="x5t5" headers="t5 r5 d1 d2 d3 d5 s5" class="data" style=" ">4086.3</td> <td id="x5t6" headers="t6 r5 d1 d2 d3 d5 s5" class="data" style=" ">4008.5</td> <td id="x5t7" headers="t7 r5 d1 d2 d3 d5 s5" class="data" style=" ">3963.4</td> <td id="x5t8" headers="t8 r5 d1 d2 d3 d5 s5" class="data" style=" ">4143.7</td> <td id="x5t9" headers="t9 r5 d1 d2 d3 d5 s5" class="data" style=" ">4151.3</td> </tr> <tr> <th id="r6" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 6</th> <th id="d6" headers="d0 d1 d2 r6" class="stub sticky sticky-column-cell in2" style=" ">Equipment (nonprofits)<sup><a href="#footnote-3" title="Footnote 3: At replacement (current) cost.">3</a></sup></th> <th id="s6" headers="s0 r6 d6" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=LM165015205&t=" title="Go to documentation for this series, LM165015205">LM165015205</a></th> <td id="x6t1" headers="t1 r6 d1 d2 d6 s6" class="data" style=" ">653.5</td> <td id="x6t2" headers="t2 r6 d1 d2 d6 s6" class="data" style=" ">681.7</td> <td id="x6t3" headers="t3 r6 d1 d2 d6 s6" class="data" style=" ">729.4</td> <td id="x6t4" headers="t4 r6 d1 d2 d6 s6" class="data" style=" ">676.8</td> <td id="x6t5" headers="t5 r6 d1 d2 d6 s6" class="data" style=" ">681.7</td> <td id="x6t6" headers="t6 r6 d1 d2 d6 s6" class="data" style=" ">688.0</td> <td id="x6t7" headers="t7 r6 d1 d2 d6 s6" class="data" style=" ">699.8</td> <td id="x6t8" headers="t8 r6 d1 d2 d6 s6" class="data" style=" ">716.3</td> <td id="x6t9" headers="t9 r6 d1 d2 d6 s6" class="data" style=" ">729.4</td> </tr> <tr> <th id="r7" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 7</th> <th id="d7" headers="d0 d1 d2 r7" class="stub sticky sticky-column-cell in2" style=" ">Intellectual property products (nonprofits)<sup><a href="#footnote-3" title="Footnote 3: At replacement (current) cost.">3</a></sup></th> <th id="s7" headers="s0 r7 d7" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=LM165013765&t=" title="Go to documentation for this series, LM165013765">LM165013765</a></th> <td id="x7t1" headers="t1 r7 d1 d2 d7 s7" class="data" style=" ">258.3</td> <td id="x7t2" headers="t2 r7 d1 d2 d7 s7" class="data" style=" ">275.6</td> <td id="x7t3" headers="t3 r7 d1 d2 d7 s7" class="data" style=" ">297.5</td> <td id="x7t4" headers="t4 r7 d1 d2 d7 s7" class="data" style=" ">270.5</td> <td id="x7t5" headers="t5 r7 d1 d2 d7 s7" class="data" style=" ">275.6</td> <td id="x7t6" headers="t6 r7 d1 d2 d7 s7" class="data" style=" ">279.1</td> <td id="x7t7" headers="t7 r7 d1 d2 d7 s7" class="data" style=" ">282.1</td> <td id="x7t8" headers="t8 r7 d1 d2 d7 s7" class="data" style=" ">289.5</td> <td id="x7t9" headers="t9 r7 d1 d2 d7 s7" class="data" style=" ">297.5</td> </tr> <tr> <th id="r8" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 8</th> <th id="d8" headers="d0 d1 d2 r8" class="stub sticky sticky-column-cell in2" style=" ">Consumer durable goods<sup><a href="#footnote-3" title="Footnote 3: At replacement (current) cost.">3</a></sup></th> <th id="s8" headers="s0 r8 d8" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=LM155111005&t=" title="Go to documentation for this series, LM155111005">LM155111005</a></th> <td id="x8t1" headers="t1 r8 d1 d2 d8 s8" class="data" style=" ">7856.6</td> <td id="x8t2" headers="t2 r8 d1 d2 d8 s8" class="data" style=" ">8111.2</td> <td id="x8t3" headers="t3 r8 d1 d2 d8 s8" class="data" style=" ">8653.5</td> <td id="x8t4" headers="t4 r8 d1 d2 d8 s8" class="data" style=" ">8013.4</td> <td id="x8t5" headers="t5 r8 d1 d2 d8 s8" class="data" style=" ">8111.2</td> <td id="x8t6" headers="t6 r8 d1 d2 d8 s8" class="data" style=" ">8241.1</td> <td id="x8t7" headers="t7 r8 d1 d2 d8 s8" class="data" style=" ">8416.9</td> <td id="x8t8" headers="t8 r8 d1 d2 d8 s8" class="data" style=" ">8534.0</td> <td id="x8t9" headers="t9 r8 d1 d2 d8 s8" class="data" style=" ">8653.5</td> </tr> <tr> <th id="r9" headers="r0" class="stub sticky sticky-column-cell" style="font-weight: bold; "><span class="globalskip">Line </span> 9</th> <th id="d9" headers="d0 d1 r9" class="stub sticky sticky-column-cell in1" style="font-weight: bold; ">Financial assets</th> <th id="s9" headers="s0 r9 d9" class="stub sticky sticky-column-cell" style="font-weight: bold; "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL154090005&t=" title="Go to documentation for this series, FL154090005">FL154090005</a></th> <td id="x9t1" headers="t1 r9 d1 d9 s9" class="data" style="font-weight: bold; ">118901.7</td> <td id="x9t2" headers="t2 r9 d1 d9 s9" class="data" style="font-weight: bold; ">130381.3</td> <td id="x9t3" headers="t3 r9 d1 d9 s9" class="data" style="font-weight: bold; ">143865.9</td> <td id="x9t4" headers="t4 r9 d1 d9 s9" class="data" style="font-weight: bold; ">129409.5</td> <td id="x9t5" headers="t5 r9 d1 d9 s9" class="data" style="font-weight: bold; ">130381.3</td> <td id="x9t6" headers="t6 r9 d1 d9 s9" class="data" style="font-weight: bold; ">128913.0</td> <td id="x9t7" headers="t7 r9 d1 d9 s9" class="data" style="font-weight: bold; ">134729.3</td> <td id="x9t8" headers="t8 r9 d1 d9 s9" class="data" style="font-weight: bold; ">141248.6</td> <td id="x9t9" headers="t9 r9 d1 d9 s9" class="data" style="font-weight: bold; ">143865.9</td> </tr> <tr> <th id="r10" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 10</th> <th id="d10" headers="d0 d1 d9 r10" class="stub sticky sticky-column-cell in2" style=" ">Checkable deposits and currency</th> <th id="s10" headers="s0 r10 d10" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL153020005&t=" title="Go to documentation for this series, FL153020005">FL153020005</a></th> <td id="x10t1" headers="t1 r10 d1 d9 d10 s10" class="data" style=" ">4424.1</td> <td id="x10t2" headers="t2 r10 d1 d9 d10 s10" class="data" style=" ">4636.3</td> <td id="x10t3" headers="t3 r10 d1 d9 d10 s10" class="data" style=" ">5934.9</td> <td id="x10t4" headers="t4 r10 d1 d9 d10 s10" class="data" style=" ">4474.5</td> <td id="x10t5" headers="t5 r10 d1 d9 d10 s10" class="data" style=" ">4636.3</td> <td id="x10t6" headers="t6 r10 d1 d9 d10 s10" class="data" style=" ">4897.9</td> <td id="x10t7" headers="t7 r10 d1 d9 d10 s10" class="data" style=" ">4915.8</td> <td id="x10t8" headers="t8 r10 d1 d9 d10 s10" class="data" style=" ">4830.2</td> <td id="x10t9" headers="t9 r10 d1 d9 d10 s10" class="data" style=" ">5934.9</td> </tr> <tr> <th id="r11" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 11</th> <th id="d11" headers="d0 d1 d9 r11" class="stub sticky sticky-column-cell in2" style=" ">Time and savings deposits</th> <th id="s11" headers="s0 r11 d11" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL153030005&t=" title="Go to documentation for this series, FL153030005">FL153030005</a></th> <td id="x11t1" headers="t1 r11 d1 d9 d11 s11" class="data" style=" ">9836.3</td> <td id="x11t2" headers="t2 r11 d1 d9 d11 s11" class="data" style=" ">9802.1</td> <td id="x11t3" headers="t3 r11 d1 d9 d11 s11" class="data" style=" ">9208.9</td> <td id="x11t4" headers="t4 r11 d1 d9 d11 s11" class="data" style=" ">9742.7</td> <td id="x11t5" headers="t5 r11 d1 d9 d11 s11" class="data" style=" ">9802.1</td> <td id="x11t6" headers="t6 r11 d1 d9 d11 s11" class="data" style=" ">9833.6</td> <td id="x11t7" headers="t7 r11 d1 d9 d11 s11" class="data" style=" ">9832.8</td> <td id="x11t8" headers="t8 r11 d1 d9 d11 s11" class="data" style=" ">9949.8</td> <td id="x11t9" headers="t9 r11 d1 d9 d11 s11" class="data" style=" ">9208.9</td> </tr> <tr> <th id="r12" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 12</th> <th id="d12" headers="d0 d1 d9 r12" class="stub sticky sticky-column-cell in2" style=" ">Other deposits</th> <th id="s12" headers="s0 r12 d12" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=LM153030505&t=" title="Go to documentation for this series, LM153030505">LM153030505</a></th> <td id="x12t1" headers="t1 r12 d1 d9 d12 s12" class="data" style=" ">50.8</td> <td id="x12t2" headers="t2 r12 d1 d9 d12 s12" class="data" style=" ">56.6</td> <td id="x12t3" headers="t3 r12 d1 d9 d12 s12" class="data" style=" ">68.3</td> <td id="x12t4" headers="t4 r12 d1 d9 d12 s12" class="data" style=" ">57.5</td> <td id="x12t5" headers="t5 r12 d1 d9 d12 s12" class="data" style=" ">56.6</td> <td id="x12t6" headers="t6 r12 d1 d9 d12 s12" class="data" style=" ">58.5</td> <td id="x12t7" headers="t7 r12 d1 d9 d12 s12" class="data" style=" ">61.3</td> <td id="x12t8" headers="t8 r12 d1 d9 d12 s12" class="data" style=" ">66.3</td> <td id="x12t9" headers="t9 r12 d1 d9 d12 s12" class="data" style=" ">68.3</td> </tr> <tr> <th id="r13" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 13</th> <th id="d13" headers="d0 d1 d9 r13" class="stub sticky sticky-column-cell in2" style=" ">Money market fund shares</th> <th id="s13" headers="s0 r13 d13" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL153034005&t=" title="Go to documentation for this series, FL153034005">FL153034005</a></th> <td id="x13t1" headers="t1 r13 d1 d9 d13 s13" class="data" style=" ">4029.5</td> <td id="x13t2" headers="t2 r13 d1 d9 d13 s13" class="data" style=" ">4709.2</td> <td id="x13t3" headers="t3 r13 d1 d9 d13 s13" class="data" style=" ">5320.6</td> <td id="x13t4" headers="t4 r13 d1 d9 d13 s13" class="data" style=" ">4397.7</td> <td id="x13t5" headers="t5 r13 d1 d9 d13 s13" class="data" style=" ">4709.2</td> <td id="x13t6" headers="t6 r13 d1 d9 d13 s13" class="data" style=" ">4797.4</td> <td id="x13t7" headers="t7 r13 d1 d9 d13 s13" class="data" style=" ">4849.4</td> <td id="x13t8" headers="t8 r13 d1 d9 d13 s13" class="data" style=" ">5038.0</td> <td id="x13t9" headers="t9 r13 d1 d9 d13 s13" class="data" style=" ">5320.6</td> </tr> <tr> <th id="r14" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 14</th> <th id="d14" headers="d0 d1 d9 r14" class="stub sticky sticky-column-cell in2" style=" ">Debt securities</th> <th id="s14" headers="s0 r14 d14" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=LM154022005&t=" title="Go to documentation for this series, LM154022005">LM154022005</a></th> <td id="x14t1" headers="t1 r14 d1 d9 d14 s14" class="data" style=" ">5556.9</td> <td id="x14t2" headers="t2 r14 d1 d9 d14 s14" class="data" style=" ">5812.9</td> <td id="x14t3" headers="t3 r14 d1 d9 d14 s14" class="data" style=" ">6147.4</td> <td id="x14t4" headers="t4 r14 d1 d9 d14 s14" class="data" style=" ">5888.8</td> <td id="x14t5" headers="t5 r14 d1 d9 d14 s14" class="data" style=" ">5812.9</td> <td id="x14t6" headers="t6 r14 d1 d9 d14 s14" class="data" style=" ">5811.9</td> <td id="x14t7" headers="t7 r14 d1 d9 d14 s14" class="data" style=" ">6002.6</td> <td id="x14t8" headers="t8 r14 d1 d9 d14 s14" class="data" style=" ">6051.6</td> <td id="x14t9" headers="t9 r14 d1 d9 d14 s14" class="data" style=" ">6147.4</td> </tr> <tr> <th id="r15" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 15</th> <th id="d15" headers="d0 d1 d9 d14 r15" class="stub sticky sticky-column-cell in3" style=" ">Treasury securities</th> <th id="s15" headers="s0 r15 d15" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=LM153061105&t=" title="Go to documentation for this series, LM153061105">LM153061105</a></th> <td id="x15t1" headers="t1 r15 d1 d9 d14 d15 s15" class="data" style=" ">2515.4</td> <td id="x15t2" headers="t2 r15 d1 d9 d14 d15 s15" class="data" style=" ">2626.3</td> <td id="x15t3" headers="t3 r15 d1 d9 d14 d15 s15" class="data" style=" ">2944.6</td> <td id="x15t4" headers="t4 r15 d1 d9 d14 d15 s15" class="data" style=" ">2737.2</td> <td id="x15t5" headers="t5 r15 d1 d9 d14 d15 s15" class="data" style=" ">2626.3</td> <td id="x15t6" headers="t6 r15 d1 d9 d14 d15 s15" class="data" style=" ">2731.0</td> <td id="x15t7" headers="t7 r15 d1 d9 d14 d15 s15" class="data" style=" ">2875.7</td> <td id="x15t8" headers="t8 r15 d1 d9 d14 d15 s15" class="data" style=" ">2889.5</td> <td id="x15t9" headers="t9 r15 d1 d9 d14 d15 s15" class="data" style=" ">2944.6</td> </tr> <tr> <th id="r16" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 16</th> <th id="d16" headers="d0 d1 d9 d14 r16" class="stub sticky sticky-column-cell in3" style=" ">Agency- and GSE-backed securities</th> <th id="s16" headers="s0 r16 d16" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=LM153061705&t=" title="Go to documentation for this series, LM153061705">LM153061705</a></th> <td id="x16t1" headers="t1 r16 d1 d9 d14 d16 s16" class="data" style=" ">972.7</td> <td id="x16t2" headers="t2 r16 d1 d9 d14 d16 s16" class="data" style=" ">1050.4</td> <td id="x16t3" headers="t3 r16 d1 d9 d14 d16 s16" class="data" style=" ">948.1</td> <td id="x16t4" headers="t4 r16 d1 d9 d14 d16 s16" class="data" style=" ">976.0</td> <td id="x16t5" headers="t5 r16 d1 d9 d14 d16 s16" class="data" style=" ">1050.4</td> <td id="x16t6" headers="t6 r16 d1 d9 d14 d16 s16" class="data" style=" ">947.7</td> <td id="x16t7" headers="t7 r16 d1 d9 d14 d16 s16" class="data" style=" ">957.0</td> <td id="x16t8" headers="t8 r16 d1 d9 d14 d16 s16" class="data" style=" ">926.5</td> <td id="x16t9" headers="t9 r16 d1 d9 d14 d16 s16" class="data" style=" ">948.1</td> </tr> <tr> <th id="r17" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 17</th> <th id="d17" headers="d0 d1 d9 d14 r17" class="stub sticky sticky-column-cell in3" style=" ">Municipal securities</th> <th id="s17" headers="s0 r17 d17" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=LM153062005&t=" title="Go to documentation for this series, LM153062005">LM153062005</a></th> <td id="x17t1" headers="t1 r17 d1 d9 d14 d17 s17" class="data" style=" ">1869.8</td> <td id="x17t2" headers="t2 r17 d1 d9 d14 d17 s17" class="data" style=" ">1941.1</td> <td id="x17t3" headers="t3 r17 d1 d9 d14 d17 s17" class="data" style=" ">2060.7</td> <td id="x17t4" headers="t4 r17 d1 d9 d14 d17 s17" class="data" style=" ">1977.8</td> <td id="x17t5" headers="t5 r17 d1 d9 d14 d17 s17" class="data" style=" ">1941.1</td> <td id="x17t6" headers="t6 r17 d1 d9 d14 d17 s17" class="data" style=" ">1938.2</td> <td id="x17t7" headers="t7 r17 d1 d9 d14 d17 s17" class="data" style=" ">1975.2</td> <td id="x17t8" headers="t8 r17 d1 d9 d14 d17 s17" class="data" style=" ">2040.7</td> <td id="x17t9" headers="t9 r17 d1 d9 d14 d17 s17" class="data" style=" ">2060.7</td> </tr> <tr> <th id="r18" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 18</th> <th id="d18" headers="d0 d1 d9 d14 r18" class="stub sticky sticky-column-cell in3" style=" ">Corporate and foreign bonds</th> <th id="s18" headers="s0 r18 d18" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=LM153063005&t=" title="Go to documentation for this series, LM153063005">LM153063005</a></th> <td id="x18t1" headers="t1 r18 d1 d9 d14 d18 s18" class="data" style=" ">199.0</td> <td id="x18t2" headers="t2 r18 d1 d9 d14 d18 s18" class="data" style=" ">195.0</td> <td id="x18t3" headers="t3 r18 d1 d9 d14 d18 s18" class="data" style=" ">194.0</td> <td id="x18t4" headers="t4 r18 d1 d9 d14 d18 s18" class="data" style=" ">197.8</td> <td id="x18t5" headers="t5 r18 d1 d9 d14 d18 s18" class="data" style=" ">195.0</td> <td id="x18t6" headers="t6 r18 d1 d9 d14 d18 s18" class="data" style=" ">195.0</td> <td id="x18t7" headers="t7 r18 d1 d9 d14 d18 s18" class="data" style=" ">194.8</td> <td id="x18t8" headers="t8 r18 d1 d9 d14 d18 s18" class="data" style=" ">194.8</td> <td id="x18t9" headers="t9 r18 d1 d9 d14 d18 s18" class="data" style=" ">194.0</td> </tr> <tr> <th id="r19" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 19</th> <th id="d19" headers="d0 d1 d9 r19" class="stub sticky sticky-column-cell in2" style=" ">Loans</th> <th id="s19" headers="s0 r19 d19" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL154023005&t=" title="Go to documentation for this series, FL154023005">FL154023005</a></th> <td id="x19t1" headers="t1 r19 d1 d9 d19 s19" class="data" style=" ">1355.9</td> <td id="x19t2" headers="t2 r19 d1 d9 d19 s19" class="data" style=" ">1201.2</td> <td id="x19t3" headers="t3 r19 d1 d9 d19 s19" class="data" style=" ">1245.7</td> <td id="x19t4" headers="t4 r19 d1 d9 d19 s19" class="data" style=" ">1428.0</td> <td id="x19t5" headers="t5 r19 d1 d9 d19 s19" class="data" style=" ">1201.2</td> <td id="x19t6" headers="t6 r19 d1 d9 d19 s19" class="data" style=" ">1249.2</td> <td id="x19t7" headers="t7 r19 d1 d9 d19 s19" class="data" style=" ">1245.0</td> <td id="x19t8" headers="t8 r19 d1 d9 d19 s19" class="data" style=" ">1256.4</td> <td id="x19t9" headers="t9 r19 d1 d9 d19 s19" class="data" style=" ">1245.7</td> </tr> <tr> <th id="r20" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 20</th> <th id="d20" headers="d0 d1 d9 d19 r20" class="stub sticky sticky-column-cell in3" style=" ">Other loans and advances<sup><a href="#footnote-4" title="Footnote 4: Includes nonmarketable Treasury securities, cash accounts at brokers and dealers, and syndicated loans to nonfinancial corporate business by nonprofits and domestic hedge funds.">4</a></sup></th> <th id="s20" headers="s0 r20 d20" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL153069005&t=" title="Go to documentation for this series, FL153069005">FL153069005</a></th> <td id="x20t1" headers="t1 r20 d1 d9 d19 d20 s20" class="data" style=" ">1263.4</td> <td id="x20t2" headers="t2 r20 d1 d9 d19 d20 s20" class="data" style=" ">1115.4</td> <td id="x20t3" headers="t3 r20 d1 d9 d19 d20 s20" class="data" style=" ">1168.9</td> <td id="x20t4" headers="t4 r20 d1 d9 d19 d20 s20" class="data" style=" ">1341.6</td> <td id="x20t5" headers="t5 r20 d1 d9 d19 d20 s20" class="data" style=" ">1115.4</td> <td id="x20t6" headers="t6 r20 d1 d9 d19 d20 s20" class="data" style=" ">1165.1</td> <td id="x20t7" headers="t7 r20 d1 d9 d19 d20 s20" class="data" style=" ">1162.3</td> <td id="x20t8" headers="t8 r20 d1 d9 d19 d20 s20" class="data" style=" ">1176.0</td> <td id="x20t9" headers="t9 r20 d1 d9 d19 d20 s20" class="data" style=" ">1168.9</td> </tr> <tr> <th id="r21" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 21</th> <th id="d21" headers="d0 d1 d9 d19 r21" class="stub sticky sticky-column-cell in3" style=" ">Mortgages</th> <th id="s21" headers="s0 r21 d21" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL153065005&t=" title="Go to documentation for this series, FL153065005">FL153065005</a></th> <td id="x21t1" headers="t1 r21 d1 d9 d19 d21 s21" class="data" style=" ">73.9</td> <td id="x21t2" headers="t2 r21 d1 d9 d19 d21 s21" class="data" style=" ">70.4</td> <td id="x21t3" headers="t3 r21 d1 d9 d19 d21 s21" class="data" style=" ">64.5</td> <td id="x21t4" headers="t4 r21 d1 d9 d19 d21 s21" class="data" style=" ">71.5</td> <td id="x21t5" headers="t5 r21 d1 d9 d19 d21 s21" class="data" style=" ">70.4</td> <td id="x21t6" headers="t6 r21 d1 d9 d19 d21 s21" class="data" style=" ">69.1</td> <td id="x21t7" headers="t7 r21 d1 d9 d19 d21 s21" class="data" style=" ">68.0</td> <td id="x21t8" headers="t8 r21 d1 d9 d19 d21 s21" class="data" style=" ">66.0</td> <td id="x21t9" headers="t9 r21 d1 d9 d19 d21 s21" class="data" style=" ">64.5</td> </tr> <tr> <th id="r22" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 22</th> <th id="d22" headers="d0 d1 d9 d19 r22" class="stub sticky sticky-column-cell in3" style=" ">Consumer credit (student loans)<sup><a href="#footnote-5" title="Footnote 5: Student loans and trade receivables are financial assets of nonprofit organizations; municipal securities, commercial mortgages, and trade payables are liabilities.">5</a></sup></th> <th id="s22" headers="s0 r22 d22" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL163066223&t=" title="Go to documentation for this series, FL163066223">FL163066223</a></th> <td id="x22t1" headers="t1 r22 d1 d9 d19 d22 s22" class="data" style=" ">18.6</td> <td id="x22t2" headers="t2 r22 d1 d9 d19 d22 s22" class="data" style=" ">15.4</td> <td id="x22t3" headers="t3 r22 d1 d9 d19 d22 s22" class="data" style=" ">12.4</td> <td id="x22t4" headers="t4 r22 d1 d9 d19 d22 s22" class="data" style=" ">14.9</td> <td id="x22t5" headers="t5 r22 d1 d9 d19 d22 s22" class="data" style=" ">15.4</td> <td id="x22t6" headers="t6 r22 d1 d9 d19 d22 s22" class="data" style=" ">15.1</td> <td id="x22t7" headers="t7 r22 d1 d9 d19 d22 s22" class="data" style=" ">14.7</td> <td id="x22t8" headers="t8 r22 d1 d9 d19 d22 s22" class="data" style=" ">14.4</td> <td id="x22t9" headers="t9 r22 d1 d9 d19 d22 s22" class="data" style=" ">12.4</td> </tr> <tr> <th id="r23" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 23</th> <th id="d23" headers="d0 d1 d9 r23" class="stub sticky sticky-column-cell in2" style=" ">Corporate equities</th> <th id="s23" headers="s0 r23 d23" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=LM153064105&t=" title="Go to documentation for this series, LM153064105">LM153064105</a></th> <td id="x23t1" headers="t1 r23 d1 d9 d23 s23" class="data" style=" ">32247.7</td> <td id="x23t2" headers="t2 r23 d1 d9 d23 s23" class="data" style=" ">39055.0</td> <td id="x23t3" headers="t3 r23 d1 d9 d23 s23" class="data" style=" ">47185.8</td> <td id="x23t4" headers="t4 r23 d1 d9 d23 s23" class="data" style=" ">38333.2</td> <td id="x23t5" headers="t5 r23 d1 d9 d23 s23" class="data" style=" ">39055.0</td> <td id="x23t6" headers="t6 r23 d1 d9 d23 s23" class="data" style=" ">37751.1</td> <td id="x23t7" headers="t7 r23 d1 d9 d23 s23" class="data" style=" ">41264.5</td> <td id="x23t8" headers="t8 r23 d1 d9 d23 s23" class="data" style=" ">45740.4</td> <td id="x23t9" headers="t9 r23 d1 d9 d23 s23" class="data" style=" ">47185.8</td> </tr> <tr> <th id="r24" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 24</th> <th id="d24" headers="d0 d1 d9 r24" class="stub sticky sticky-column-cell in2" style=" ">Miscellaneous other equity</th> <th id="s24" headers="s0 r24 d24" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=LM153081115&t=" title="Go to documentation for this series, LM153081115">LM153081115</a></th> <td id="x24t1" headers="t1 r24 d1 d9 d24 s24" class="data" style=" ">15593.4</td> <td id="x24t2" headers="t2 r24 d1 d9 d24 s24" class="data" style=" ">15837.1</td> <td id="x24t3" headers="t3 r24 d1 d9 d24 s24" class="data" style=" ">16001.1</td> <td id="x24t4" headers="t4 r24 d1 d9 d24 s24" class="data" style=" ">15734.4</td> <td id="x24t5" headers="t5 r24 d1 d9 d24 s24" class="data" style=" ">15837.1</td> <td id="x24t6" headers="t6 r24 d1 d9 d24 s24" class="data" style=" ">15772.4</td> <td id="x24t7" headers="t7 r24 d1 d9 d24 s24" class="data" style=" ">15752.1</td> <td id="x24t8" headers="t8 r24 d1 d9 d24 s24" class="data" style=" ">16015.8</td> <td id="x24t9" headers="t9 r24 d1 d9 d24 s24" class="data" style=" ">16001.1</td> </tr> <tr> <th id="r25" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 25</th> <th id="d25" headers="d0 d1 d9 r25" class="stub sticky sticky-column-cell in2" style=" ">Mutual fund shares</th> <th id="s25" headers="s0 r25 d25" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=LM153064205&t=" title="Go to documentation for this series, LM153064205">LM153064205</a></th> <td id="x25t1" headers="t1 r25 d1 d9 d25 s25" class="data" style=" ">11084.3</td> <td id="x25t2" headers="t2 r25 d1 d9 d25 s25" class="data" style=" ">12328.8</td> <td id="x25t3" headers="t3 r25 d1 d9 d25 s25" class="data" style=" ">13680.2</td> <td id="x25t4" headers="t4 r25 d1 d9 d25 s25" class="data" style=" ">12543.0</td> <td id="x25t5" headers="t5 r25 d1 d9 d25 s25" class="data" style=" ">12328.8</td> <td id="x25t6" headers="t6 r25 d1 d9 d25 s25" class="data" style=" ">12056.5</td> <td id="x25t7" headers="t7 r25 d1 d9 d25 s25" class="data" style=" ">12994.3</td> <td id="x25t8" headers="t8 r25 d1 d9 d25 s25" class="data" style=" ">13598.4</td> <td id="x25t9" headers="t9 r25 d1 d9 d25 s25" class="data" style=" ">13680.2</td> </tr> <tr> <th id="r26" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 26</th> <th id="d26" headers="d0 d1 d9 r26" class="stub sticky sticky-column-cell in2" style=" ">Life insurance reserves</th> <th id="s26" headers="s0 r26 d26" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL153040005&t=" title="Go to documentation for this series, FL153040005">FL153040005</a></th> <td id="x26t1" headers="t1 r26 d1 d9 d26 s26" class="data" style=" ">2060.5</td> <td id="x26t2" headers="t2 r26 d1 d9 d26 s26" class="data" style=" ">2161.9</td> <td id="x26t3" headers="t3 r26 d1 d9 d26 s26" class="data" style=" ">2201.2</td> <td id="x26t4" headers="t4 r26 d1 d9 d26 s26" class="data" style=" ">2150.8</td> <td id="x26t5" headers="t5 r26 d1 d9 d26 s26" class="data" style=" ">2161.9</td> <td id="x26t6" headers="t6 r26 d1 d9 d26 s26" class="data" style=" ">2135.8</td> <td id="x26t7" headers="t7 r26 d1 d9 d26 s26" class="data" style=" ">2169.5</td> <td id="x26t8" headers="t8 r26 d1 d9 d26 s26" class="data" style=" ">2192.9</td> <td id="x26t9" headers="t9 r26 d1 d9 d26 s26" class="data" style=" ">2201.2</td> </tr> <tr> <th id="r27" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 27</th> <th id="d27" headers="d0 d1 d9 r27" class="stub sticky sticky-column-cell in2" style=" ">Pension entitlements<sup><a href="#footnote-6" title="Footnote 6: Includes public and private defined benefit and defined contribution pension plans and annuities, including those in IRAs and at life insurance companies. Excludes social security.">6</a></sup></th> <th id="s27" headers="s0 r27 d27" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL153050005&t=" title="Go to documentation for this series, FL153050005">FL153050005</a></th> <td id="x27t1" headers="t1 r27 d1 d9 d27 s27" class="data" style=" ">30632.1</td> <td id="x27t2" headers="t2 r27 d1 d9 d27 s27" class="data" style=" ">32620.7</td> <td id="x27t3" headers="t3 r27 d1 d9 d27 s27" class="data" style=" ">34591.6</td> <td id="x27t4" headers="t4 r27 d1 d9 d27 s27" class="data" style=" ">32535.3</td> <td id="x27t5" headers="t5 r27 d1 d9 d27 s27" class="data" style=" ">32620.7</td> <td id="x27t6" headers="t6 r27 d1 d9 d27 s27" class="data" style=" ">32359.6</td> <td id="x27t7" headers="t7 r27 d1 d9 d27 s27" class="data" style=" ">33425.5</td> <td id="x27t8" headers="t8 r27 d1 d9 d27 s27" class="data" style=" ">34268.6</td> <td id="x27t9" headers="t9 r27 d1 d9 d27 s27" class="data" style=" ">34591.6</td> </tr> <tr> <th id="r28" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 28</th> <th id="d28" headers="d0 d1 d9 r28" class="stub sticky sticky-column-cell in2" style=" ">Trade receivables<sup><a href="#footnote-5" title="Footnote 5: Student loans and trade receivables are financial assets of nonprofit organizations; municipal securities, commercial mortgages, and trade payables are liabilities.">5</a></sup></th> <th id="s28" headers="s0 r28 d28" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL163070005&t=" title="Go to documentation for this series, FL163070005">FL163070005</a></th> <td id="x28t1" headers="t1 r28 d1 d9 d28 s28" class="data" style=" ">414.5</td> <td id="x28t2" headers="t2 r28 d1 d9 d28 s28" class="data" style=" ">451.0</td> <td id="x28t3" headers="t3 r28 d1 d9 d28 s28" class="data" style=" ">487.1</td> <td id="x28t4" headers="t4 r28 d1 d9 d28 s28" class="data" style=" ">441.9</td> <td id="x28t5" headers="t5 r28 d1 d9 d28 s28" class="data" style=" ">451.0</td> <td id="x28t6" headers="t6 r28 d1 d9 d28 s28" class="data" style=" ">460.1</td> <td id="x28t7" headers="t7 r28 d1 d9 d28 s28" class="data" style=" ">469.1</td> <td id="x28t8" headers="t8 r28 d1 d9 d28 s28" class="data" style=" ">478.1</td> <td id="x28t9" headers="t9 r28 d1 d9 d28 s28" class="data" style=" ">487.1</td> </tr> <tr> <th id="r29" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 29</th> <th id="d29" headers="d0 d1 d9 r29" class="stub sticky sticky-column-cell in2" style=" ">Miscellaneous assets</th> <th id="s29" headers="s0 r29 d29" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL153090005&t=" title="Go to documentation for this series, FL153090005">FL153090005</a></th> <td id="x29t1" headers="t1 r29 d1 d9 d29 s29" class="data" style=" ">1615.6</td> <td id="x29t2" headers="t2 r29 d1 d9 d29 s29" class="data" style=" ">1708.5</td> <td id="x29t3" headers="t3 r29 d1 d9 d29 s29" class="data" style=" ">1793.1</td> <td id="x29t4" headers="t4 r29 d1 d9 d29 s29" class="data" style=" ">1681.7</td> <td id="x29t5" headers="t5 r29 d1 d9 d29 s29" class="data" style=" ">1708.5</td> <td id="x29t6" headers="t6 r29 d1 d9 d29 s29" class="data" style=" ">1729.1</td> <td id="x29t7" headers="t7 r29 d1 d9 d29 s29" class="data" style=" ">1747.5</td> <td id="x29t8" headers="t8 r29 d1 d9 d29 s29" class="data" style=" ">1762.0</td> <td id="x29t9" headers="t9 r29 d1 d9 d29 s29" class="data" style=" ">1793.1</td> </tr> <tr> <th id="r30" headers="r0" class="stub sticky sticky-column-cell total" style="font-weight: bold; "><span class="globalskip">Line </span> 30</th> <th id="d30" headers="d0  r30" class="stub sticky sticky-column-cell total" style="font-weight: bold; ">Liabilities</th> <th id="s30" headers="s0 r30 d30" class="stub sticky sticky-column-cell total" style="font-weight: bold; "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL154190005&t=" title="Go to documentation for this series, FL154190005">FL154190005</a></th> <td id="x30t1" headers="t1 r30  d30 s30" class="totaldata" style="font-weight: bold; ">20492.9</td> <td id="x30t2" headers="t2 r30  d30 s30" class="totaldata" style="font-weight: bold; ">20845.2</td> <td id="x30t3" headers="t3 r30  d30 s30" class="totaldata" style="font-weight: bold; ">21507.7</td> <td id="x30t4" headers="t4 r30  d30 s30" class="totaldata" style="font-weight: bold; ">20895.9</td> <td id="x30t5" headers="t5 r30  d30 s30" class="totaldata" style="font-weight: bold; ">20845.2</td> <td id="x30t6" headers="t6 r30  d30 s30" class="totaldata" style="font-weight: bold; ">20860.8</td> <td id="x30t7" headers="t7 r30  d30 s30" class="totaldata" style="font-weight: bold; ">21031.9</td> <td id="x30t8" headers="t8 r30  d30 s30" class="totaldata" style="font-weight: bold; ">21269.3</td> <td id="x30t9" headers="t9 r30  d30 s30" class="totaldata" style="font-weight: bold; ">21507.7</td> </tr> <tr> <th id="r31" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 31</th> <th id="d31" headers="d0 d30 r31" class="stub sticky sticky-column-cell in1" style=" ">Debt securities (municipal securities)<sup><a href="#footnote-5" title="Footnote 5: Student loans and trade receivables are financial assets of nonprofit organizations; municipal securities, commercial mortgages, and trade payables are liabilities.">5</a></sup></th> <th id="s31" headers="s0 r31 d31" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL163162003&t=" title="Go to documentation for this series, FL163162003">FL163162003</a></th> <td id="x31t1" headers="t1 r31 d30 d31 s31" class="data" style=" ">207.9</td> <td id="x31t2" headers="t2 r31 d30 d31 s31" class="data" style=" ">216.3</td> <td id="x31t3" headers="t3 r31 d30 d31 s31" class="data" style=" ">232.5</td> <td id="x31t4" headers="t4 r31 d30 d31 s31" class="data" style=" ">215.7</td> <td id="x31t5" headers="t5 r31 d30 d31 s31" class="data" style=" ">216.3</td> <td id="x31t6" headers="t6 r31 d30 d31 s31" class="data" style=" ">218.3</td> <td id="x31t7" headers="t7 r31 d30 d31 s31" class="data" style=" ">224.5</td> <td id="x31t8" headers="t8 r31 d30 d31 s31" class="data" style=" ">227.8</td> <td id="x31t9" headers="t9 r31 d30 d31 s31" class="data" style=" ">232.5</td> </tr> <tr> <th id="r32" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 32</th> <th id="d32" headers="d0 d30 r32" class="stub sticky sticky-column-cell in1" style=" ">Loans</th> <th id="s32" headers="s0 r32 d32" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL154123005&t=" title="Go to documentation for this series, FL154123005">FL154123005</a></th> <td id="x32t1" headers="t1 r32 d30 d32 s32" class="data" style=" ">19748.8</td> <td id="x32t2" headers="t2 r32 d30 d32 s32" class="data" style=" ">20074.6</td> <td id="x32t3" headers="t3 r32 d30 d32 s32" class="data" style=" ">20702.1</td> <td id="x32t4" headers="t4 r32 d30 d32 s32" class="data" style=" ">20130.5</td> <td id="x32t5" headers="t5 r32 d30 d32 s32" class="data" style=" ">20074.6</td> <td id="x32t6" headers="t6 r32 d30 d32 s32" class="data" style=" ">20080.9</td> <td id="x32t7" headers="t7 r32 d30 d32 s32" class="data" style=" ">20242.0</td> <td id="x32t8" headers="t8 r32 d30 d32 s32" class="data" style=" ">20474.6</td> <td id="x32t9" headers="t9 r32 d30 d32 s32" class="data" style=" ">20702.1</td> </tr> <tr> <th id="r33" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 33</th> <th id="d33" headers="d0 d30 d32 r33" class="stub sticky sticky-column-cell in2" style=" ">One-to-four-family residential mortgages<sup><a href="#footnote-7" title="Footnote 7: Includes loans made under home equity lines of credit and home equity loans secured by junior liens (table L.218, line 23).">7</a></sup></th> <th id="s33" headers="s0 r33 d33" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL153165105&t=" title="Go to documentation for this series, FL153165105">FL153165105</a></th> <td id="x33t1" headers="t1 r33 d30 d32 d33 s33" class="data" style=" ">13017.1</td> <td id="x33t2" headers="t2 r33 d30 d32 d33 s33" class="data" style=" ">13381.2</td> <td id="x33t3" headers="t3 r33 d30 d32 d33 s33" class="data" style=" ">13767.1</td> <td id="x33t4" headers="t4 r33 d30 d32 d33 s33" class="data" style=" ">13270.2</td> <td id="x33t5" headers="t5 r33 d30 d32 d33 s33" class="data" style=" ">13381.2</td> <td id="x33t6" headers="t6 r33 d30 d32 d33 s33" class="data" style=" ">13433.8</td> <td id="x33t7" headers="t7 r33 d30 d32 d33 s33" class="data" style=" ">13550.6</td> <td id="x33t8" headers="t8 r33 d30 d32 d33 s33" class="data" style=" ">13667.8</td> <td id="x33t9" headers="t9 r33 d30 d32 d33 s33" class="data" style=" ">13767.1</td> </tr> <tr> <th id="r34" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 34</th> <th id="d34" headers="d0 d30 d32 r34" class="stub sticky sticky-column-cell in2" style=" ">Consumer credit</th> <th id="s34" headers="s0 r34 d34" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL153166000&t=" title="Go to documentation for this series, FL153166000">FL153166000</a></th> <td id="x34t1" headers="t1 r34 d30 d32 d34 s34" class="data" style=" ">4988.2</td> <td id="x34t2" headers="t2 r34 d30 d32 d34 s34" class="data" style=" ">4948.1</td> <td id="x34t3" headers="t3 r34 d30 d32 d34 s34" class="data" style=" ">5106.6</td> <td id="x34t4" headers="t4 r34 d30 d32 d34 s34" class="data" style=" ">5027.8</td> <td id="x34t5" headers="t5 r34 d30 d32 d34 s34" class="data" style=" ">4948.1</td> <td id="x34t6" headers="t6 r34 d30 d32 d34 s34" class="data" style=" ">4963.4</td> <td id="x34t7" headers="t7 r34 d30 d32 d34 s34" class="data" style=" ">4996.3</td> <td id="x34t8" headers="t8 r34 d30 d32 d34 s34" class="data" style=" ">5042.3</td> <td id="x34t9" headers="t9 r34 d30 d32 d34 s34" class="data" style=" ">5106.6</td> </tr> <tr> <th id="r35" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 35</th> <th id="d35" headers="d0 d30 d32 r35" class="stub sticky sticky-column-cell in2" style=" ">Depository institution loans n.e.c.</th> <th id="s35" headers="s0 r35 d35" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL153168005&t=" title="Go to documentation for this series, FL153168005">FL153168005</a></th> <td id="x35t1" headers="t1 r35 d30 d32 d35 s35" class="data" style=" ">475.3</td> <td id="x35t2" headers="t2 r35 d30 d32 d35 s35" class="data" style=" ">347.5</td> <td id="x35t3" headers="t3 r35 d30 d32 d35 s35" class="data" style=" ">234.7</td> <td id="x35t4" headers="t4 r35 d30 d32 d35 s35" class="data" style=" ">478.9</td> <td id="x35t5" headers="t5 r35 d30 d32 d35 s35" class="data" style=" ">347.5</td> <td id="x35t6" headers="t6 r35 d30 d32 d35 s35" class="data" style=" ">277.7</td> <td id="x35t7" headers="t7 r35 d30 d32 d35 s35" class="data" style=" ">238.8</td> <td id="x35t8" headers="t8 r35 d30 d32 d35 s35" class="data" style=" ">233.7</td> <td id="x35t9" headers="t9 r35 d30 d32 d35 s35" class="data" style=" ">234.7</td> </tr> <tr> <th id="r36" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 36</th> <th id="d36" headers="d0 d30 d32 r36" class="stub sticky sticky-column-cell in2" style=" ">Other loans and advances</th> <th id="s36" headers="s0 r36 d36" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL153169005&t=" title="Go to documentation for this series, FL153169005">FL153169005</a></th> <td id="x36t1" headers="t1 r36 d30 d32 d36 s36" class="data" style=" ">737.9</td> <td id="x36t2" headers="t2 r36 d30 d32 d36 s36" class="data" style=" ">849.1</td> <td id="x36t3" headers="t3 r36 d30 d32 d36 s36" class="data" style=" ">1004.3</td> <td id="x36t4" headers="t4 r36 d30 d32 d36 s36" class="data" style=" ">806.5</td> <td id="x36t5" headers="t5 r36 d30 d32 d36 s36" class="data" style=" ">849.1</td> <td id="x36t6" headers="t6 r36 d30 d32 d36 s36" class="data" style=" ">851.8</td> <td id="x36t7" headers="t7 r36 d30 d32 d36 s36" class="data" style=" ">892.3</td> <td id="x36t8" headers="t8 r36 d30 d32 d36 s36" class="data" style=" ">953.0</td> <td id="x36t9" headers="t9 r36 d30 d32 d36 s36" class="data" style=" ">1004.3</td> </tr> <tr> <th id="r37" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 37</th> <th id="d37" headers="d0 d30 d32 r37" class="stub sticky sticky-column-cell in2" style=" ">Commercial mortgages<sup><a href="#footnote-5" title="Footnote 5: Student loans and trade receivables are financial assets of nonprofit organizations; municipal securities, commercial mortgages, and trade payables are liabilities.">5</a></sup></th> <th id="s37" headers="s0 r37 d37" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL163165505&t=" title="Go to documentation for this series, FL163165505">FL163165505</a></th> <td id="x37t1" headers="t1 r37 d30 d32 d37 s37" class="data" style=" ">530.3</td> <td id="x37t2" headers="t2 r37 d30 d32 d37 s37" class="data" style=" ">548.8</td> <td id="x37t3" headers="t3 r37 d30 d32 d37 s37" class="data" style=" ">589.3</td> <td id="x37t4" headers="t4 r37 d30 d32 d37 s37" class="data" style=" ">547.1</td> <td id="x37t5" headers="t5 r37 d30 d32 d37 s37" class="data" style=" ">548.8</td> <td id="x37t6" headers="t6 r37 d30 d32 d37 s37" class="data" style=" ">554.3</td> <td id="x37t7" headers="t7 r37 d30 d32 d37 s37" class="data" style=" ">564.1</td> <td id="x37t8" headers="t8 r37 d30 d32 d37 s37" class="data" style=" ">577.8</td> <td id="x37t9" headers="t9 r37 d30 d32 d37 s37" class="data" style=" ">589.3</td> </tr> <tr> <th id="r38" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 38</th> <th id="d38" headers="d0 d30 r38" class="stub sticky sticky-column-cell in1" style=" ">Trade payables<sup><a href="#footnote-5" title="Footnote 5: Student loans and trade receivables are financial assets of nonprofit organizations; municipal securities, commercial mortgages, and trade payables are liabilities.">5</a></sup></th> <th id="s38" headers="s0 r38 d38" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL163170005&t=" title="Go to documentation for this series, FL163170005">FL163170005</a></th> <td id="x38t1" headers="t1 r38 d30 d38 s38" class="data" style=" ">496.9</td> <td id="x38t2" headers="t2 r38 d30 d38 s38" class="data" style=" ">514.8</td> <td id="x38t3" headers="t3 r38 d30 d38 s38" class="data" style=" ">532.0</td> <td id="x38t4" headers="t4 r38 d30 d38 s38" class="data" style=" ">510.3</td> <td id="x38t5" headers="t5 r38 d30 d38 s38" class="data" style=" ">514.8</td> <td id="x38t6" headers="t6 r38 d30 d38 s38" class="data" style=" ">519.1</td> <td id="x38t7" headers="t7 r38 d30 d38 s38" class="data" style=" ">523.4</td> <td id="x38t8" headers="t8 r38 d30 d38 s38" class="data" style=" ">527.7</td> <td id="x38t9" headers="t9 r38 d30 d38 s38" class="data" style=" ">532.0</td> </tr> <tr> <th id="r39" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 39</th> <th id="d39" headers="d0 d30 r39" class="stub sticky sticky-column-cell in1" style=" ">Deferred and unpaid life insurance premiums</th> <th id="s39" headers="s0 r39 d39" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL543077073&t=" title="Go to documentation for this series, FL543077073">FL543077073</a></th> <td id="x39t1" headers="t1 r39 d30 d39 s39" class="data" style=" ">39.4</td> <td id="x39t2" headers="t2 r39 d30 d39 s39" class="data" style=" ">39.5</td> <td id="x39t3" headers="t3 r39 d30 d39 s39" class="data" style=" ">41.1</td> <td id="x39t4" headers="t4 r39 d30 d39 s39" class="data" style=" ">39.4</td> <td id="x39t5" headers="t5 r39 d30 d39 s39" class="data" style=" ">39.5</td> <td id="x39t6" headers="t6 r39 d30 d39 s39" class="data" style=" ">42.4</td> <td id="x39t7" headers="t7 r39 d30 d39 s39" class="data" style=" ">42.0</td> <td id="x39t8" headers="t8 r39 d30 d39 s39" class="data" style=" ">39.2</td> <td id="x39t9" headers="t9 r39 d30 d39 s39" class="data" style=" ">41.1</td> </tr> <tr> <th id="r40" headers="r0" class="stub sticky sticky-column-cell total" style="font-weight: bold; "><span class="globalskip">Line </span> 40</th> <th id="d40" headers="d0  r40" class="stub sticky sticky-column-cell total" style="font-weight: bold; ">Net worth (assets minus liabilities)</th> <th id="s40" headers="s0 r40 d40" class="stub sticky sticky-column-cell total" style="font-weight: bold; "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL152090005&t=" title="Go to documentation for this series, FL152090005">FL152090005</a></th> <td id="x40t1" headers="t1 r40  d40 s40" class="totaldata" style="font-weight: bold; ">156080.7</td> <td id="x40t2" headers="t2 r40  d40 s40" class="totaldata" style="font-weight: bold; ">169619.2</td> <td id="x40t3" headers="t3 r40  d40 s40" class="totaldata" style="font-weight: bold; ">184105.6</td> <td id="x40t4" headers="t4 r40  d40 s40" class="totaldata" style="font-weight: bold; ">168846.9</td> <td id="x40t5" headers="t5 r40  d40 s40" class="totaldata" style="font-weight: bold; ">169619.2</td> <td id="x40t6" headers="t6 r40  d40 s40" class="totaldata" style="font-weight: bold; ">168759.5</td> <td id="x40t7" headers="t7 r40  d40 s40" class="totaldata" style="font-weight: bold; ">175697.6</td> <td id="x40t8" headers="t8 r40  d40 s40" class="totaldata" style="font-weight: bold; ">181932.6</td> <td id="x40t9" headers="t9 r40  d40 s40" class="totaldata" style="font-weight: bold; ">184105.6</td> </tr> <tr> <td id="spacer41" colspan="12" class="sticky sticky-column-cell sticky-column-cell__fullspan"> </td> </tr> <tr> <th id="r41" headers="r0" class="stub sticky sticky-column-cell" style="font-weight: bold; "></th> <th id="d41" headers="d0  r41" class="stub sticky sticky-column-cell" style="font-weight: bold; ">Memo:</th> <th id="s41" headers="s0 r41 d41" class="stub sticky sticky-column-cell" style="font-weight: bold; "></th> <td id="x41t1" headers="t1 r41  d41 s41" class="data" style="font-weight: bold; "></td> <td id="x41t2" headers="t2 r41  d41 s41" class="data" style="font-weight: bold; "></td> <td id="x41t3" headers="t3 r41  d41 s41" class="data" style="font-weight: bold; "></td> <td id="x41t4" headers="t4 r41  d41 s41" class="data" style="font-weight: bold; "></td> <td id="x41t5" headers="t5 r41  d41 s41" class="data" style="font-weight: bold; "></td> <td id="x41t6" headers="t6 r41  d41 s41" class="data" style="font-weight: bold; "></td> <td id="x41t7" headers="t7 r41  d41 s41" class="data" style="font-weight: bold; "></td> <td id="x41t8" headers="t8 r41  d41 s41" class="data" style="font-weight: bold; "></td> <td id="x41t9" headers="t9 r41  d41 s41" class="data" style="font-weight: bold; "></td> </tr> <tr> <th id="r42" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 41</th> <th id="d42" headers="d0 d41 r42" class="stub sticky sticky-column-cell in1" style=" ">Assets held in IRAs<sup><a href="#footnote-8" title="Footnote 8: Included in assets shown on the household balance sheet.">8</a></sup></th> <th id="s42" headers="s0 r42 d42" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL893131573&t=" title="Go to documentation for this series, FL893131573">FL893131573</a></th> <td id="x42t1" headers="t1 r42 d41 d42 s42" class="data" style=" ">15000.0</td> <td id="x42t2" headers="t2 r42 d41 d42 s42" class="data" style=" ">17000.0</td> <td id="x42t3" headers="t3 r42 d41 d42 s42" class="data" style=" "></td> <td id="x42t4" headers="t4 r42 d41 d42 s42" class="data" style=" ">17030.0</td> <td id="x42t5" headers="t5 r42 d41 d42 s42" class="data" style=" ">17000.0</td> <td id="x42t6" headers="t6 r42 d41 d42 s42" class="data" style=" ">16784.0</td> <td id="x42t7" headers="t7 r42 d41 d42 s42" class="data" style=" ">17960.0</td> <td id="x42t8" headers="t8 r42 d41 d42 s42" class="data" style=" ">18894.0</td> <td id="x42t9" headers="t9 r42 d41 d42 s42" class="data" style=" "></td> </tr> <tr> <th id="r43" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 42</th> <th id="d43" headers="d0 d41 r43" class="stub sticky sticky-column-cell in1" style=" ">Assets held in 529 college plans<sup><a href="#footnote-8" title="Footnote 8: Included in assets shown on the household balance sheet.">8</a></sup></th> <th id="s43" headers="s0 r43 d43" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL154023205&t=" title="Go to documentation for this series, FL154023205">FL154023205</a></th> <td id="x43t1" headers="t1 r43 d41 d43 s43" class="data" style=" ">471.2</td> <td id="x43t2" headers="t2 r43 d41 d43 s43" class="data" style=" ">525.1</td> <td id="x43t3" headers="t3 r43 d41 d43 s43" class="data" style=" ">602.9</td> <td id="x43t4" headers="t4 r43 d41 d43 s43" class="data" style=" ">527.6</td> <td id="x43t5" headers="t5 r43 d41 d43 s43" class="data" style=" ">525.1</td> <td id="x43t6" headers="t6 r43 d41 d43 s43" class="data" style=" ">525.1</td> <td id="x43t7" headers="t7 r43 d41 d43 s43" class="data" style=" ">567.8</td> <td id="x43t8" headers="t8 r43 d41 d43 s43" class="data" style=" ">588.0</td> <td id="x43t9" headers="t9 r43 d41 d43 s43" class="data" style=" ">602.9</td> </tr> <tr> <th id="r44" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 43</th> <th id="d44" headers="d0 d41 d43 r44" class="stub sticky sticky-column-cell in2" style=" ">College savings plans</th> <th id="s44" headers="s0 r44 d44" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=LM154023223&t=" title="Go to documentation for this series, LM154023223">LM154023223</a></th> <td id="x44t1" headers="t1 r44 d41 d43 d44 s44" class="data" style=" ">446.6</td> <td id="x44t2" headers="t2 r44 d41 d43 d44 s44" class="data" style=" ">500.6</td> <td id="x44t3" headers="t3 r44 d41 d43 d44 s44" class="data" style=" ">576.7</td> <td id="x44t4" headers="t4 r44 d41 d43 d44 s44" class="data" style=" ">502.0</td> <td id="x44t5" headers="t5 r44 d41 d43 d44 s44" class="data" style=" ">500.6</td> <td id="x44t6" headers="t6 r44 d41 d43 d44 s44" class="data" style=" ">500.4</td> <td id="x44t7" headers="t7 r44 d41 d43 d44 s44" class="data" style=" ">542.4</td> <td id="x44t8" headers="t8 r44 d41 d43 d44 s44" class="data" style=" ">561.9</td> <td id="x44t9" headers="t9 r44 d41 d43 d44 s44" class="data" style=" ">576.7</td> </tr> <tr> <th id="r45" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 44</th> <th id="d45" headers="d0 d41 d43 r45" class="stub sticky sticky-column-cell in2" style=" ">Prepaid tuition plans</th> <th id="s45" headers="s0 r45 d45" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL154023213&t=" title="Go to documentation for this series, FL154023213">FL154023213</a></th> <td id="x45t1" headers="t1 r45 d41 d43 d45 s45" class="data" style=" ">24.6</td> <td id="x45t2" headers="t2 r45 d41 d43 d45 s45" class="data" style=" ">24.5</td> <td id="x45t3" headers="t3 r45 d41 d43 d45 s45" class="data" style=" ">26.3</td> <td id="x45t4" headers="t4 r45 d41 d43 d45 s45" class="data" style=" ">25.6</td> <td id="x45t5" headers="t5 r45 d41 d43 d45 s45" class="data" style=" ">24.5</td> <td id="x45t6" headers="t6 r45 d41 d43 d45 s45" class="data" style=" ">24.7</td> <td id="x45t7" headers="t7 r45 d41 d43 d45 s45" class="data" style=" ">25.4</td> <td id="x45t8" headers="t8 r45 d41 d43 d45 s45" class="data" style=" ">26.1</td> <td id="x45t9" headers="t9 r45 d41 d43 d45 s45" class="data" style=" ">26.3</td> </tr> <tr> <td id="spacer46" colspan="12" class="sticky sticky-column-cell sticky-column-cell__fullspan"> </td> </tr> <tr> <th id="r46" headers="r0" class="stub sticky sticky-column-cell" style=" "></th> <th id="d46" headers="d0 d41 r46" class="stub sticky sticky-column-cell in1" style=" ">Replacement-cost value of structures:</th> <th id="s46" headers="s0 r46 d46" class="stub sticky sticky-column-cell" style=" "></th> <td id="x46t1" headers="t1 r46 d41 d46 s46" class="data" style=" "></td> <td id="x46t2" headers="t2 r46 d41 d46 s46" class="data" style=" "></td> <td id="x46t3" headers="t3 r46 d41 d46 s46" class="data" style=" "></td> <td id="x46t4" headers="t4 r46 d41 d46 s46" class="data" style=" "></td> <td id="x46t5" headers="t5 r46 d41 d46 s46" class="data" style=" "></td> <td id="x46t6" headers="t6 r46 d41 d46 s46" class="data" style=" "></td> <td id="x46t7" headers="t7 r46 d41 d46 s46" class="data" style=" "></td> <td id="x46t8" headers="t8 r46 d41 d46 s46" class="data" style=" "></td> <td id="x46t9" headers="t9 r46 d41 d46 s46" class="data" style=" "></td> </tr> <tr> <th id="r47" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 45</th> <th id="d47" headers="d0 d41 d46 r47" class="stub sticky sticky-column-cell in2" style=" ">Residential</th> <th id="s47" headers="s0 r47 d47" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=LM155012605&t=" title="Go to documentation for this series, LM155012605">LM155012605</a></th> <td id="x47t1" headers="t1 r47 d41 d46 d47 s47" class="data" style=" ">27411.5</td> <td id="x47t2" headers="t2 r47 d41 d46 d47 s47" class="data" style=" ">28339.5</td> <td id="x47t3" headers="t3 r47 d41 d46 d47 s47" class="data" style=" ">29414.0</td> <td id="x47t4" headers="t4 r47 d41 d46 d47 s47" class="data" style=" ">28122.3</td> <td id="x47t5" headers="t5 r47 d41 d46 d47 s47" class="data" style=" ">28339.5</td> <td id="x47t6" headers="t6 r47 d41 d46 d47 s47" class="data" style=" ">28711.8</td> <td id="x47t7" headers="t7 r47 d41 d46 d47 s47" class="data" style=" ">28933.3</td> <td id="x47t8" headers="t8 r47 d41 d46 d47 s47" class="data" style=" ">29263.6</td> <td id="x47t9" headers="t9 r47 d41 d46 d47 s47" class="data" style=" ">29414.0</td> </tr> <tr> <th id="r48" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 46</th> <th id="d48" headers="d0 d41 d46 d47 r48" class="stub sticky sticky-column-cell in3" style=" ">Households</th> <th id="s48" headers="s0 r48 d48" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=LM155012665&t=" title="Go to documentation for this series, LM155012665">LM155012665</a></th> <td id="x48t1" headers="t1 r48 d41 d46 d47 d48 s48" class="data" style=" ">26996.2</td> <td id="x48t2" headers="t2 r48 d41 d46 d47 d48 s48" class="data" style=" ">27911.3</td> <td id="x48t3" headers="t3 r48 d41 d46 d47 d48 s48" class="data" style=" ">28972.7</td> <td id="x48t4" headers="t4 r48 d41 d46 d47 d48 s48" class="data" style=" ">27697.3</td> <td id="x48t5" headers="t5 r48 d41 d46 d47 d48 s48" class="data" style=" ">27911.3</td> <td id="x48t6" headers="t6 r48 d41 d46 d47 d48 s48" class="data" style=" ">28278.8</td> <td id="x48t7" headers="t7 r48 d41 d46 d47 d48 s48" class="data" style=" ">28497.7</td> <td id="x48t8" headers="t8 r48 d41 d46 d47 d48 s48" class="data" style=" ">28823.8</td> <td id="x48t9" headers="t9 r48 d41 d46 d47 d48 s48" class="data" style=" ">28972.7</td> </tr> <tr> <th id="r49" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 47</th> <th id="d49" headers="d0 d41 d46 d47 r49" class="stub sticky sticky-column-cell in3" style=" ">Nonprofit organizations</th> <th id="s49" headers="s0 r49 d49" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=LM165012665&t=" title="Go to documentation for this series, LM165012665">LM165012665</a></th> <td id="x49t1" headers="t1 r49 d41 d46 d47 d49 s49" class="data" style=" ">415.4</td> <td id="x49t2" headers="t2 r49 d41 d46 d47 d49 s49" class="data" style=" ">428.1</td> <td id="x49t3" headers="t3 r49 d41 d46 d47 d49 s49" class="data" style=" ">441.3</td> <td id="x49t4" headers="t4 r49 d41 d46 d47 d49 s49" class="data" style=" ">425.0</td> <td id="x49t5" headers="t5 r49 d41 d46 d47 d49 s49" class="data" style=" ">428.1</td> <td id="x49t6" headers="t6 r49 d41 d46 d47 d49 s49" class="data" style=" ">433.0</td> <td id="x49t7" headers="t7 r49 d41 d46 d47 d49 s49" class="data" style=" ">435.6</td> <td id="x49t8" headers="t8 r49 d41 d46 d47 d49 s49" class="data" style=" ">439.8</td> <td id="x49t9" headers="t9 r49 d41 d46 d47 d49 s49" class="data" style=" ">441.3</td> </tr> <tr> <th id="r50" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 48</th> <th id="d50" headers="d0 d41 d46 r50" class="stub sticky sticky-column-cell in2" style=" ">Nonresidential (nonprofits)</th> <th id="s50" headers="s0 r50 d50" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=LM165013665&t=" title="Go to documentation for this series, LM165013665">LM165013665</a></th> <td id="x50t1" headers="t1 r50 d41 d46 d50 s50" class="data" style=" ">2884.0</td> <td id="x50t2" headers="t2 r50 d41 d46 d50 s50" class="data" style=" ">2966.1</td> <td id="x50t3" headers="t3 r50 d41 d46 d50 s50" class="data" style=" ">3064.2</td> <td id="x50t4" headers="t4 r50 d41 d46 d50 s50" class="data" style=" ">2942.3</td> <td id="x50t5" headers="t5 r50 d41 d46 d50 s50" class="data" style=" ">2966.1</td> <td id="x50t6" headers="t6 r50 d41 d46 d50 s50" class="data" style=" ">2982.8</td> <td id="x50t7" headers="t7 r50 d41 d46 d50 s50" class="data" style=" ">2983.1</td> <td id="x50t8" headers="t8 r50 d41 d46 d50 s50" class="data" style=" ">3015.9</td> <td id="x50t9" headers="t9 r50 d41 d46 d50 s50" class="data" style=" ">3064.2</td> </tr> <tr> <th id="r51" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 49</th> <th id="d51" headers="d0 d41 d46 r51" class="stub sticky sticky-column-cell in1" style=" ">Disposable personal income (DPI) (SAAR)</th> <th id="s51" headers="s0 r51 d51" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FA156012005&t=" title="Go to documentation for this series, FA156012005">FA156012005</a></th> <td id="x51t1" headers="t1 r51 d41 d46 d51 s51" class="data" style=" ">20749.3</td> <td id="x51t2" headers="t2 r51 d41 d46 d51 s51" class="data" style=" ">21917.7</td> <td id="x51t3" headers="t3 r51 d41 d46 d51 s51" class="data" style=" ">22882.4</td> <td id="x51t4" headers="t4 r51 d41 d46 d51 s51" class="data" style=" ">22002.6</td> <td id="x51t5" headers="t5 r51 d41 d46 d51 s51" class="data" style=" ">22249.5</td> <td id="x51t6" headers="t6 r51 d41 d46 d51 s51" class="data" style=" ">22563.7</td> <td id="x51t7" headers="t7 r51 d41 d46 d51 s51" class="data" style=" ">22786.6</td> <td id="x51t8" headers="t8 r51 d41 d46 d51 s51" class="data" style=" ">23001.2</td> <td id="x51t9" headers="t9 r51 d41 d46 d51 s51" class="data" style=" ">23178.2</td> </tr> <tr> <th id="r52" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 50</th> <th id="d52" headers="d0 d41 d46 r52" class="stub sticky sticky-column-cell in1" style=" ">Net worth/DPI (percent) (line 40/line 49)</th> <th id="s52" headers="s0 r52 d52" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL152090006&t=" title="Go to documentation for this series, FL152090006">FL152090006</a></th> <td id="x52t1" headers="t1 r52 d41 d46 d52 s52" class="data" style=" ">752.2</td> <td id="x52t2" headers="t2 r52 d41 d46 d52 s52" class="data" style=" ">773.9</td> <td id="x52t3" headers="t3 r52 d41 d46 d52 s52" class="data" style=" ">804.6</td> <td id="x52t4" headers="t4 r52 d41 d46 d52 s52" class="data" style=" ">767.4</td> <td id="x52t5" headers="t5 r52 d41 d46 d52 s52" class="data" style=" ">762.4</td> <td id="x52t6" headers="t6 r52 d41 d46 d52 s52" class="data" style=" ">747.9</td> <td id="x52t7" headers="t7 r52 d41 d46 d52 s52" class="data" style=" ">771.1</td> <td id="x52t8" headers="t8 r52 d41 d46 d52 s52" class="data" style=" ">791.0</td> <td id="x52t9" headers="t9 r52 d41 d46 d52 s52" class="data" style=" ">794.3</td> </tr> <tr> <th id="r53" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 51</th> <th id="d53" headers="d0 d41 d46 r53" class="stub sticky sticky-column-cell in1" style=" ">Owners' equity in real estate (line 4 less line 33)</th> <th id="s53" headers="s0 r53 d53" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL155035065&t=" title="Go to documentation for this series, FL155035065">FL155035065</a></th> <td id="x53t1" headers="t1 r53 d41 d46 d53 s53" class="data" style=" ">31779.5</td> <td id="x53t2" headers="t2 r53 d41 d46 d53 s53" class="data" style=" ">33547.1</td> <td id="x53t3" headers="t3 r53 d41 d46 d53 s53" class="data" style=" ">34148.5</td> <td id="x53t4" headers="t4 r53 d41 d46 d53 s53" class="data" style=" ">34045.3</td> <td id="x53t5" headers="t5 r53 d41 d46 d53 s53" class="data" style=" ">33547.1</td> <td id="x53t6" headers="t6 r53 d41 d46 d53 s53" class="data" style=" ">34056.8</td> <td id="x53t7" headers="t7 r53 d41 d46 d53 s53" class="data" style=" ">35087.4</td> <td id="x53t8" headers="t8 r53 d41 d46 d53 s53" class="data" style=" ">34602.0</td> <td id="x53t9" headers="t9 r53 d41 d46 d53 s53" class="data" style=" ">34148.5</td> </tr> <tr> <th id="r54" headers="r0" class="stub sticky sticky-column-cell" style=" "><span class="globalskip">Line </span> 52</th> <th id="d54" headers="d0 d41 d46 r54" class="stub sticky sticky-column-cell in1" style=" ">Owners' equity/real estate (percent) (line 51/line 4)</th> <th id="s54" headers="s0 r54 d54" class="stub sticky sticky-column-cell" style=" "><a href="/apps/fof/SeriesAnalyzer.aspx?s=FL155035066&t=" title="Go to documentation for this series, FL155035066">FL155035066</a></th> <td id="x54t1" headers="t1 r54 d41 d46 d54 s54" class="data" style=" ">70.9</td> <td id="x54t2" headers="t2 r54 d41 d46 d54 s54" class="data" style=" ">71.5</td> <td id="x54t3" headers="t3 r54 d41 d46 d54 s54" class="data" style=" ">71.3</td> <td id="x54t4" headers="t4 r54 d41 d46 d54 s54" class="data" style=" ">72.0</td> <td id="x54t5" headers="t5 r54 d41 d46 d54 s54" class="data" style=" ">71.5</td> <td id="x54t6" headers="t6 r54 d41 d46 d54 s54" class="data" style=" ">71.7</td> <td id="x54t7" headers="t7 r54 d41 d46 d54 s54" class="data" style=" ">72.1</td> <td id="x54t8" headers="t8 r54 d41 d46 d54 s54" class="data" style=" ">71.7</td> <td id="x54t9" headers="t9 r54 d41 d46 d54 s54" class="data" style=" ">71.3</td> </tr> </tbody> </table> <div class="footnotes"> <p>Notes:</p> <ol> <li id="footnote-1">Sector includes domestic hedge funds, private equity funds, and personal trusts. Supplementary balance sheet tables B.101.h and B.101.n show estimates of annual year-end outstandings of households and nonprofit organizations, respectively. Detail on the sector's indirect holdings of debt securities and equity is shown on table B.101.e.</li> <li id="footnote-2">All types of owner-occupied housing including farm houses and mobile homes, as well as second homes that are not rented, vacant homes for sale, and vacant land. At market value.</li> <li id="footnote-3">At replacement (current) cost.</li> <li id="footnote-4">Includes nonmarketable Treasury securities, cash accounts at brokers and dealers, and syndicated loans to nonfinancial corporate business by nonprofits and domestic hedge funds.</li> <li id="footnote-5">Student loans and trade receivables are financial assets of nonprofit organizations; municipal securities, commercial mortgages, and trade payables are liabilities.</li> <li id="footnote-6">Includes public and private defined benefit and defined contribution pension plans and annuities, including those in IRAs and at life insurance companies. Excludes social security.</li> <li id="footnote-7">Includes loans made under home equity lines of credit and home equity loans secured by junior liens (table L.218, line 23).</li> <li id="footnote-8">Included in assets shown on the household balance sheet.</li> </ol></p>
+           </div>
+           </div>
+
+	      
+<div class="row">
+    <div class="lastUpdate" id="lastUpdate">Last Update: 2026-03-19 </div>
+</div>
+</div>
+<footer class="container footer">
+    <div class="row footer__content">
+        <div class="col-xs-12 col-sm-4">
+            <h6 class="footer__heading"><span class="text-uppercase">Board of Governors</span> <em>of the</em> <span class="text-uppercase">Federal Reserve System</span></h6>
+            <ul class="list-unstyled">
+                <li class="footer__listItem"><a class="footer__link" href="/aboutthefed.htm">About the Fed</a></li>
+                <li class="footer__listItem"><a class="footer__link" href="/newsevents.htm">News &amp; Events</a></li>
+                <li class="footer__listItem"><a class="footer__link" href="/monetarypolicy.htm">Monetary Policy</a></li>
+                <li class="footer__listItem"><a class="footer__link" href="/supervisionreg.htm">Supervision &amp; Regulation</a></li>
+                <li class="footer__listItem"><a class="footer__link" href="/paymentsystems.htm">Payment Systems</a></li>
+                <li class="footer__listItem"><a class="footer__link" href="/econres.htm">Economic Research</a></li>
+                <li class="footer__listItem"><a class="footer__link" href="/data.htm">Data</a></li>
+                <li class="footer__listItem"><a class="footer__link" href="/consumerscommunities.htm">Consumers &amp; Communities</a></li>
+            </ul>
+        </div>
+        <div class="col-xs-12 col-sm-4">
+            <h6 class="text-uppercase footer__heading">Tools and Information</h6>
+            <ul class="list-unstyled">
+                <li class="footer__listItem"><a href="/aboutthefed/contact-us-topics.htm" class="footer__link">Contact</a></li>
+                <li class="footer__listItem"><a href="/publications.htm" class="footer__link">Publications</a></li>
+                <li class="footer__listItem"><a href="/foia/about_foia.htm" class="footer__link">Freedom of Information (FOIA)</a></li>
+                <li class="footer__listItem"><a href="https://oig.federalreserve.gov/" class="footer__link">Office of Inspector General</a></li>
+                <li class="footer__listItem"><a href="/publications/annual-report.htm" class="footer__link">Budget &amp; Performance</a> | <a href="/regreform/audit.htm" class="footer__link">Audit</a></li>
+                <li class="footer__listItem"><a href="/eeo.htm" class="footer__link">No FEAR Act</a></li>
+                <li class="footer__listItem"><a href="/espanol.htm" class="footer__link">Español</a></li>
+                <li class="footer__listItem"><a href="/website-linking-policies.htm" class="footer__link">Website Policies</a> | <a href="/privacy.htm" class="footer__link">Privacy Program</a></li>
+                <li class="footer__listItem"><a href="/accessibility.htm" class="footer__link">Accessibility</a></li>
+            </ul>
+        </div>
+        <div class="col-xs-12 col-sm-4">
+            <div class="footer__social">
+                <h6 class="text-uppercase footer__heading footer__heading--social">Stay Connected</h6>
+                <a class="icon__md icon footer__btn icon-facebook-color" href="https://www.facebook.com/federalreserve"><span class="sr-only">Link to Facebook</span></a>
+                <a class="icon__md icon footer__btn icon-twitter-color" href="https://twitter.com/federalreserve"><span class="sr-only">Link to Federal Reserve Twitter Page</span></a>
+                <a class="icon__md icon footer__btn icon-youtube-color" href="https://www.youtube.com/federalreserve"><span class="sr-only">Link to Federal Reserve YouTube Page</span></a>
+                <a class="icon__md icon footer__btn icon-flickr-color" href="https://www.flickr.com/photos/federalreserve/"><span class="sr-only">Link to Federal Reserve Flickr Page</span></a>
+                <a class="icon__md icon footer__btn icon-linkedin-color" href="https://www.linkedin.com/company/federal-reserve-board"><span class="sr-only">Link to Federal Reserve LinkedIn Page</span></a>
+                <a class="icon__md icon footer__btn icon-rss-color" href="/feeds/feeds.htm"><span class="sr-only">Link to RSS Feeds</span></a>
+                <a class="icon__md icon footer__btn icon-email-color" href="/subscribe.htm"><span class="sr-only">Link to Email Subscribe</span></a>
+            </div>
+            <a href="https://www.usa.gov/" target="_blank" title="Link to USA.gov">
+                <img class="footer__image" src="/images/USAGov%402x.png" alt="Link to USA.gov">
+            </a>
+            <a href="/open/open.htm" target="_blank" title="Link to Open.gov">
+                <img class="footer__image" src="/images/OpenGov%402x.png" alt="Link to Open.gov">
+            </a>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-xs-12 footer__footer">
+            <p class="text-uppercase footer__text footer__text--left">Board of Governors <em class="text-lowercase">of the</em> Federal Reserve System</p>
+            <p class="footer__text footer__text--right">20th Street and Constitution Avenue N.W., Washington, DC 20551</p>
+        </div>
+    </div>
+</footer>
+<script src="/js/jquery1.11.1.min.js" type="text/javascript"></script>
+<script src="/js/bootstrap.min.js" type="text/javascript"></script>
+<script src="/js/scripts.js" type="text/javascript"></script>
+<script src="/js/modal.js" type="text/javascript"></script>
+<script src="/js/sticky-tables.js" type="text/javascript"></script>
+<script type="text/javascript" src="/js/slides/ekko-lightbox.min.js"></script>
+<script src="/js/t4-nav-controller.js" type="text/javascript"></script>
+<script type="text/javascript">
+$(document).ready(function($) {
+    // delegate calls to data-toggle="lightbox"
+    $(document).delegate('*[data-toggle="lightbox"]:not([data-gallery="navigateTo"])', 'click', function(event) {
+        event.preventDefault();
+        $(this).ekkoLightbox();
+    });
+    $('a[data-click="false"]').click(function(e) {
+        e.preventDefault();
+        var target = $(this).data('target');
+        $(target).click();
+    });
+});
+</script>
+<script type="text/javascript" src="/resources/track_downloads.js"></script>
+
+
+
+<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'9fa175c33db1e8c5',t:'MTc3ODUwNTQwNQ=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
+</html>

--- a/db/data/federal_reserve/z1_household_net_worth_2026/manifest.yaml
+++ b/db/data/federal_reserve/z1_household_net_worth_2026/manifest.yaml
@@ -1,0 +1,18 @@
+source_id: federal_reserve
+package_id: federal-reserve-z1-household-net-worth
+dataset: federal_reserve_federal-reserve-z1-household-net-worth
+source_page: https://www.federalreserve.gov/releases/z1/20260319/
+table: Z.1 B.101 Households and nonprofit organizations
+files:
+  2026:
+    filename: federal_reserve_z1_20260319_b101.html
+    source_url: https://www.federalreserve.gov/releases/z1/20260319/html/b101.htm
+    sha256: 3bcdb1e0309537de21a427501fe930ae769b6c08fa8f38ec029e3c42a7bb42fa
+    size_bytes: 142683
+    fetched_at: '2026-05-11T13:16:45+00:00'
+    storage:
+      r2:
+        provider: r2
+        bucket: arch-raw
+        key: raw/federal_reserve/federal-reserve-z1-household-net-worth/2026/3bcdb1e0309537de21a427501fe930ae769b6c08fa8f38ec029e3c42a7bb42fa/federal_reserve_z1_20260319_b101.html
+        uri: r2://arch-raw/raw/federal_reserve/federal-reserve-z1-household-net-worth/2026/3bcdb1e0309537de21a427501fe930ae769b6c08fa8f38ec029e3c42a7bb42fa/federal_reserve_z1_20260319_b101.html

--- a/packages/federal_reserve/z1_household_net_worth/source_package.yaml
+++ b/packages/federal_reserve/z1_household_net_worth/source_package.yaml
@@ -1,0 +1,68 @@
+schema_version: arch.source_package.v1
+package_id: federal-reserve-z1-household-net-worth
+label: Federal Reserve Z.1 household and nonprofit net worth
+artifact:
+  source_name: federal_reserve
+  source_table: Z.1 B.101 Households and nonprofit organizations
+  resource_package: db
+  resource_directory: data/federal_reserve/z1_household_net_worth_2026
+  manifest: manifest.yaml
+  vintage: z1_2026_03_19
+  extracted_at: '2026-05-11'
+  extraction_method: html table parse from official Federal Reserve Z.1 release
+  parser: html_tables_and_text
+  artifact_year: 2026
+record_sets:
+  - record_set_id: federal_reserve_z1.cy{year}.households_nonprofits_balance_sheet.net_worth
+    record_set_spec_id: federal_reserve_z1.households_nonprofits_balance_sheet.net_worth.v1
+    source_record_id_prefix: federal_reserve_z1.cy{year}.households_nonprofits_balance_sheet.net_worth
+    sheet_name: table_1
+    period_type: calendar_year
+    period: '{year}'
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    entity: institutional_sector
+    entity_role: households_and_nonprofit_organizations
+    domain: household_balance_sheet
+    groupby_dimension: federal_reserve.z1_series_code
+    rows:
+      - value_id: fl152090005
+        label: Net worth (assets minus liabilities)
+        ordinal: 0
+        row_number: 41
+        expected_row_header_column: B
+        expected_row_header: Net worth (assets minus liabilities)
+        guard_cells:
+          - column: A
+            row: start
+            expected_value: Line 40
+            label: source line number
+          - column: C
+            row: start
+            expected_value: FL152090005
+            label: source series code
+        table_record_kind: total
+    measures:
+      - measure_id: amount_outstanding
+        label: Amount outstanding
+        ordinal: 0
+        column_by_year:
+          2023: D
+          2024: E
+          2025: F
+        source_column_id: amount_outstanding_billions
+        expected_column_header_row: 1
+        expected_column_header_by_year:
+          2023: 2023
+          2024: 2024
+          2025: 2025
+        concept: federal_reserve.z1.households_nonprofits_net_worth
+        source_concept: federal_reserve.z1.fl152090005
+        concept_relation: source_label
+        concept_authority: arch-us
+        unit: usd
+        aggregation: sum
+        value_scale: 1000000000
+        expected_cell_type: number

--- a/tests/test_arch_bundle.py
+++ b/tests/test_arch_bundle.py
@@ -27,28 +27,29 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
     assert summary["valid"]
     assert summary["counts"] == {
         "aggregate_duplicate_key_count": 0,
-        "entity_count": 5,
+        "entity_count": 6,
         "error_count": 0,
-        "fact_count": 7039,
+        "fact_count": 7040,
         "geography_count": 54,
-        "period_count": 6,
+        "period_count": 7,
         "semantic_duplicate_key_count": 3,
         "skipped_source_count": 0,
-        "source_count": 8,
-        "source_package_count": 23,
+        "source_count": 9,
+        "source_package_count": 24,
         "warning_count": 1,
     }
-    assert len(rows) == 7039
+    assert len(rows) == 7040
     assert rows[0]["aggregate_fact_key"].startswith("arch.aggregate_fact.v2:")
     assert rows[0]["semantic_fact_key"].startswith("arch.semantic_fact.v2:")
-    assert source_packages["source_package_count"] == 23
+    assert source_packages["source_package_count"] == 24
     assert source_packages["skipped_source_count"] == 0
     assert not source_packages["skipped_sources"]
-    assert coverage["fact_count"] == 7039
+    assert coverage["fact_count"] == 7040
     assert coverage["counts"]["by_source"] == {
         "census_pep": 988,
         "census_stc": 46,
         "cms_medicaid": 255,
+        "federal_reserve": 1,
         "hhs_acf_tanf": 110,
         "irs_soi": 5367,
         "kff": 51,
@@ -69,6 +70,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
             "cms_medicaid:State Medicaid and CHIP Applications, Eligibility "
             "Determinations, and Enrollment Data"
         ): 255,
+        "federal_reserve:Z.1 B.101 Households and nonprofit organizations": 1,
         "hhs_acf_tanf:FY 2024 Federal TANF and State MOE Financial Data": 52,
         "hhs_acf_tanf:TANF Caseload Data 2024": 58,
         "irs_soi:Historic Table 2": 605,
@@ -101,6 +103,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "usda_snap:SNAP Monthly State Participation and Benefit Summary FY69 to current": 216,
     }
     assert coverage["counts"]["by_period"] == {
+        "calendar_year:2023": 1,
         "calendar_year:2024": 1045,
         "fiscal_year:2023": 46,
         "fiscal_year:2024": 326,
@@ -108,13 +111,14 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "tax_year:2022": 4968,
         "tax_year:2023": 399,
     }
-    assert coverage["counts"]["by_geography"]["country:0100000US"] == 1274
+    assert coverage["counts"]["by_geography"]["country:0100000US"] == 1275
     assert coverage["counts"]["by_geography"]["state:0400000US06"] == 113
     assert len(coverage["counts"]["by_geography"]) == 54
     assert coverage["counts"]["by_entity"] == {
         "family": 107,
         "government": 100,
         "household": 54,
+        "institutional_sector": 1,
         "person": 1411,
         "tax_unit": 5367,
     }
@@ -145,6 +149,12 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
     ).exists()
     assert (
         output_dir / "sources" / "census-stc-individual-income-tax" / "consumer_facts.jsonl"
+    ).exists()
+    assert (
+        output_dir
+        / "sources"
+        / "federal-reserve-z1-household-net-worth"
+        / "consumer_facts.jsonl"
     ).exists()
     assert (
         output_dir / "sources" / "usda-snap-fy69-to-current" / "consumer_facts.jsonl"

--- a/tests/test_arch_source_package.py
+++ b/tests/test_arch_source_package.py
@@ -412,6 +412,54 @@ def test_census_stc_income_tax_package_builds_state_tax_facts():
     )
 
 
+def test_federal_reserve_z1_package_builds_net_worth_fact():
+    report = validate_source_package(
+        "federal-reserve-z1-household-net-worth",
+        year=2024,
+    )
+    package = load_source_package("federal-reserve-z1-household-net-worth")
+    cells = package.build_source_cells(2024)
+    records = package.build_source_records(2024, cells=cells)
+    facts = package.build_facts(2024, cells=cells)
+    records_by_id = {record.source_record_id: record for record in records}
+    values_by_record = {fact.source_record_id: fact for fact in facts}
+
+    assert package.package_id == "federal-reserve-z1-household-net-worth"
+    assert report.valid
+    assert report.counts == {
+        "record_set_count": 1,
+        "row_count": 1,
+        "measure_count": 1,
+        "source_record_count": 1,
+        "source_region_count": 1,
+    }
+    assert len(cells) == 709
+    assert validate_source_cells(cells).valid
+    assert len(facts) == 1
+    assert validate_facts(facts).valid
+    assert all(fact.source.source_name == "federal_reserve" for fact in facts)
+    assert all("fred" not in (fact.source.url or "") for fact in facts)
+    assert all(fact.source.raw_r2_uri for fact in facts)
+
+    record_id = (
+        "federal_reserve_z1.cy2024.households_nonprofits_balance_sheet."
+        "net_worth.fl152090005.amount_outstanding"
+    )
+
+    assert records_by_id[record_id].source_cell_addresses == (
+        "E41",
+        "E1",
+        "A41",
+        "C41",
+    )
+    assert values_by_record[record_id].value == 169_619_200_000_000
+    assert values_by_record[record_id].period.value == 2024
+    assert values_by_record[record_id].geography.id == "0100000US"
+    assert values_by_record[record_id].entity.name == "institutional_sector"
+    assert not values_by_record[record_id].filters
+    assert not values_by_record[record_id].constraints
+
+
 def test_soi_table_2_5_eitc_child_totals_build_2022_facts():
     package = load_source_package("soi-table-2-5-eitc-agi-children-2022")
     cells = package.build_source_cells(2023)


### PR DESCRIPTION
Adds a Federal Reserve Z.1 source package for households and nonprofit organizations net worth from the official B.101 release table. The package emits one national institutional-sector net-worth fact for calendar year 2024 and is included in the default Arch bundle registry.

Microplex coverage impact: combining the current 2023 Arch bundle with FY2024 Census STC and 2024 Federal Reserve Z.1 raises PE native broad target coverage to 156 / 189, with net_worth covered by FEDERAL_RESERVE.

Validation:
- uv run ruff check arch/source_package.py tests/test_arch_source_package.py tests/test_arch_bundle.py
- uv run pytest tests/test_arch_source_package.py::test_federal_reserve_z1_package_builds_net_worth_fact -q
- uv run pytest tests/test_arch_bundle.py -q