### PR TITLE
Add national KFF marketplace enrollment aggregate

### DIFF
--- a/packages/kff/marketplace_effectuated_enrollment/source_package.yaml
+++ b/packages/kff/marketplace_effectuated_enrollment/source_package.yaml
@@ -133,6 +133,82 @@ record_sets:
   domain: aca_marketplace_effectuated_enrollment
   groupby_dimension: kff.state
   rows:
+  - value_id: us
+    label: United States
+    ordinal: -1
+    row_number: 2
+    row_end_number: 52
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Alabama
+    guard_cells:
+    - column: A
+      expected_value: 2024
+      row: start
+      label: first year
+    - column: A
+      expected_value: 2024
+      row: end
+      label: last year
+    range_label_guards:
+    - column: B
+      label: state name
+      expected_values:
+      - Alabama
+      - Alaska
+      - Arizona
+      - Arkansas
+      - California
+      - Colorado
+      - Connecticut
+      - Delaware
+      - District of Columbia
+      - Florida
+      - Georgia
+      - Hawaii
+      - Idaho
+      - Illinois
+      - Indiana
+      - Iowa
+      - Kansas
+      - Kentucky
+      - Louisiana
+      - Maine
+      - Maryland
+      - Massachusetts
+      - Michigan
+      - Minnesota
+      - Mississippi
+      - Missouri
+      - Montana
+      - Nebraska
+      - Nevada
+      - New Hampshire
+      - New Jersey
+      - New Mexico
+      - New York
+      - North Carolina
+      - North Dakota
+      - Ohio
+      - Oklahoma
+      - Oregon
+      - Pennsylvania
+      - Rhode Island
+      - South Carolina
+      - South Dakota
+      - Tennessee
+      - Texas
+      - Utah
+      - Vermont
+      - Virginia
+      - Washington
+      - West Virginia
+      - Wisconsin
+      - Wyoming
+    table_record_kind: total
   - value_id: al
     label: Alabama
     ordinal: 0

--- a/tests/test_arch_bundle.py
+++ b/tests/test_arch_bundle.py
@@ -29,7 +29,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "aggregate_duplicate_key_count": 0,
         "entity_count": 6,
         "error_count": 0,
-        "fact_count": 7048,
+        "fact_count": 7049,
         "geography_count": 54,
         "period_count": 7,
         "semantic_duplicate_key_count": 3,
@@ -38,13 +38,13 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "source_package_count": 27,
         "warning_count": 1,
     }
-    assert len(rows) == 7048
+    assert len(rows) == 7049
     assert rows[0]["aggregate_fact_key"].startswith("arch.aggregate_fact.v2:")
     assert rows[0]["semantic_fact_key"].startswith("arch.semantic_fact.v2:")
     assert source_packages["source_package_count"] == 27
     assert source_packages["skipped_source_count"] == 0
     assert not source_packages["skipped_sources"]
-    assert coverage["fact_count"] == 7048
+    assert coverage["fact_count"] == 7049
     assert coverage["counts"]["by_source"] == {
         "census_pep": 988,
         "census_stc": 46,
@@ -55,7 +55,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "hhs_acf_liheap": 1,
         "hhs_acf_tanf": 110,
         "irs_soi": 5367,
-        "kff": 51,
+        "kff": 52,
         "ssa": 6,
         "usda_snap": 216,
     }
@@ -107,20 +107,20 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
             "Arrangement (IRA) Plan Contributions, by Size of Contribution and "
             "Age of Taxpayer"
         ): 2,
-        "kff:Full Year Average Marketplace Effectuated Enrollment, 2017-2024": 51,
+        "kff:Full Year Average Marketplace Effectuated Enrollment, 2017-2024": 52,
         "ssa:SSA Annual Statistical Supplement 2025 extracted OASDI and SSI target rows": 6,
         "usda_snap:SNAP Monthly State Participation and Benefit Summary FY69 to current": 216,
     }
     assert coverage["counts"]["by_period"] == {
         "calendar_year:2023": 2,
-        "calendar_year:2024": 1046,
+        "calendar_year:2024": 1047,
         "fiscal_year:2023": 46,
         "fiscal_year:2024": 327,
         "month:2024-12": 260,
         "tax_year:2022": 4968,
         "tax_year:2023": 399,
     }
