### PR TITLE
Add BEA NIPA source packages

### DIFF
--- a/arch/source_package.py
+++ b/arch/source_package.py
@@ -66,6 +66,11 @@ from arch.sources.specs import (
 
 SOURCE_PACKAGE_RESOURCE_PACKAGE = "packages"
 SOURCE_PACKAGE_ALIASES = {
+    "bea-nipa-personal-income-components": Path("bea/nipa_personal_income_components"),
+    "bea-nipa-personal-income-disposition": Path(
+        "bea/nipa_personal_income_disposition"
+    ),
+    "bea-nipa-total-wages-salaries": Path("bea/nipa_total_wages_salaries"),
     "census-pep-2024-national-age-sex": Path("census/pep_2024_national_age_sex"),
     "census-pep-2024-state-age-sex": Path("census/pep_2024_state_age_sex"),
     "census-stc-individual-income-tax": Path(

--- a/db/data/bea/nipa_total_wages_salaries/manifest.yaml
+++ b/db/data/bea/nipa_total_wages_salaries/manifest.yaml
@@ -1,0 +1,18 @@
+source_id: bea
+package_id: bea-nipa-total-wages-salaries
+dataset: bea_nipa_total_wages_salaries
+source_page: https://www.bea.gov/open-data
+table: NIPA Annual Data Flat File
+files:
+  2024:
+    filename: NipaDataA.txt
+    source_url: https://apps.bea.gov/national/Release/TXT/NipaDataA.txt
+    sha256: b4e985b133e21f099eb538c89263b27632751b7041e79d6a5f5bac4aa54fab81
+    size_bytes: 12032724
+    fetched_at: '2026-05-11T13:59:30+00:00'
+    storage:
+      r2:
+        provider: r2
+        bucket: arch-raw
+        key: raw/bea/bea-nipa-total-wages-salaries/2024/b4e985b133e21f099eb538c89263b27632751b7041e79d6a5f5bac4aa54fab81/NipaDataA.txt
+        uri: r2://arch-raw/raw/bea/bea-nipa-total-wages-salaries/2024/b4e985b133e21f099eb538c89263b27632751b7041e79d6a5f5bac4aa54fab81/NipaDataA.txt

--- a/packages/bea/nipa_personal_income_components/source_package.yaml
+++ b/packages/bea/nipa_personal_income_components/source_package.yaml
@@ -1,0 +1,935 @@
+schema_version: arch.source_package.v1
+package_id: bea-nipa-personal-income-components
+label: BEA NIPA personal income components
+artifact:
+  source_name: bea
+  source_table: BEA NIPA annual data flat file
+  resource_package: db
+  resource_directory: data/bea/nipa_total_wages_salaries
+  manifest: manifest.yaml
+  vintage: bea_nipa_annual_release_2026_04_30
+  extracted_at: "2026-05-11"
+  extraction_method: delimited text full-row parse with selected-cell facts
+  parser: delimited_text_full_rows
+  sheet_name: NipaDataA
+  artifact_year: 2024
+  selected_rows:
+    - SeriesCode: A041RC
+      Period: "{year}"
+    - SeriesCode: A048RC
+      Period: "{year}"
+    - SeriesCode: A064RC
+      Period: "{year}"
+    - SeriesCode: B703RC
+      Period: "{year}"
+    - SeriesCode: A038RC
+      Period: "{year}"
+    - SeriesCode: B040RC
+      Period: "{year}"
+    - SeriesCode: B039RC
+      Period: "{year}"
+    - SeriesCode: B042RC
+      Period: "{year}"
+    - SeriesCode: A045RC
+      Period: "{year}"
+    - SeriesCode: A063RC
+      Period: "{year}"
+    - SeriesCode: W823RC
+      Period: "{year}"
+    - SeriesCode: W824RC
+      Period: "{year}"
+    - SeriesCode: W729RC
+      Period: "{year}"
+    - SeriesCode: W825RC
+      Period: "{year}"
+    - SeriesCode: W826RC
+      Period: "{year}"
+    - SeriesCode: W827RC
+      Period: "{year}"
+    - SeriesCode: B931RC
+      Period: "{year}"
+    - SeriesCode: A577RC
+      Period: "{year}"
+record_sets:
+  - record_set_id: bea_nipa.cy{year}.proprietors_income
+    record_set_spec_id: bea_nipa.proprietors_income.v1
+    source_record_id_prefix: bea_nipa.cy{year}.proprietors_income
+    sheet_name: NipaDataA
+    period_type: calendar_year
+    period: "{year}"
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    entity: person
+    entity_role: proprietor
+    domain: personal_income
+    groupby_dimension: bea_nipa.series_code
+    rows:
+      - value_id: a041rc
+        label: A041RC
+        ordinal: 0
+        row_number: 2
+        expected_row_header_column: A
+        expected_row_header: A041RC
+        filters:
+          bea_nipa.series_code: A041RC
+        constraints:
+          - variable: bea_nipa.series_code
+            operator: "=="
+            value: A041RC
+            label: BEA NIPA series code
+        guard_cells:
+          - column: B
+            row: start
+            expected_value: "{year}"
+            label: calendar year
+    measures:
+      - measure_id: amount
+        label: Proprietors' income with inventory valuation and capital consumption adjustments
+        ordinal: 0
+        column: C
+        source_column_id: value
+        expected_column_header_row: 1
+        expected_column_header: Value
+        concept: bea_nipa.proprietors_income_with_inventory_valuation_and_capital_consumption_adjustments
+        source_concept: bea_nipa.a041rc_proprietors_income_with_inventory_valuation_and_capital_consumption_adjustments
+        concept_relation: source_label
+        concept_authority: bea
+        unit: usd
+        aggregation: sum
+        value_scale: 1000000
+        expected_cell_type: number
+  - record_set_id: bea_nipa.cy{year}.rental_income_of_persons
+    record_set_spec_id: bea_nipa.rental_income_of_persons.v1
+    source_record_id_prefix: bea_nipa.cy{year}.rental_income_of_persons
+    sheet_name: NipaDataA
+    period_type: calendar_year
+    period: "{year}"
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    entity: person
+    entity_role: income_recipient
+    domain: personal_income
+    groupby_dimension: bea_nipa.series_code
+    rows:
+      - value_id: a048rc
+        label: A048RC
+        ordinal: 0
+        row_number: 3
+        expected_row_header_column: A
+        expected_row_header: A048RC
+        filters:
+          bea_nipa.series_code: A048RC
+        constraints:
+          - variable: bea_nipa.series_code
+            operator: "=="
+            value: A048RC
+            label: BEA NIPA series code
+        guard_cells:
+          - column: B
+            row: start
+            expected_value: "{year}"
+            label: calendar year
+    measures:
+      - measure_id: amount
+        label: Rental income of persons with capital consumption adjustment
+        ordinal: 0
+        column: C
+        source_column_id: value
+        expected_column_header_row: 1
+        expected_column_header: Value
+        concept: bea_nipa.rental_income_of_persons_with_capital_consumption_adjustment
+        source_concept: bea_nipa.a048rc_rental_income_of_persons_with_capital_consumption_adjustment
+        concept_relation: source_label
+        concept_authority: bea
+        unit: usd
+        aggregation: sum
+        value_scale: 1000000
+        expected_cell_type: number
+  - record_set_id: bea_nipa.cy{year}.personal_interest_income
+    record_set_spec_id: bea_nipa.personal_interest_income.v1
+    source_record_id_prefix: bea_nipa.cy{year}.personal_interest_income
+    sheet_name: NipaDataA
+    period_type: calendar_year
+    period: "{year}"
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    entity: person
+    entity_role: income_recipient
+    domain: personal_income
+    groupby_dimension: bea_nipa.series_code
+    rows:
+      - value_id: a064rc
+        label: A064RC
+        ordinal: 0
+        row_number: 4
+        expected_row_header_column: A
+        expected_row_header: A064RC
+        filters:
+          bea_nipa.series_code: A064RC
+        constraints:
+          - variable: bea_nipa.series_code
+            operator: "=="
+            value: A064RC
+            label: BEA NIPA series code
+        guard_cells:
+          - column: B
+            row: start
+            expected_value: "{year}"
+            label: calendar year
+    measures:
+      - measure_id: amount
+        label: Personal interest income
+        ordinal: 0
+        column: C
+        source_column_id: value
+        expected_column_header_row: 1
+        expected_column_header: Value
+        concept: bea_nipa.personal_interest_income
+        source_concept: bea_nipa.a064rc_personal_interest_income
+        concept_relation: source_label
+        concept_authority: bea
+        unit: usd
+        aggregation: sum
+        value_scale: 1000000
+        expected_cell_type: number
+  - record_set_id: bea_nipa.cy{year}.personal_dividend_income
+    record_set_spec_id: bea_nipa.personal_dividend_income.v1
+    source_record_id_prefix: bea_nipa.cy{year}.personal_dividend_income
+    sheet_name: NipaDataA
+    period_type: calendar_year
+    period: "{year}"
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    entity: person
+    entity_role: income_recipient
+    domain: personal_income
+    groupby_dimension: bea_nipa.series_code
+    rows:
+      - value_id: b703rc
+        label: B703RC
+        ordinal: 0
+        row_number: 5
+        expected_row_header_column: A
+        expected_row_header: B703RC
+        filters:
+          bea_nipa.series_code: B703RC
+        constraints:
+          - variable: bea_nipa.series_code
+            operator: "=="
+            value: B703RC
+            label: BEA NIPA series code
+        guard_cells:
+          - column: B
+            row: start
+            expected_value: "{year}"
+            label: calendar year
+    measures:
+      - measure_id: amount
+        label: Personal dividend income
+        ordinal: 0
+        column: C
+        source_column_id: value
+        expected_column_header_row: 1
+        expected_column_header: Value
+        concept: bea_nipa.personal_dividend_income
+        source_concept: bea_nipa.b703rc_personal_dividend_income
+        concept_relation: source_label
+        concept_authority: bea
+        unit: usd
+        aggregation: sum
+        value_scale: 1000000
+        expected_cell_type: number
+  - record_set_id: bea_nipa.cy{year}.supplements_to_wages_and_salaries
+    record_set_spec_id: bea_nipa.supplements_to_wages_and_salaries.v1
+    source_record_id_prefix: bea_nipa.cy{year}.supplements_to_wages_and_salaries
+    sheet_name: NipaDataA
+    period_type: calendar_year
+    period: "{year}"
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    entity: person
+    entity_role: employee
+    domain: compensation_of_employees
+    groupby_dimension: bea_nipa.series_code
+    rows:
+      - value_id: a038rc
+        label: A038RC
+        ordinal: 0
+        row_number: 6
+        expected_row_header_column: A
+        expected_row_header: A038RC
+        filters:
+          bea_nipa.series_code: A038RC
+        constraints:
+          - variable: bea_nipa.series_code
+            operator: "=="
+            value: A038RC
+            label: BEA NIPA series code
+        guard_cells:
+          - column: B
+            row: start
+            expected_value: "{year}"
+            label: calendar year
+    measures:
+      - measure_id: amount
+        label: Supplements to wages and salaries
+        ordinal: 0
+        column: C
+        source_column_id: value
+        expected_column_header_row: 1
+        expected_column_header: Value
+        concept: bea_nipa.supplements_to_wages_and_salaries
+        source_concept: bea_nipa.a038rc_supplements_to_wages_and_salaries
+        concept_relation: source_label
+        concept_authority: bea
+        unit: usd
+        aggregation: sum
+        value_scale: 1000000
+        expected_cell_type: number
+  - record_set_id: bea_nipa.cy{year}.employer_pension_and_insurance_contributions
+    record_set_spec_id: bea_nipa.employer_pension_and_insurance_contributions.v1
+    source_record_id_prefix: bea_nipa.cy{year}.employer_pension_and_insurance_contributions
+    sheet_name: NipaDataA
+    period_type: calendar_year
+    period: "{year}"
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    entity: person
+    entity_role: employee
+    domain: compensation_of_employees
+    groupby_dimension: bea_nipa.series_code
+    rows:
+      - value_id: b040rc
+        label: B040RC
+        ordinal: 0
+        row_number: 7
+        expected_row_header_column: A
+        expected_row_header: B040RC
+        filters:
+          bea_nipa.series_code: B040RC
+        constraints:
+          - variable: bea_nipa.series_code
+            operator: "=="
+            value: B040RC
+            label: BEA NIPA series code
+        guard_cells:
+          - column: B
+            row: start
+            expected_value: "{year}"
+            label: calendar year
+    measures:
+      - measure_id: amount
+        label: Employer contributions for employee pension and insurance funds
+        ordinal: 0
+        column: C
+        source_column_id: value
+        expected_column_header_row: 1
+        expected_column_header: Value
+        concept: bea_nipa.employer_contributions_for_employee_pension_and_insurance_funds
+        source_concept: bea_nipa.b040rc_employer_contributions_for_employee_pension_and_insurance_funds
+        concept_relation: source_label
+        concept_authority: bea
+        unit: usd
+        aggregation: sum
+        value_scale: 1000000
+        expected_cell_type: number
+  - record_set_id: bea_nipa.cy{year}.employer_government_social_insurance_contributions
+    record_set_spec_id: bea_nipa.employer_government_social_insurance_contributions.v1
+    source_record_id_prefix: bea_nipa.cy{year}.employer_government_social_insurance_contributions
+    sheet_name: NipaDataA
+    period_type: calendar_year
+    period: "{year}"
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    entity: person
+    entity_role: employee
+    domain: compensation_of_employees
+    groupby_dimension: bea_nipa.series_code
+    rows:
+      - value_id: b039rc
+        label: B039RC
+        ordinal: 0
+        row_number: 8
+        expected_row_header_column: A
+        expected_row_header: B039RC
+        filters:
+          bea_nipa.series_code: B039RC
+        constraints:
+          - variable: bea_nipa.series_code
+            operator: "=="
+            value: B039RC
+            label: BEA NIPA series code
+        guard_cells:
+          - column: B
+            row: start
+            expected_value: "{year}"
+            label: calendar year
+    measures:
+      - measure_id: amount
+        label: Employer contributions for government social insurance
+        ordinal: 0
+        column: C
+        source_column_id: value
+        expected_column_header_row: 1
+        expected_column_header: Value
+        concept: bea_nipa.employer_contributions_for_government_social_insurance
+        source_concept: bea_nipa.b039rc_employer_contributions_for_government_social_insurance
+        concept_relation: source_label
+        concept_authority: bea
+        unit: usd
+        aggregation: sum
+        value_scale: 1000000
+        expected_cell_type: number
+  - record_set_id: bea_nipa.cy{year}.farm_proprietors_income
+    record_set_spec_id: bea_nipa.farm_proprietors_income.v1
+    source_record_id_prefix: bea_nipa.cy{year}.farm_proprietors_income
+    sheet_name: NipaDataA
+    period_type: calendar_year
+    period: "{year}"
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    entity: person
+    entity_role: proprietor
+    domain: personal_income
+    groupby_dimension: bea_nipa.series_code
+    rows:
+      - value_id: b042rc
+        label: B042RC
+        ordinal: 0
+        row_number: 9
+        expected_row_header_column: A
+        expected_row_header: B042RC
+        filters:
+          bea_nipa.series_code: B042RC
+        constraints:
+          - variable: bea_nipa.series_code
+            operator: "=="
+            value: B042RC
+            label: BEA NIPA series code
+        guard_cells:
+          - column: B
+            row: start
+            expected_value: "{year}"
+            label: calendar year
+    measures:
+      - measure_id: amount
+        label: Farm proprietors' income
+        ordinal: 0
+        column: C
+        source_column_id: value
+        expected_column_header_row: 1
+        expected_column_header: Value
+        concept: bea_nipa.farm_proprietors_income
+        source_concept: bea_nipa.b042rc_farm_proprietors_income
+        concept_relation: source_label
+        concept_authority: bea
+        unit: usd
+        aggregation: sum
+        value_scale: 1000000
+        expected_cell_type: number
+  - record_set_id: bea_nipa.cy{year}.nonfarm_proprietors_income
+    record_set_spec_id: bea_nipa.nonfarm_proprietors_income.v1
+    source_record_id_prefix: bea_nipa.cy{year}.nonfarm_proprietors_income
+    sheet_name: NipaDataA
+    period_type: calendar_year
+    period: "{year}"
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    entity: person
+    entity_role: proprietor
+    domain: personal_income
+    groupby_dimension: bea_nipa.series_code
+    rows:
+      - value_id: a045rc
+        label: A045RC
+        ordinal: 0
+        row_number: 10
+        expected_row_header_column: A
+        expected_row_header: A045RC
+        filters:
+          bea_nipa.series_code: A045RC
+        constraints:
+          - variable: bea_nipa.series_code
+            operator: "=="
+            value: A045RC
+            label: BEA NIPA series code
+        guard_cells:
+          - column: B
+            row: start
+            expected_value: "{year}"
+            label: calendar year
+    measures:
+      - measure_id: amount
+        label: Nonfarm proprietors' income
+        ordinal: 0
+        column: C
+        source_column_id: value
+        expected_column_header_row: 1
+        expected_column_header: Value
+        concept: bea_nipa.nonfarm_proprietors_income
+        source_concept: bea_nipa.a045rc_nonfarm_proprietors_income
+        concept_relation: source_label
+        concept_authority: bea
+        unit: usd
+        aggregation: sum
+        value_scale: 1000000
+        expected_cell_type: number
+  - record_set_id: bea_nipa.cy{year}.government_social_benefits_to_persons
+    record_set_spec_id: bea_nipa.government_social_benefits_to_persons.v1
+    source_record_id_prefix: bea_nipa.cy{year}.government_social_benefits_to_persons
+    sheet_name: NipaDataA
+    period_type: calendar_year
+    period: "{year}"
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    entity: person
+    entity_role: benefit_recipient
+    domain: personal_current_transfer_receipts
+    groupby_dimension: bea_nipa.series_code
+    rows:
+      - value_id: a063rc
+        label: A063RC
+        ordinal: 0
+        row_number: 11
+        expected_row_header_column: A
+        expected_row_header: A063RC
+        filters:
+          bea_nipa.series_code: A063RC
+        constraints:
+          - variable: bea_nipa.series_code
+            operator: "=="
+            value: A063RC
+            label: BEA NIPA series code
+        guard_cells:
+          - column: B
+            row: start
+            expected_value: "{year}"
+            label: calendar year
+    measures:
+      - measure_id: amount
+        label: Government social benefits to persons
+        ordinal: 0
+        column: C
+        source_column_id: value
+        expected_column_header_row: 1
+        expected_column_header: Value
+        concept: bea_nipa.government_social_benefits_to_persons
+        source_concept: bea_nipa.a063rc_government_social_benefits_to_persons
+        concept_relation: source_label
+        concept_authority: bea
+        unit: usd
+        aggregation: sum
+        value_scale: 1000000
+        expected_cell_type: number
+  - record_set_id: bea_nipa.cy{year}.social_security_benefits
+    record_set_spec_id: bea_nipa.social_security_benefits.v1
+    source_record_id_prefix: bea_nipa.cy{year}.social_security_benefits
+    sheet_name: NipaDataA
+    period_type: calendar_year
+    period: "{year}"
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    entity: person
+    entity_role: benefit_recipient
+    domain: personal_current_transfer_receipts
+    groupby_dimension: bea_nipa.series_code
+    rows:
+      - value_id: w823rc
+        label: W823RC
+        ordinal: 0
+        row_number: 12
+        expected_row_header_column: A
+        expected_row_header: W823RC
+        filters:
+          bea_nipa.series_code: W823RC
+        constraints:
+          - variable: bea_nipa.series_code
+            operator: "=="
+            value: W823RC
+            label: BEA NIPA series code
+        guard_cells:
+          - column: B
+            row: start
+            expected_value: "{year}"
+            label: calendar year
+    measures:
+      - measure_id: amount
+        label: Social Security benefits
+        ordinal: 0
+        column: C
+        source_column_id: value
+        expected_column_header_row: 1
+        expected_column_header: Value
+        concept: bea_nipa.social_security_benefits
+        source_concept: bea_nipa.w823rc_social_security_benefits
+        concept_relation: source_label
+        concept_authority: bea
+        unit: usd
+        aggregation: sum
+        value_scale: 1000000
+        expected_cell_type: number
+  - record_set_id: bea_nipa.cy{year}.medicare_benefits
+    record_set_spec_id: bea_nipa.medicare_benefits.v1
+    source_record_id_prefix: bea_nipa.cy{year}.medicare_benefits
+    sheet_name: NipaDataA
+    period_type: calendar_year
+    period: "{year}"
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    entity: person
+    entity_role: benefit_recipient
+    domain: personal_current_transfer_receipts
+    groupby_dimension: bea_nipa.series_code
+    rows:
+      - value_id: w824rc
+        label: W824RC
+        ordinal: 0
+        row_number: 13
+        expected_row_header_column: A
+        expected_row_header: W824RC
+        filters:
+          bea_nipa.series_code: W824RC
+        constraints:
+          - variable: bea_nipa.series_code
+            operator: "=="
+            value: W824RC
+            label: BEA NIPA series code
+        guard_cells:
+          - column: B
+            row: start
+            expected_value: "{year}"
+            label: calendar year
+    measures:
+      - measure_id: amount
+        label: Medicare benefits
+        ordinal: 0
+        column: C
+        source_column_id: value
+        expected_column_header_row: 1
+        expected_column_header: Value
+        concept: bea_nipa.medicare_benefits
+        source_concept: bea_nipa.w824rc_medicare_benefits
+        concept_relation: source_label
+        concept_authority: bea
+        unit: usd
+        aggregation: sum
+        value_scale: 1000000
+        expected_cell_type: number
+  - record_set_id: bea_nipa.cy{year}.medicaid_benefits
+    record_set_spec_id: bea_nipa.medicaid_benefits.v1
+    source_record_id_prefix: bea_nipa.cy{year}.medicaid_benefits
+    sheet_name: NipaDataA
+    period_type: calendar_year
+    period: "{year}"
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    entity: person
+    entity_role: benefit_recipient
+    domain: personal_current_transfer_receipts
+    groupby_dimension: bea_nipa.series_code
+    rows:
+      - value_id: w729rc
+        label: W729RC
+        ordinal: 0
+        row_number: 14
+        expected_row_header_column: A
+        expected_row_header: W729RC
+        filters:
+          bea_nipa.series_code: W729RC
+        constraints:
+          - variable: bea_nipa.series_code
+            operator: "=="
+            value: W729RC
+            label: BEA NIPA series code
+        guard_cells:
+          - column: B
+            row: start
+            expected_value: "{year}"
+            label: calendar year
+    measures:
+      - measure_id: amount
+        label: Medicaid benefits
+        ordinal: 0
+        column: C
+        source_column_id: value
+        expected_column_header_row: 1
+        expected_column_header: Value
+        concept: bea_nipa.medicaid_benefits
+        source_concept: bea_nipa.w729rc_medicaid_benefits
+        concept_relation: source_label
+        concept_authority: bea
+        unit: usd
+        aggregation: sum
+        value_scale: 1000000
+        expected_cell_type: number
+  - record_set_id: bea_nipa.cy{year}.unemployment_insurance_benefits
+    record_set_spec_id: bea_nipa.unemployment_insurance_benefits.v1
+    source_record_id_prefix: bea_nipa.cy{year}.unemployment_insurance_benefits
+    sheet_name: NipaDataA
+    period_type: calendar_year
+    period: "{year}"
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    entity: person
+    entity_role: benefit_recipient
+    domain: personal_current_transfer_receipts
+    groupby_dimension: bea_nipa.series_code
+    rows:
+      - value_id: w825rc
+        label: W825RC
+        ordinal: 0
+        row_number: 15
+        expected_row_header_column: A
+        expected_row_header: W825RC
+        filters:
+          bea_nipa.series_code: W825RC
+        constraints:
+          - variable: bea_nipa.series_code
+            operator: "=="
+            value: W825RC
+            label: BEA NIPA series code
+        guard_cells:
+          - column: B
+            row: start
+            expected_value: "{year}"
+            label: calendar year
+    measures:
+      - measure_id: amount
+        label: Unemployment insurance benefits
+        ordinal: 0
+        column: C
+        source_column_id: value
+        expected_column_header_row: 1
+        expected_column_header: Value
+        concept: bea_nipa.unemployment_insurance_benefits
+        source_concept: bea_nipa.w825rc_unemployment_insurance_benefits
+        concept_relation: source_label
+        concept_authority: bea
+        unit: usd
+        aggregation: sum
+        value_scale: 1000000
+        expected_cell_type: number
+  - record_set_id: bea_nipa.cy{year}.veterans_benefits
+    record_set_spec_id: bea_nipa.veterans_benefits.v1
+    source_record_id_prefix: bea_nipa.cy{year}.veterans_benefits
+    sheet_name: NipaDataA
+    period_type: calendar_year
+    period: "{year}"
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    entity: person
+    entity_role: benefit_recipient
+    domain: personal_current_transfer_receipts
+    groupby_dimension: bea_nipa.series_code
+    rows:
+      - value_id: w826rc
+        label: W826RC
+        ordinal: 0
+        row_number: 16
+        expected_row_header_column: A
+        expected_row_header: W826RC
+        filters:
+          bea_nipa.series_code: W826RC
+        constraints:
+          - variable: bea_nipa.series_code
+            operator: "=="
+            value: W826RC
+            label: BEA NIPA series code
+        guard_cells:
+          - column: B
+            row: start
+            expected_value: "{year}"
+            label: calendar year
+    measures:
+      - measure_id: amount
+        label: Veterans' benefits
+        ordinal: 0
+        column: C
+        source_column_id: value
+        expected_column_header_row: 1
+        expected_column_header: Value
+        concept: bea_nipa.veterans_benefits
+        source_concept: bea_nipa.w826rc_veterans_benefits
+        concept_relation: source_label
+        concept_authority: bea
+        unit: usd
+        aggregation: sum
+        value_scale: 1000000
+        expected_cell_type: number
+  - record_set_id: bea_nipa.cy{year}.other_government_social_benefits
+    record_set_spec_id: bea_nipa.other_government_social_benefits.v1
+    source_record_id_prefix: bea_nipa.cy{year}.other_government_social_benefits
+    sheet_name: NipaDataA
+    period_type: calendar_year
+    period: "{year}"
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    entity: person
+    entity_role: benefit_recipient
+    domain: personal_current_transfer_receipts
+    groupby_dimension: bea_nipa.series_code
+    rows:
+      - value_id: w827rc
+        label: W827RC
+        ordinal: 0
+        row_number: 17
+        expected_row_header_column: A
+        expected_row_header: W827RC
+        filters:
+          bea_nipa.series_code: W827RC
+        constraints:
+          - variable: bea_nipa.series_code
+            operator: "=="
+            value: W827RC
+            label: BEA NIPA series code
+        guard_cells:
+          - column: B
+            row: start
+            expected_value: "{year}"
+            label: calendar year
+    measures:
+      - measure_id: amount
+        label: Other government social benefits to persons
+        ordinal: 0
+        column: C
+        source_column_id: value
+        expected_column_header_row: 1
+        expected_column_header: Value
+        concept: bea_nipa.other_government_social_benefits_to_persons
+        source_concept: bea_nipa.w827rc_other_government_social_benefits_to_persons
+        concept_relation: source_label
+        concept_authority: bea
+        unit: usd
+        aggregation: sum
+        value_scale: 1000000
+        expected_cell_type: number
+  - record_set_id: bea_nipa.cy{year}.business_current_transfer_receipts
+    record_set_spec_id: bea_nipa.business_current_transfer_receipts.v1
+    source_record_id_prefix: bea_nipa.cy{year}.business_current_transfer_receipts
+    sheet_name: NipaDataA
+    period_type: calendar_year
+    period: "{year}"
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    entity: person
+    entity_role: transfer_recipient
+    domain: personal_current_transfer_receipts
+    groupby_dimension: bea_nipa.series_code
+    rows:
+      - value_id: b931rc
+        label: B931RC
+        ordinal: 0
+        row_number: 18
+        expected_row_header_column: A
+        expected_row_header: B931RC
+        filters:
+          bea_nipa.series_code: B931RC
+        constraints:
+          - variable: bea_nipa.series_code
+            operator: "=="
+            value: B931RC
+            label: BEA NIPA series code
+        guard_cells:
+          - column: B
+            row: start
+            expected_value: "{year}"
+            label: calendar year
+    measures:
+      - measure_id: amount
+        label: Other current transfer receipts, from business (net)
+        ordinal: 0
+        column: C
+        source_column_id: value
+        expected_column_header_row: 1
+        expected_column_header: Value
+        concept: bea_nipa.other_current_transfer_receipts_from_business_net
+        source_concept: bea_nipa.b931rc_other_current_transfer_receipts_from_business_net
+        concept_relation: source_label
+        concept_authority: bea
+        unit: usd
+        aggregation: sum
+        value_scale: 1000000
+        expected_cell_type: number
+  - record_set_id: bea_nipa.cy{year}.personal_current_transfer_receipts
+    record_set_spec_id: bea_nipa.personal_current_transfer_receipts.v1
+    source_record_id_prefix: bea_nipa.cy{year}.personal_current_transfer_receipts
+    sheet_name: NipaDataA
+    period_type: calendar_year
+    period: "{year}"
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    entity: person
+    entity_role: transfer_recipient
+    domain: personal_current_transfer_receipts
+    groupby_dimension: bea_nipa.series_code
+    rows:
+      - value_id: a577rc
+        label: A577RC
+        ordinal: 0
+        row_number: 19
+        expected_row_header_column: A
+        expected_row_header: A577RC
+        filters:
+          bea_nipa.series_code: A577RC
+        constraints:
+          - variable: bea_nipa.series_code
+            operator: "=="
+            value: A577RC
+            label: BEA NIPA series code
+        guard_cells:
+          - column: B
+            row: start
+            expected_value: "{year}"
+            label: calendar year
+    measures:
+      - measure_id: amount
+        label: Personal current transfer receipts
+        ordinal: 0
+        column: C
+        source_column_id: value
+        expected_column_header_row: 1
+        expected_column_header: Value
+        concept: bea_nipa.personal_current_transfer_receipts
+        source_concept: bea_nipa.a577rc_personal_current_transfer_receipts
+        concept_relation: source_label
+        concept_authority: bea
+        unit: usd
+        aggregation: sum
+        value_scale: 1000000
+        expected_cell_type: number

--- a/packages/bea/nipa_personal_income_disposition/source_package.yaml
+++ b/packages/bea/nipa_personal_income_disposition/source_package.yaml
@@ -1,0 +1,323 @@
+schema_version: arch.source_package.v1
+package_id: bea-nipa-personal-income-disposition
+label: BEA NIPA personal income disposition
+artifact:
+  source_name: bea
+  source_table: BEA NIPA annual data flat file
+  resource_package: db
+  resource_directory: data/bea/nipa_total_wages_salaries
+  manifest: manifest.yaml
+  vintage: bea_nipa_annual_release_2026_04_30
+  extracted_at: '2026-05-11'
+  extraction_method: delimited text full-row parse with selected-cell facts
+  parser: delimited_text_full_rows
+  sheet_name: NipaDataA
+  artifact_year: 2024
+  selected_rows:
+  - SeriesCode: A065RC
+    Period: '{year}'
+  - SeriesCode: W055RC
+    Period: '{year}'
+  - SeriesCode: A067RC
+    Period: '{year}'
+  - SeriesCode: A068RC
+    Period: '{year}'
+  - SeriesCode: A071RC
+    Period: '{year}'
+  - SeriesCode: A072RC
+    Period: '{year}'
+record_sets:
+- record_set_id: bea_nipa.cy{year}.personal_income
+  record_set_spec_id: bea_nipa.personal_income.v1
+  source_record_id_prefix: bea_nipa.cy{year}.personal_income
+  sheet_name: NipaDataA
+  period_type: calendar_year
+  period: '{year}'
+  geography_id: 0100000US
+  geography_level: country
+  geography_name: United States
+  geography_vintage: current
+  entity: person
+  entity_role: income_recipient
+  domain: personal_income
+  groupby_dimension: bea_nipa.series_code
+  rows:
+  - value_id: a065rc
+    label: A065RC
+    ordinal: 0
+    row_number: 2
+    expected_row_header_column: A
+    expected_row_header: A065RC
+    filters:
+      bea_nipa.series_code: A065RC
+    constraints:
+    - variable: bea_nipa.series_code
+      operator: ==
+      value: A065RC
+      label: BEA NIPA series code
+    guard_cells:
+    - column: B
+      row: start
+      expected_value: '{year}'
+      label: calendar year
+  measures:
+  - measure_id: amount
+    label: Personal income
+    ordinal: 0
+    column: C
+    source_column_id: value
+    expected_column_header_row: 1
+    expected_column_header: Value
+    concept: bea_nipa.personal_income
+    source_concept: bea_nipa.a065rc_personal_income
+    concept_relation: source_label
+    concept_authority: bea
+    unit: usd
+    aggregation: sum
+    value_scale: 1000000
+    expected_cell_type: number
+- record_set_id: bea_nipa.cy{year}.personal_current_taxes
+  record_set_spec_id: bea_nipa.personal_current_taxes.v1
+  source_record_id_prefix: bea_nipa.cy{year}.personal_current_taxes
+  sheet_name: NipaDataA
+  period_type: calendar_year
+  period: '{year}'
+  geography_id: 0100000US
+  geography_level: country
+  geography_name: United States
+  geography_vintage: current
+  entity: person
+  entity_role: income_recipient
+  domain: personal_income
+  groupby_dimension: bea_nipa.series_code
+  rows:
+  - value_id: w055rc
+    label: W055RC
+    ordinal: 0
+    row_number: 3
+    expected_row_header_column: A
+    expected_row_header: W055RC
+    filters:
+      bea_nipa.series_code: W055RC
+    constraints:
+    - variable: bea_nipa.series_code
+      operator: ==
+      value: W055RC
+      label: BEA NIPA series code
+    guard_cells:
+    - column: B
+      row: start
+      expected_value: '{year}'
+      label: calendar year
+  measures:
+  - measure_id: amount
+    label: Personal current taxes
+    ordinal: 0
+    column: C
+    source_column_id: value
+    expected_column_header_row: 1
+    expected_column_header: Value
+    concept: bea_nipa.personal_current_taxes
+    source_concept: bea_nipa.w055rc_personal_current_taxes
+    concept_relation: source_label
+    concept_authority: bea
+    unit: usd
+    aggregation: sum
+    value_scale: 1000000
+    expected_cell_type: number
+- record_set_id: bea_nipa.cy{year}.disposable_personal_income
+  record_set_spec_id: bea_nipa.disposable_personal_income.v1
+  source_record_id_prefix: bea_nipa.cy{year}.disposable_personal_income
+  sheet_name: NipaDataA
+  period_type: calendar_year
+  period: '{year}'
+  geography_id: 0100000US
+  geography_level: country
+  geography_name: United States
+  geography_vintage: current
+  entity: person
+  entity_role: income_recipient
+  domain: personal_income
+  groupby_dimension: bea_nipa.series_code
+  rows:
+  - value_id: a067rc
+    label: A067RC
+    ordinal: 0
+    row_number: 4
+    expected_row_header_column: A
+    expected_row_header: A067RC
+    filters:
+      bea_nipa.series_code: A067RC
+    constraints:
+    - variable: bea_nipa.series_code
+      operator: ==
+      value: A067RC
+      label: BEA NIPA series code
+    guard_cells:
+    - column: B
+      row: start
+      expected_value: '{year}'
+      label: calendar year
+  measures:
+  - measure_id: amount
+    label: Disposable personal income
+    ordinal: 0
+    column: C
+    source_column_id: value
+    expected_column_header_row: 1
+    expected_column_header: Value
+    concept: bea_nipa.disposable_personal_income
+    source_concept: bea_nipa.a067rc_disposable_personal_income
+    concept_relation: source_label
+    concept_authority: bea
+    unit: usd
+    aggregation: sum
+    value_scale: 1000000
+    expected_cell_type: number
+- record_set_id: bea_nipa.cy{year}.personal_outlays
+  record_set_spec_id: bea_nipa.personal_outlays.v1
+  source_record_id_prefix: bea_nipa.cy{year}.personal_outlays
+  sheet_name: NipaDataA
+  period_type: calendar_year
+  period: '{year}'
+  geography_id: 0100000US
+  geography_level: country
+  geography_name: United States
+  geography_vintage: current
+  entity: person
+  entity_role: income_recipient
+  domain: personal_income
+  groupby_dimension: bea_nipa.series_code
+  rows:
+  - value_id: a068rc
+    label: A068RC
+    ordinal: 0
+    row_number: 5
+    expected_row_header_column: A
+    expected_row_header: A068RC
+    filters:
+      bea_nipa.series_code: A068RC
+    constraints:
+    - variable: bea_nipa.series_code
+      operator: ==
+      value: A068RC
+      label: BEA NIPA series code
+    guard_cells:
+    - column: B
+      row: start
+      expected_value: '{year}'
+      label: calendar year
+  measures:
+  - measure_id: amount
+    label: Personal outlays
+    ordinal: 0
+    column: C
+    source_column_id: value
+    expected_column_header_row: 1
+    expected_column_header: Value
+    concept: bea_nipa.personal_outlays
+    source_concept: bea_nipa.a068rc_personal_outlays
+    concept_relation: source_label
+    concept_authority: bea
+    unit: usd
+    aggregation: sum
+    value_scale: 1000000
+    expected_cell_type: number
+- record_set_id: bea_nipa.cy{year}.personal_saving
+  record_set_spec_id: bea_nipa.personal_saving.v1
+  source_record_id_prefix: bea_nipa.cy{year}.personal_saving
+  sheet_name: NipaDataA
+  period_type: calendar_year
+  period: '{year}'
+  geography_id: 0100000US
+  geography_level: country
+  geography_name: United States
+  geography_vintage: current
+  entity: person
+  entity_role: income_recipient
+  domain: personal_income
+  groupby_dimension: bea_nipa.series_code
+  rows:
+  - value_id: a071rc
+    label: A071RC
+    ordinal: 0
+    row_number: 6
+    expected_row_header_column: A
+    expected_row_header: A071RC
+    filters:
+      bea_nipa.series_code: A071RC
+    constraints:
+    - variable: bea_nipa.series_code
+      operator: ==
+      value: A071RC
+      label: BEA NIPA series code
+    guard_cells:
+    - column: B
+      row: start
+      expected_value: '{year}'
+      label: calendar year
+  measures:
+  - measure_id: amount
+    label: Personal saving
+    ordinal: 0
+    column: C
+    source_column_id: value
+    expected_column_header_row: 1
+    expected_column_header: Value
+    concept: bea_nipa.personal_saving
+    source_concept: bea_nipa.a071rc_personal_saving
+    concept_relation: source_label
+    concept_authority: bea
+    unit: usd
+    aggregation: sum
+    value_scale: 1000000
+    expected_cell_type: number
+- record_set_id: bea_nipa.cy{year}.personal_saving_rate
+  record_set_spec_id: bea_nipa.personal_saving_rate.v1
+  source_record_id_prefix: bea_nipa.cy{year}.personal_saving_rate
+  sheet_name: NipaDataA
+  period_type: calendar_year
+  period: '{year}'
+  geography_id: 0100000US
+  geography_level: country
+  geography_name: United States
+  geography_vintage: current
+  entity: person
+  entity_role: income_recipient
+  domain: personal_income
+  groupby_dimension: bea_nipa.series_code
+  rows:
+  - value_id: a072rc
+    label: A072RC
+    ordinal: 0
+    row_number: 7
+    expected_row_header_column: A
+    expected_row_header: A072RC
+    filters:
+      bea_nipa.series_code: A072RC
+    constraints:
+    - variable: bea_nipa.series_code
+      operator: ==
+      value: A072RC
+      label: BEA NIPA series code
+    guard_cells:
+    - column: B
+      row: start
+      expected_value: '{year}'
+      label: calendar year
+  measures:
+  - measure_id: rate
+    label: Personal saving as a percentage of disposable personal income
+    ordinal: 0
+    column: C
+    source_column_id: value
+    expected_column_header_row: 1
+    expected_column_header: Value
+    concept: bea_nipa.personal_saving_rate
+    source_concept: bea_nipa.a072rc_personal_saving_as_percentage_of_disposable_personal_income
+    concept_relation: source_label
+    concept_authority: bea
+    unit: percent
+    aggregation: sum
+    value_scale: 1
+    expected_cell_type: number

--- a/packages/bea/nipa_total_wages_salaries/source_package.yaml
+++ b/packages/bea/nipa_total_wages_salaries/source_package.yaml
@@ -1,0 +1,170 @@
+schema_version: arch.source_package.v1
+package_id: bea-nipa-total-wages-salaries
+label: BEA NIPA total wages and salaries
+artifact:
+  source_name: bea
+  source_table: BEA NIPA annual data flat file
+  resource_package: db
+  resource_directory: data/bea/nipa_total_wages_salaries
+  manifest: manifest.yaml
+  vintage: bea_nipa_annual_release_2026_04_30
+  extracted_at: "2026-05-11"
+  extraction_method: delimited text full-row parse with selected-cell facts
+  parser: delimited_text_full_rows
+  sheet_name: NipaDataA
+  artifact_year: 2024
+  selected_rows:
+    - SeriesCode: A034RC
+      Period: 2018
+    - SeriesCode: A034RC
+      Period: 2023
+    - SeriesCode: A034RC
+      Period: 2024
+record_sets:
+  - record_set_id: bea_nipa.cy2018.total_wages_salaries
+    record_set_spec_id: bea_nipa.total_wages_salaries.v1
+    source_record_id_prefix: bea_nipa.cy2018.total_wages_salaries
+    sheet_name: NipaDataA
+    period_type: calendar_year
+    period: "2018"
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    entity: person
+    entity_role: employee
+    domain: compensation_of_employees
+    groupby_dimension: bea_nipa.series_code
+    rows:
+      - value_id: a034rc
+        label: A034RC
+        ordinal: 0
+        row_number: 2
+        expected_row_header_column: A
+        expected_row_header: A034RC
+        filters:
+          bea_nipa.series_code: A034RC
+        constraints:
+          - variable: bea_nipa.series_code
+            operator: "=="
+            value: A034RC
+            label: BEA NIPA series code
+        guard_cells:
+          - column: B
+            row: start
+            expected_value: 2018
+            label: calendar year
+    measures:
+      - measure_id: wages_salaries_amount
+        label: Total wages and salaries
+        ordinal: 0
+        column: C
+        source_column_id: value
+        expected_column_header_row: 1
+        expected_column_header: Value
+        concept: bea_nipa.wages_and_salaries
+        source_concept: bea_nipa.a034rc_wages_and_salaries
+        concept_relation: source_label
+        concept_authority: bea
+        unit: usd
+        aggregation: sum
+        value_scale: 1000000
+        expected_cell_type: number
+  - record_set_id: bea_nipa.cy2023.total_wages_salaries
+    record_set_spec_id: bea_nipa.total_wages_salaries.v1
+    source_record_id_prefix: bea_nipa.cy2023.total_wages_salaries
+    sheet_name: NipaDataA
+    period_type: calendar_year
+    period: "2023"
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    entity: person
+    entity_role: employee
+    domain: compensation_of_employees
+    groupby_dimension: bea_nipa.series_code
+    rows:
+      - value_id: a034rc
+        label: A034RC
+        ordinal: 0
+        row_number: 3
+        expected_row_header_column: A
+        expected_row_header: A034RC
+        filters:
+          bea_nipa.series_code: A034RC
+        constraints:
+          - variable: bea_nipa.series_code
+            operator: "=="
+            value: A034RC
+            label: BEA NIPA series code
+        guard_cells:
+          - column: B
+            row: start
+            expected_value: 2023
+            label: calendar year
+    measures:
+      - measure_id: wages_salaries_amount
+        label: Total wages and salaries
+        ordinal: 0
+        column: C
+        source_column_id: value
+        expected_column_header_row: 1
+        expected_column_header: Value
+        concept: bea_nipa.wages_and_salaries
+        source_concept: bea_nipa.a034rc_wages_and_salaries
+        concept_relation: source_label
+        concept_authority: bea
+        unit: usd
+        aggregation: sum
+        value_scale: 1000000
+        expected_cell_type: number
+  - record_set_id: bea_nipa.cy2024.total_wages_salaries
+    record_set_spec_id: bea_nipa.total_wages_salaries.v1
+    source_record_id_prefix: bea_nipa.cy2024.total_wages_salaries
+    sheet_name: NipaDataA
+    period_type: calendar_year
+    period: "2024"
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    entity: person
+    entity_role: employee
+    domain: compensation_of_employees
+    groupby_dimension: bea_nipa.series_code
+    rows:
+      - value_id: a034rc
+        label: A034RC
+        ordinal: 0
+        row_number: 4
+        expected_row_header_column: A
+        expected_row_header: A034RC
+        filters:
+          bea_nipa.series_code: A034RC
+        constraints:
+          - variable: bea_nipa.series_code
+            operator: "=="
+            value: A034RC
+            label: BEA NIPA series code
+        guard_cells:
+          - column: B
+            row: start
+            expected_value: 2024
+            label: calendar year
+    measures:
+      - measure_id: wages_salaries_amount
+        label: Total wages and salaries
+        ordinal: 0
+        column: C
+        source_column_id: value
+        expected_column_header_row: 1
+        expected_column_header: Value
+        concept: bea_nipa.wages_and_salaries
+        source_concept: bea_nipa.a034rc_wages_and_salaries
+        concept_relation: source_label
+        concept_authority: bea
+        unit: usd
+        aggregation: sum
+        value_scale: 1000000
+        expected_cell_type: number

--- a/tests/test_arch_source_package.py
+++ b/tests/test_arch_source_package.py
@@ -249,6 +249,84 @@ def test_source_package_path_builds_valid_soi_table_1_4_facts():
     assert facts[0].source.source_table == "Publication 1304 Table 1.4"
 
 
+def test_bea_nipa_total_wages_package_preserves_bea_concept():
+    package = load_source_package("bea-nipa-total-wages-salaries")
+    rows = package.build_source_rows(2024)
+    cells = package.build_source_cells(2024, source_rows=rows)
+    records = package.build_source_records(2024, cells=cells, source_rows=rows)
+    facts = package.build_facts(2024, cells=cells, source_rows=rows)
+    records_by_id = {record.source_record_id: record for record in records}
+    facts_by_record = {fact.source_record_id: fact for fact in facts}
+
+    assert len(rows) == 559_069
+    assert validate_source_rows(rows).valid
+    assert validate_source_cells(cells).valid
+    assert validate_facts(facts).valid
+    assert len(cells) == 12
+    assert len(facts) == 3
+    assert all(fact.source_row_keys for fact in facts)
+    assert all(fact.source.source_name == "bea" for fact in facts)
+    assert all(fact.source.raw_r2_uri for fact in facts)
+
+    value_2018 = "bea_nipa.cy2018.total_wages_salaries.a034rc.wages_salaries_amount"
+    value_2024 = "bea_nipa.cy2024.total_wages_salaries.a034rc.wages_salaries_amount"
+    assert records_by_id[value_2018].source_cell_addresses == ("C2", "C1", "B2")
+    assert records_by_id[value_2024].source_cell_addresses == ("C4", "C1", "B4")
+    assert facts_by_record[value_2018].value == 8_899_824_000_000
+    assert facts_by_record[value_2024].value == 12_387_929_000_000
+    assert facts_by_record[value_2024].measure.concept == (
+        "bea_nipa.wages_and_salaries"
+    )
+    assert facts_by_record[value_2024].measure.source_concept == (
+        "bea_nipa.a034rc_wages_and_salaries"
+    )
+
+
+def test_bea_nipa_personal_income_components_keep_broad_concepts_namespaced():
+    package = load_source_package("bea-nipa-personal-income-components")
+    facts = package.build_facts(2024)
+    facts_by_record = {fact.source_record_id: fact for fact in facts}
+
+    assert len(facts) == 18
+    assert validate_facts(facts).valid
+    proprietors = facts_by_record["bea_nipa.cy2024.proprietors_income.a041rc.amount"]
+    interest = facts_by_record["bea_nipa.cy2024.personal_interest_income.a064rc.amount"]
+    dividends = facts_by_record[
+        "bea_nipa.cy2024.personal_dividend_income.b703rc.amount"
+    ]
+
+    assert proprietors.value == 2_023_080_000_000
+    assert proprietors.measure.concept == (
+        "bea_nipa.proprietors_income_with_inventory_valuation_and_capital_"
+        "consumption_adjustments"
+    )
+    assert proprietors.measure.concept != "self_employment_income"
+    assert interest.value == 1_926_644_000_000
+    assert interest.measure.concept == "bea_nipa.personal_interest_income"
+    assert dividends.value == 2_218_700_000_000
+    assert dividends.measure.concept == "bea_nipa.personal_dividend_income"
+
+
+def test_bea_nipa_personal_income_disposition_builds_amounts_and_rates():
+    package = load_source_package("bea-nipa-personal-income-disposition")
+    facts = package.build_facts(2024)
+    facts_by_record = {fact.source_record_id: fact for fact in facts}
+
+    assert len(facts) == 6
+    assert validate_facts(facts).valid
+    assert (
+        facts_by_record["bea_nipa.cy2024.personal_income.a065rc.amount"].value
+        == 24_905_900_000_000
+    )
+    assert (
+        facts_by_record["bea_nipa.cy2024.personal_current_taxes.w055rc.amount"].value
+        == 2_988_243_000_000
+    )
+    saving_rate = facts_by_record["bea_nipa.cy2024.personal_saving_rate.a072rc.rate"]
+    assert saving_rate.value == 5.4
+    assert saving_rate.measure.unit == "percent"
+
+
 def test_validate_source_package_reports_fixture_counts():
     report = validate_source_package("soi-table-1-1", year=2023)
 


### PR DESCRIPTION
## Summary
- Add BEA NIPA source packages for total wages and salaries, personal income components, and personal income disposition.
- Register package aliases so the fixtures can be loaded through the source-package CLI.
- Add focused tests that preserve broad BEA concepts under `bea_nipa.*`, including a guard that proprietors' income is not mapped to `self_employment_income`.

## Validation
- `uv run --python 3.13 ruff check arch/source_package.py tests/test_arch_source_package.py`
- `uv run --python 3.13 pytest -q tests/test_arch_source_package.py -k bea_nipa`
- `uv run --python 3.13 arch validate-package bea-nipa-total-wages-salaries --year 2024`
- `uv run --python 3.13 arch validate-package bea-nipa-personal-income-components --year 2024`
- `uv run --python 3.13 arch validate-package bea-nipa-personal-income-disposition --year 2024`
- `uv run --python 3.13 arch build-suite bea-nipa-total-wages-salaries --year 2024 --out /tmp/arch-bea-nipa-total-wages-2024 --replace`
- `uv run --python 3.13 arch build-suite bea-nipa-personal-income-components --year 2024 --out /tmp/arch-bea-nipa-personal-income-components-2024 --replace`
- `uv run --python 3.13 arch build-suite bea-nipa-personal-income-disposition --year 2024 --out /tmp/arch-bea-nipa-personal-income-disposition-2024 --replace`

Part of splitting the useful source-package work out of the conflicted draft parity PR, while keeping target semantics conservative for Microplex.
