### PR TITLE
Add national CMS Medicaid enrollment aggregate

### DIFF
--- a/packages/cms_medicaid/chip_monthly_enrollment_december_2024/source_package.yaml
+++ b/packages/cms_medicaid/chip_monthly_enrollment_december_2024/source_package.yaml
@@ -236,6 +236,98 @@ record_sets:
   domain: medicaid_chip_enrollment
   groupby_dimension: cms_medicaid.state_abbreviation
   rows:
+  - value_id: us
+    label: United States
+    ordinal: -1
+    row_number: 2
+    row_end_number: 52
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    expected_row_header_column: A
+    expected_row_header: AK
+    guard_cells:
+    - column: C
+      expected_value: 202412
+      row: start
+      label: first reporting period
+    - column: E
+      expected_value: U
+      row: start
+      label: first updated report
+    - column: F
+      expected_value: Y
+      row: start
+      label: first final report
+    - column: C
+      expected_value: 202412
+      row: end
+      label: last reporting period
+    - column: E
+      expected_value: U
+      row: end
+      label: last updated report
+    - column: F
+      expected_value: Y
+      row: end
+      label: last final report
+    range_label_guards:
+    - column: A
+      label: state abbreviation
+      expected_values:
+      - AK
+      - AL
+      - AR
+      - AZ
+      - CA
+      - CO
+      - CT
+      - DC
+      - DE
+      - FL
+      - GA
+      - HI
+      - IA
+      - ID
+      - IL
+      - IN
+      - KS
+      - KY
+      - LA
+      - MA
+      - MD
+      - ME
+      - MI
+      - MN
+      - MO
+      - MS
+      - MT
+      - NC
+      - ND
+      - NE
+      - NH
+      - NJ
+      - NM
+      - NV
+      - NY
+      - OH
+      - OK
+      - OR
+      - PA
+      - RI
+      - SC
+      - SD
+      - TN
+      - TX
+      - UT
+      - VA
+      - VT
+      - WA
+      - WI
+      - WV
+      - WY
+    table_record_kind: total
   - value_id: ak
     label: Alaska
     ordinal: 0

--- a/tests/test_arch_bundle.py
+++ b/tests/test_arch_bundle.py
@@ -29,7 +29,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "aggregate_duplicate_key_count": 0,
         "entity_count": 6,
         "error_count": 0,
-        "fact_count": 7043,
+        "fact_count": 7048,
         "geography_count": 54,
         "period_count": 7,
         "semantic_duplicate_key_count": 3,
@@ -38,17 +38,17 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "source_package_count": 27,
         "warning_count": 1,
     }
-    assert len(rows) == 7043
+    assert len(rows) == 7048
     assert rows[0]["aggregate_fact_key"].startswith("arch.aggregate_fact.v2:")
     assert rows[0]["semantic_fact_key"].startswith("arch.semantic_fact.v2:")
     assert source_packages["source_package_count"] == 27
     assert source_packages["skipped_source_count"] == 0
     assert not source_packages["skipped_sources"]
-    assert coverage["fact_count"] == 7043
+    assert coverage["fact_count"] == 7048
     assert coverage["counts"]["by_source"] == {
         "census_pep": 988,
         "census_stc": 46,
-        "cms_medicaid": 255,
+        "cms_medicaid": 260,
         "cms_medicare": 1,
         "cms_nhe": 1,
         "federal_reserve": 1,
@@ -72,7 +72,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         (
             "cms_medicaid:State Medicaid and CHIP Applications, Eligibility "
             "Determinations, and Enrollment Data"
-        ): 255,
+        ): 260,
         "cms_medicare:2025 Medicare Trustees Report Table III.C3": 1,
         (
             "cms_nhe:National Health Expenditures by type of service and source "
@@ -116,11 +116,11 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "calendar_year:2024": 1046,
         "fiscal_year:2023": 46,
         "fiscal_year:2024": 327,
-        "month:2024-12": 255,
+        "month:2024-12": 260,
         "tax_year:2022": 4968,
         "tax_year:2023": 399,
     }
-    assert coverage["counts"]["by_geography"]["country:0100000US"] == 1278
+    assert coverage["counts"]["by_geography"]["country:0100000US"] == 1283
     assert coverage["counts"]["by_geography"]["state:0400000US06"] == 113
     assert len(coverage["counts"]["by_geography"]) == 54
     assert coverage["counts"]["by_entity"] == {
@@ -128,7 +128,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "government": 101,
         "household": 55,
         "institutional_sector": 1,
-        "person": 1412,
+        "person": 1417,
         "tax_unit": 5367,
     }
     assert not coverage["duplicates"]["aggregate_fact_keys"]