-    assert coverage["counts"]["by_geography"]["country:0100000US"] == 1283
+    assert coverage["counts"]["by_geography"]["country:0100000US"] == 1284
     assert coverage["counts"]["by_geography"]["state:0400000US06"] == 113
     assert len(coverage["counts"]["by_geography"]) == 54
     assert coverage["counts"]["by_entity"] == {
@@ -128,7 +128,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "government": 101,
         "household": 55,
         "institutional_sector": 1,
-        "person": 1417,
+        "person": 1418,
         "tax_unit": 5367,
     }
     assert not coverage["duplicates"]["aggregate_fact_keys"]

--- a/tests/test_arch_source_package.py
+++ b/tests/test_arch_source_package.py
@@ -1133,9 +1133,9 @@ def test_kff_marketplace_effectuated_enrollment_alias_validates_fixture_counts()
     assert report.valid
     assert report.counts == {
         "record_set_count": 1,
-        "row_count": 51,
+        "row_count": 52,
         "measure_count": 1,
-        "source_record_count": 51,
+        "source_record_count": 52,
         "source_region_count": 1,
     }
 
@@ -1162,12 +1162,16 @@ def test_kff_marketplace_effectuated_enrollment_builds_2024_state_facts():
     assert validate_source_cells(cells).valid
     assert validate_facts(facts).valid
     assert len(cells) == 260
-    assert len(facts) == 51
+    assert len(facts) == 52
     assert all(fact.source_row_keys for fact in facts)
     assert all(fact.source.source_name == "kff" for fact in facts)
     assert all(fact.source.source_file.endswith(".html") for fact in facts)
     assert all(fact.source.raw_r2_uri for fact in facts)
 
+    us = (
+        "kff.marketplace_effectuated_enrollment.2024.state.us."
+        "total_effectuated_marketplace_enrollment"
+    )
     al = (
         "kff.marketplace_effectuated_enrollment.2024.state.al."
         "total_effectuated_marketplace_enrollment"
@@ -1177,6 +1181,14 @@ def test_kff_marketplace_effectuated_enrollment_builds_2024_state_facts():
         "total_effectuated_marketplace_enrollment"
     )
 
+    assert records_by_id[us].source_cell_addresses[:3] == ("C2", "C3", "C4")
+    assert "C52" in records_by_id[us].source_cell_addresses
+    assert "C1" in records_by_id[us].source_cell_addresses
+    assert "B2" in records_by_id[us].source_cell_addresses
+    assert "B52" in records_by_id[us].source_cell_addresses
     assert records_by_id[al].source_cell_addresses == ("C2", "C1")
+    assert values_by_record[us].value == 20_968_847
+    assert values_by_record[us].geography.id == "0100000US"
+    assert values_by_record[us].geography.level == "country"
     assert values_by_record[al].value == 396_750
     assert values_by_record[ca].value == 1_795_695


### PR DESCRIPTION
## Summary
- add a United States aggregate fact for KFF full-year average marketplace effectuated enrollment
- compute the national fact as a guarded range aggregate over the 51 state rows, which matches the KFF national row value exactly
- update bundle/source-package tests for the new national marketplace enrollment fact

## Microplex impact
- fills the national `person_count` target cell with domain `aca_ptc` from KFF
- refreshed Microplex broad target coverage reaches 161/189 when combined with the recent Arch source-package additions

## Validation
- `uv run ruff check tests/test_arch_source_package.py tests/test_arch_bundle.py`
- `uv run pytest tests/test_arch_source_package.py::test_kff_marketplace_effectuated_enrollment_alias_validates_fixture_counts tests/test_arch_source_package.py::test_kff_marketplace_effectuated_enrollment_builds_2024_state_facts -q`
- `uv run arch validate-package kff-marketplace-effectuated-enrollment --year 2024`
- `uv run pytest tests/test_arch_bundle.py::test_build_bundle_writes_merged_consumer_contract -q`
- `uv run arch build-suite kff-marketplace-effectuated-enrollment --year 2024 --out /Users/maxghenis/CosilicoAI/microplex-us/artifacts/arch_kff_national_marketplace_coverage_20260528/kff_marketplace_y2024 --replace`
- refreshed Microplex coverage report: `/Users/maxghenis/CosilicoAI/microplex-us/artifacts/arch_kff_national_marketplace_coverage_20260528/pe_native_broad_2024_coverage_y2023_plus_recent_arch_prs_with_stc_z1.json`