### PR TITLE
Add SOI Table 1.4 alimony facts

### DIFF
--- a/packages/irs_soi/table_1_4/source_package.yaml
+++ b/packages/irs_soi/table_1_4/source_package.yaml
@@ -544,9 +544,55 @@ record_sets:
         unit: usd
         aggregation: sum
         value_scale: 1000
+      - measure_id: alimony_received_returns
+        label: Returns with alimony received
+        ordinal: 12
+        column: AD
+        column_by_year:
+          2021: R
+          2022: AD
+          2023: AD
+        concept: irs_soi.returns_with_alimony_received
+        unit: count
+        aggregation: count
+      - measure_id: alimony_received_amount
+        label: Alimony received
+        ordinal: 13
+        column: AE
+        column_by_year:
+          2021: S
+          2022: AE
+          2023: AE
+        concept: irs_soi.alimony_received
+        unit: usd
+        aggregation: sum
+        value_scale: 1000
+      - measure_id: alimony_paid_returns
+        label: Returns with alimony paid
+        ordinal: 14
+        column: DR
+        column_by_year:
+          2021: DF
+          2022: DR
+          2023: DR
+        concept: irs_soi.returns_with_alimony_paid
+        unit: count
+        aggregation: count
+      - measure_id: alimony_paid_amount
+        label: Alimony paid
+        ordinal: 15
+        column: DS
+        column_by_year:
+          2021: DG
+          2022: DS
+          2023: DS
+        concept: irs_soi.alimony_paid
+        unit: usd
+        aggregation: sum
+        value_scale: 1000
       - measure_id: self_employed_pension_contribution_ald
         label: Payments to a Keogh plan
-        ordinal: 12
+        ordinal: 16
         column: DM
         column_by_year:
           2021: DA

--- a/tests/test_arch_bundle.py
+++ b/tests/test_arch_bundle.py
@@ -29,7 +29,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "aggregate_duplicate_key_count": 0,
         "entity_count": 6,
         "error_count": 0,
-        "fact_count": 7049,
+        "fact_count": 7149,
         "geography_count": 54,
         "period_count": 7,
         "semantic_duplicate_key_count": 3,
@@ -38,13 +38,13 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "source_package_count": 27,
         "warning_count": 1,
     }
-    assert len(rows) == 7049
+    assert len(rows) == 7149
     assert rows[0]["aggregate_fact_key"].startswith("arch.aggregate_fact.v2:")
     assert rows[0]["semantic_fact_key"].startswith("arch.semantic_fact.v2:")
     assert source_packages["source_package_count"] == 27
     assert source_packages["skipped_source_count"] == 0
     assert not source_packages["skipped_sources"]
-    assert coverage["fact_count"] == 7049
+    assert coverage["fact_count"] == 7149
     assert coverage["counts"]["by_source"] == {
         "census_pep": 988,
         "census_stc": 46,
@@ -54,7 +54,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "federal_reserve": 1,
         "hhs_acf_liheap": 1,
         "hhs_acf_tanf": 110,
-        "irs_soi": 5367,
+        "irs_soi": 5467,
         "kff": 52,
         "ssa": 6,
         "usda_snap": 216,
@@ -88,8 +88,8 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "irs_soi:Historic Table 2 state EITC totals": 510,
         "irs_soi:Publication 1304 Table 1.1": 80,
         "irs_soi:Publication 1304 Table 1.2": 7,
-        "irs_soi:Publication 1304 Table 1.4": 260,
-        "irs_soi:Publication 1304 Table 2.1": 17,
+        "irs_soi:Publication 1304 Table 1.4": 340,
+        "irs_soi:Publication 1304 Table 2.1": 37,
         "irs_soi:Publication 1304 Table 2.5": 8,
         "irs_soi:Publication 1304 Table 2.5 EITC by AGI and qualifying children": 232,
         "irs_soi:Publication 1304 Table 4.3": 18,
@@ -118,9 +118,9 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "fiscal_year:2024": 327,
         "month:2024-12": 260,
         "tax_year:2022": 4968,
-        "tax_year:2023": 399,
+        "tax_year:2023": 499,
     }
-    assert coverage["counts"]["by_geography"]["country:0100000US"] == 1284
+    assert coverage["counts"]["by_geography"]["country:0100000US"] == 1384
     assert coverage["counts"]["by_geography"]["state:0400000US06"] == 113
     assert len(coverage["counts"]["by_geography"]) == 54
     assert coverage["counts"]["by_entity"] == {
@@ -129,7 +129,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "household": 55,
         "institutional_sector": 1,
         "person": 1418,
-        "tax_unit": 5367,
+        "tax_unit": 5467,
     }
     assert not coverage["duplicates"]["aggregate_fact_keys"]
     assert len(coverage["duplicates"]["semantic_fact_keys"]) == 3