--- a/tests/test_arch_source_package.py
+++ b/tests/test_arch_source_package.py
@@ -661,9 +661,9 @@ def test_cms_medicaid_source_package_alias_validates_fixture_counts():
     assert report.valid
     assert report.counts == {
         "record_set_count": 1,
-        "row_count": 51,
+        "row_count": 52,
         "measure_count": 5,
-        "source_record_count": 255,
+        "source_record_count": 260,
         "source_region_count": 1,
     }
 
@@ -682,9 +682,13 @@ def test_cms_medicaid_package_builds_december_2024_state_enrollment_facts():
     assert validate_source_cells(cells).valid
     assert validate_facts(facts).valid
     assert len(cells) == 2_288
-    assert len(facts) == 255
+    assert len(facts) == 260
     assert all(fact.source.raw_r2_uri for fact in facts)
 
+    us_medicaid = (
+        "cms_medicaid.month2024_12.state_enrollment.us."
+        "total_medicaid_enrollment"
+    )
     ca_medicaid = (
         "cms_medicaid.month2024_12.state_enrollment.ca."
         "total_medicaid_enrollment"
@@ -702,6 +706,15 @@ def test_cms_medicaid_package_builds_december_2024_state_enrollment_facts():
         "medicaid_chip_child_enrollment"
     )
 
+    assert records_by_id[us_medicaid].source_cell_addresses[:3] == (
+        "W2",
+        "W3",
+        "W4",
+    )
+    assert "W52" in records_by_id[us_medicaid].source_cell_addresses
+    assert "W1" in records_by_id[us_medicaid].source_cell_addresses
+    assert "A2" in records_by_id[us_medicaid].source_cell_addresses
+    assert "A52" in records_by_id[us_medicaid].source_cell_addresses
     assert records_by_id[ca_medicaid].source_cell_addresses == (
         "W6",
         "W1",
@@ -716,6 +729,9 @@ def test_cms_medicaid_package_builds_december_2024_state_enrollment_facts():
         "E45",
         "F45",
     )
+    assert values_by_record[us_medicaid].value == 71_841_081
+    assert values_by_record[us_medicaid].geography.id == "0100000US"
+    assert values_by_record[us_medicaid].geography.level == "country"
     assert values_by_record[ca_medicaid].value == 12_254_163
     assert values_by_record[ca_medicaid].geography.id == "0400000US06"
     assert values_by_record[ca_medicaid].domain == "medicaid_chip_enrollment"


### PR DESCRIPTION
## Summary
- add a United States aggregate row to the CMS Medicaid December 2024 enrollment source package by summing guarded state rows
- preserve source-cell lineage for the aggregate through range selectors and state-abbreviation guards
- update bundle/source-package tests for the five new national CMS Medicaid facts

## Microplex impact
- fills the national Medicaid enrollment target coverage gap for `person_count` where `medicaid > 0`
- refreshed Microplex broad target coverage moves from 159/189 to 160/189 with the new CMS Medicaid artifact

## Validation
- `uv run ruff check tests/test_arch_source_package.py tests/test_arch_bundle.py`
- `uv run pytest tests/test_arch_source_package.py::test_cms_medicaid_source_package_alias_validates_fixture_counts tests/test_arch_source_package.py::test_cms_medicaid_package_builds_december_2024_state_enrollment_facts -q`
- `uv run arch validate-package cms-medicaid-chip-monthly-enrollment-december-2024 --year 2024`
- `uv run pytest tests/test_arch_bundle.py::test_build_bundle_writes_merged_consumer_contract -q`
- `uv run arch build-suite cms-medicaid-chip-monthly-enrollment-december-2024 --year 2024 --out /Users/maxghenis/CosilicoAI/microplex-us/artifacts/arch_cms_medicaid_national_coverage_20260528/cms_medicaid_y2024 --replace`
- refreshed Microplex coverage report: `/Users/maxghenis/CosilicoAI/microplex-us/artifacts/arch_cms_medicaid_national_coverage_20260528/pe_native_broad_2024_coverage_y2023_plus_stc_z1_medicaid_nhe_medicare_liheap.json`