### PR TITLE
Add SOI Table 2.1 itemized deduction details

### DIFF
--- a/packages/irs_soi/table_2_1/source_package.yaml
+++ b/packages/irs_soi/table_2_1/source_package.yaml
@@ -256,3 +256,313 @@ record_sets:
         aggregation: sum
         value_scale: 1000
         expected_cell_type: number
+      - measure_id: total_state_local_taxes_returns
+        label: Returns with state and local taxes
+        ordinal: 17
+        column: CC
+        column_by_year:
+          2021: BQ
+          2022: CC
+          2023: CC
+        source_column_id: total_state_local_taxes_returns
+        expected_column_header_row: 8
+        expected_column_header: Number of returns
+        concept: irs_soi.returns_with_state_and_local_taxes
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+      - measure_id: total_state_local_taxes_amount
+        label: State and local taxes amount
+        ordinal: 18
+        column: CD
+        column_by_year:
+          2021: BR
+          2022: CD
+          2023: CD
+        source_column_id: total_state_local_taxes_amount
+        expected_column_header_row: 8
+        expected_column_header: Amount
+        concept: irs_soi.state_and_local_taxes
+        unit: usd
+        aggregation: sum
+        value_scale: 1000
+        expected_cell_type: number
+      - measure_id: state_local_income_or_sales_tax_returns
+        label: Returns with state and local income or general sales taxes
+        ordinal: 19
+        column: CE
+        column_by_year:
+          2021: BS
+          2022: CE
+          2023: CE
+        source_column_id: state_local_income_or_sales_tax_returns
+        expected_column_header_row: 8
+        expected_column_header: Number of returns
+        concept: irs_soi.returns_with_state_local_income_or_sales_taxes
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+      - measure_id: state_local_income_or_sales_tax_amount
+        label: State and local income or general sales taxes amount
+        ordinal: 20
+        column: CF
+        column_by_year:
+          2021: BT
+          2022: CF
+          2023: CF
+        source_column_id: state_local_income_or_sales_tax_amount
+        expected_column_header_row: 8
+        expected_column_header: Amount
+        concept: irs_soi.state_local_income_or_sales_taxes
+        unit: usd
+        aggregation: sum
+        value_scale: 1000
+        expected_cell_type: number
+      - measure_id: real_estate_taxes_claims
+        label: Returns with real estate taxes
+        ordinal: 21
+        column: CK
+        column_by_year:
+          2021: BY
+          2022: CK
+          2023: CK
+        source_column_id: real_estate_taxes_claims
+        expected_column_header_row: 8
+        expected_column_header: Number of returns
+        concept: irs_soi.returns_with_real_estate_taxes
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+      - measure_id: real_estate_taxes_amount
+        label: Real estate taxes amount
+        ordinal: 22
+        column: CL
+        column_by_year:
+          2021: BZ
+          2022: CL
+          2023: CL
+        source_column_id: real_estate_taxes_amount
+        expected_column_header_row: 8
+        expected_column_header: Amount
+        concept: irs_soi.real_estate_taxes
+        unit: usd
+        aggregation: sum
+        value_scale: 1000
+        expected_cell_type: number
+      - measure_id: limited_state_local_taxes_returns
+        label: Returns with limited state and local taxes
+        ordinal: 23
+        column: CO
+        column_by_year:
+          2021: CC
+          2022: CO
+          2023: CO
+        source_column_id: limited_state_local_taxes_returns
+        expected_column_header_row: 7
+        expected_column_header: "Number of\nreturns"
+        concept: irs_soi.returns_with_limited_state_local_taxes
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+      - measure_id: limited_state_local_taxes_amount
+        label: Limited state and local taxes amount
+        ordinal: 24
+        column: CP
+        column_by_year:
+          2021: CD
+          2022: CP
+          2023: CP
+        source_column_id: limited_state_local_taxes_amount
+        expected_column_header_row: 7
+        expected_column_header: Amount
+        concept: irs_soi.limited_state_local_taxes
+        unit: usd
+        aggregation: sum
+        value_scale: 1000
+        expected_cell_type: number
+      - measure_id: interest_paid_deduction_returns
+        label: Returns with interest paid deduction
+        ordinal: 25
+        column: CS
+        column_by_year:
+          2021: CG
+          2022: CS
+          2023: CS
+        source_column_id: interest_paid_deduction_returns
+        expected_column_header_row: 7
+        expected_column_header: "Number of\nreturns"
+        concept: irs_soi.returns_with_interest_paid_deduction
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+      - measure_id: interest_paid_deduction_amount
+        label: Interest paid deduction amount
+        ordinal: 26
+        column: CT
+        column_by_year:
+          2021: CH
+          2022: CT
+          2023: CT
+        source_column_id: interest_paid_deduction_amount
+        expected_column_header_row: 7
+        expected_column_header: Amount
+        concept: irs_soi.interest_paid_deduction
+        unit: usd
+        aggregation: sum
+        value_scale: 1000
+        expected_cell_type: number
+      - measure_id: mortgage_interest_paid_returns
+        label: Returns with home mortgage interest paid to financial institutions
+        ordinal: 27
+        column: CY
+        column_by_year:
+          2021: CM
+          2022: CY
+          2023: CY
+        source_column_id: mortgage_interest_paid_returns
+        expected_column_header_row: 8
+        expected_column_header: Number of returns
+        concept: irs_soi.returns_with_home_mortgage_interest_paid_to_financial_institutions
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+      - measure_id: mortgage_interest_paid_amount
+        label: Home mortgage interest paid to financial institutions amount
+        ordinal: 28
+        column: CZ
+        column_by_year:
+          2021: CN
+          2022: CZ
+          2023: CZ
+        source_column_id: mortgage_interest_paid_amount
+        expected_column_header_row: 8
+        expected_column_header: Amount
+        concept: irs_soi.home_mortgage_interest_paid_to_financial_institutions
+        unit: usd
+        aggregation: sum
+        value_scale: 1000
+        expected_cell_type: number
+      - measure_id: home_mortgage_personal_seller_returns
+        label: Returns with home mortgage interest paid to individuals
+        ordinal: 29
+        column: DA
+        column_by_year:
+          2021: CO
+          2022: DA
+          2023: DA
+        source_column_id: home_mortgage_personal_seller_returns
+        expected_column_header_row: 8
+        expected_column_header: Number of returns
+        concept: irs_soi.returns_with_home_mortgage_interest_paid_to_individuals
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+      - measure_id: home_mortgage_personal_seller_amount
+        label: Home mortgage interest paid to individuals amount
+        ordinal: 30
+        column: DB
+        column_by_year:
+          2021: CP
+          2022: DB
+          2023: DB
+        source_column_id: home_mortgage_personal_seller_amount
+        expected_column_header_row: 8
+        expected_column_header: Amount
+        concept: irs_soi.home_mortgage_interest_paid_to_individuals
+        unit: usd
+        aggregation: sum
+        value_scale: 1000
+        expected_cell_type: number
+      - measure_id: deductible_points_returns
+        label: Returns with deductible points
+        ordinal: 31
+        column: DC
+        column_by_year:
+          2021: CQ
+          2022: DC
+          2023: DC
+        source_column_id: deductible_points_returns
+        expected_column_header_row: 8
+        expected_column_header: Number of returns
+        concept: irs_soi.returns_with_deductible_points
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+      - measure_id: deductible_points_amount
+        label: Deductible points amount
+        ordinal: 32
+        column: DD
+        column_by_year:
+          2021: CR
+          2022: DD
+          2023: DD
+        source_column_id: deductible_points_amount
+        expected_column_header_row: 8
+        expected_column_header: Amount
+        concept: irs_soi.deductible_points
+        unit: usd
+        aggregation: sum
+        value_scale: 1000
+        expected_cell_type: number
+      - measure_id: investment_interest_paid_returns
+        label: Returns with investment interest expense deduction
+        ordinal: 33
+        column: DE
+        column_by_year:
+          2021: CU
+          2022: DE
+          2023: DE
+        source_column_id: investment_interest_paid_returns
+        expected_column_header_row: 7
+        expected_column_header: "Number of\nreturns"
+        concept: irs_soi.returns_with_investment_interest_expense_deduction
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+      - measure_id: investment_interest_paid_amount
+        label: Investment interest expense deduction amount
+        ordinal: 34
+        column: DF
+        column_by_year:
+          2021: CV
+          2022: DF
+          2023: DF
+        source_column_id: investment_interest_paid_amount
+        expected_column_header_row: 7
+        expected_column_header: Amount
+        concept: irs_soi.investment_interest_expense_deduction
+        unit: usd
+        aggregation: sum
+        value_scale: 1000
+        expected_cell_type: number
+      - measure_id: charitable_returns
+        label: Returns with contributions deduction
+        ordinal: 35
+        column: DG
+        column_by_year:
+          2021: CW
+          2022: DG
+          2023: DG
+        source_column_id: charitable_returns
+        expected_column_header_row: 7
+        expected_column_header: "Number of\nreturns"
+        concept: irs_soi.returns_with_contributions_deduction
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+      - measure_id: charitable_amount
+        label: Contributions deduction amount
+        ordinal: 36
+        column: DH
+        column_by_year:
+          2021: CX
+          2022: DH
+          2023: DH
+        source_column_id: charitable_amount
+        expected_column_header_row: 7
+        expected_column_header: Amount
+        concept: irs_soi.contributions_deduction
+        unit: usd
+        aggregation: sum
+        value_scale: 1000
+        expected_cell_type: number