--- a/tests/test_arch_soi_targets.py
+++ b/tests/test_arch_soi_targets.py
@@ -139,7 +139,7 @@ def test_build_soi_table_1_4_wage_facts_from_packaged_source():
     }
 
     assert validate_facts(facts).valid
-    assert len(facts) == 260
+    assert len(facts) == 340
     assert facts_by_concept_and_range[
         ("irs_soi.returns_with_total_wages", "all")
     ].value == 128_591_050
@@ -164,6 +164,12 @@ def test_build_soi_table_1_4_wage_facts_from_packaged_source():
     assert facts_by_concept_and_range[
         ("irs_soi.taxable_social_security_benefits", "all")
     ].value == 527_072_873_000
+    assert facts_by_concept_and_range[
+        ("irs_soi.alimony_received", "all")
+    ].value == 6_686_429_000
+    assert facts_by_concept_and_range[
+        ("irs_soi.alimony_paid", "all")
+    ].value == 7_497_135_000
     assert {fact.source.url for fact in facts} == {
         "https://www.irs.gov/pub/irs-soi/23in14ar.xls"
     }
@@ -180,4 +186,4 @@ def test_soi_table_1_4_source_region_spec_covers_wage_record_set():
     assert regions[0].top_row == 9
     assert regions[0].bottom_row == 28
     assert regions[0].left_column == 1
-    assert regions[0].right_column == 117
+    assert regions[0].right_column == 123

--- a/tests/test_arch_source_package.py
+++ b/tests/test_arch_source_package.py
@@ -241,12 +241,23 @@ def test_source_package_path_builds_valid_soi_table_1_4_facts():
     package = load_source_package(package_path)
     cells = package.build_source_cells(2023)
     facts = package.build_facts(2023, cells=cells)
+    values_by_record = {fact.source_record_id: fact for fact in facts}
 
     assert package.package_id == "soi-table-1-4"
     assert len(cells) == 8109
-    assert len(facts) == 260
+    assert len(facts) == 340
     assert validate_facts(facts).valid
     assert facts[0].source.source_table == "Publication 1304 Table 1.4"
+    assert (
+        values_by_record[
+            "irs_soi.ty2023.table_1_4.all.alimony_received_amount"
+        ].value
+        == 6_686_429_000
+    )
+    assert (
+        values_by_record["irs_soi.ty2023.table_1_4.all.alimony_paid_amount"].value
+        == 7_497_135_000
+    )
 
 
 def test_validate_source_package_reports_fixture_counts():

--- a/tests/test_arch_suite.py
+++ b/tests/test_arch_suite.py
@@ -140,16 +140,16 @@ def test_build_source_suite_supports_soi_table_1_4(tmp_path):
         "artifact_count": 1,
         "agent_acceptance_error_count": 0,
         "concept_alignment_count": 2,
-        "constraint_count": 468,
-        "consumer_fact_count": 260,
-        "fact_count": 260,
+        "constraint_count": 612,
+        "consumer_fact_count": 340,
+        "fact_count": 340,
         "lineage_coverage": 1.0,
         "source_cell_count": 8109,
-        "source_record_count": 260,
+        "source_record_count": 340,
         "source_region_count": 1,
         "source_row_count": 0,
     }
-    assert summary["reports"]["source_regions"]["covered_cell_count"] == 2340
+    assert summary["reports"]["source_regions"]["covered_cell_count"] == 2460
     assert summary["reports"]["agent_acceptance"]["valid"]
     assert summary["reports"]["agent_acceptance"]["warnings"][0]["code"] == (
         "concept_alignment_validation_skipped"


### PR DESCRIPTION
## Summary
- add SOI Publication 1304 Table 1.4 alimony received/paid return counts and amounts
- handle the 2021 vs 2022/2023 column layout shift declaratively
- refresh source package, suite, and merged bundle fixtures

## Tests
- uv run ruff check tests/test_arch_source_package.py tests/test_arch_soi_targets.py tests/test_arch_suite.py tests/test_arch_bundle.py
- uv run pytest tests/test_arch_bundle.py::test_build_bundle_writes_merged_consumer_contract -q
- uv run pytest tests/test_arch_source_package.py::test_source_package_path_builds_valid_soi_table_1_4_facts tests/test_arch_soi_targets.py::test_build_soi_table_1_4_wage_facts_from_packaged_source tests/test_arch_soi_targets.py::test_soi_table_1_4_source_region_spec_covers_wage_record_set tests/test_arch_suite.py::test_build_source_suite_supports_soi_table_1_4 -q