--- a/tests/test_arch_source_package.py
+++ b/tests/test_arch_source_package.py
@@ -274,8 +274,8 @@ def test_national_soi_source_package_aliases_validate_fixture_counts():
         "soi-table-2-1": {
             "record_set_count": 1,
             "row_count": 1,
-            "measure_count": 17,
-            "source_record_count": 17,
+            "measure_count": 37,
+            "source_record_count": 37,
             "source_region_count": 1,
         },
         "soi-table-2-5": {
@@ -348,6 +348,68 @@ def test_national_soi_source_package_aliases_validate_fixture_counts():
 
         assert report.valid, package_id
         assert report.counts == counts
+
+
+def test_soi_table_2_1_package_builds_itemized_deduction_details():
+    package = load_source_package("soi-table-2-1")
+    rows = package.build_source_rows(2023)
+    cells = package.build_source_cells(2023, source_rows=rows)
+    facts = package.build_facts(2023, cells=cells, source_rows=rows)
+    values_by_record = {fact.source_record_id: fact for fact in facts}
+
+    assert package.package_id == "soi-table-2-1"
+    assert validate_source_rows(rows).valid
+    assert validate_source_cells(cells).valid
+    assert validate_facts(facts).valid
+    assert len(facts) == 37
+
+    charitable = values_by_record[
+        "irs_soi.ty2023.table_2_1.itemized_all_returns.all.charitable_amount"
+    ]
+    interest = values_by_record[
+        "irs_soi.ty2023.table_2_1.itemized_all_returns.all."
+        "interest_paid_deduction_amount"
+    ]
+    mortgage_financial = values_by_record[
+        "irs_soi.ty2023.table_2_1.itemized_all_returns.all."
+        "mortgage_interest_paid_amount"
+    ]
+    mortgage_individual = values_by_record[
+        "irs_soi.ty2023.table_2_1.itemized_all_returns.all."
+        "home_mortgage_personal_seller_amount"
+    ]
+    deductible_points = values_by_record[
+        "irs_soi.ty2023.table_2_1.itemized_all_returns.all."
+        "deductible_points_amount"
+    ]
+    limited_salt = values_by_record[
+        "irs_soi.ty2023.table_2_1.itemized_all_returns.all."
+        "limited_state_local_taxes_amount"
+    ]
+    raw_state_local = values_by_record[
+        "irs_soi.ty2023.table_2_1.itemized_all_returns.all."
+        "total_state_local_taxes_amount"
+    ]
+    income_or_sales = values_by_record[
+        "irs_soi.ty2023.table_2_1.itemized_all_returns.all."
+        "state_local_income_or_sales_tax_amount"
+    ]
+    real_estate_taxes = values_by_record[
+        "irs_soi.ty2023.table_2_1.itemized_all_returns.all."
+        "real_estate_taxes_amount"
+    ]
+
+    assert charitable.value == 211_975_123_000
+    assert charitable.measure.concept == "irs_soi.contributions_deduction"
+    assert interest.value == 208_176_768_000
+    assert mortgage_financial.value == 167_675_863_000
+    assert mortgage_individual.value == 3_688_924_000
+    assert deductible_points.value == 1_027_127_000
+    assert limited_salt.value == 121_050_787_000
+    assert raw_state_local.value == 331_823_221_000
+    assert income_or_sales.value == 218_543_083_000
+    assert real_estate_taxes.value == 108_606_373_000
+    assert raw_state_local.source.raw_r2_uri
 
 
 def test_census_stc_income_tax_package_builds_state_tax_facts():


### PR DESCRIPTION
## Summary
- expands the IRS SOI Publication 1304 Table 2.1 source package with detailed itemized-deduction measures for state/local taxes, real estate taxes, limited SALT, interest paid, mortgage interest components, deductible points, investment interest, and contributions
- adds year-aware column mappings for 2021-2023 where the table layout shifted
- adds a focused regression test with 2023 all-return totals for the new measures

## Validation
- uv run arch validate-package soi-table-2-1 --year 2021
- uv run arch validate-package soi-table-2-1 --year 2022
- uv run arch validate-package soi-table-2-1 --year 2023
- uv run arch build-suite soi-table-2-1 --year 2023 --out /Users/maxghenis/CosilicoAI/microplex-us/artifacts/arch_soi_table_2_1_itemized_details_20260528/soi_table_2_1_y2023 --replace
- uv run pytest tests/test_arch_source_package.py -q
- uv run ruff check tests/test_arch_source_package.py