### PR TITLE
Add BEA regional state income package

### DIFF
--- a/arch/source_package.py
+++ b/arch/source_package.py
@@ -71,6 +71,9 @@ SOURCE_PACKAGE_ALIASES = {
         "bea/nipa_personal_income_disposition"
     ),
     "bea-nipa-total-wages-salaries": Path("bea/nipa_total_wages_salaries"),
+    "bea-regional-state-personal-income-components-2024": Path(
+        "bea/regional_personal_income_state"
+    ),
     "cbo-revenue-projections-income-by-source-2026-02": Path(
         "cbo/revenue_projections_income_by_source_2026_02"
     ),

--- a/db/data/bea/regional_personal_income_state/manifest.yaml
+++ b/db/data/bea/regional_personal_income_state/manifest.yaml
@@ -1,0 +1,18 @@
+source_id: bea
+package_id: bea-regional-state-personal-income-components-2024
+dataset: bea_regional_state_personal_income
+source_page: https://apps.bea.gov/regional/downloadzip.htm
+table: Annual Personal Income by State
+files:
+  2024:
+    filename: SAINC.zip
+    source_url: https://apps.bea.gov/regional/zip/SAINC.zip
+    sha256: 339a3d3d6a283eea3f5647ea5b33570da73801d4248c5e2209c1e196428d9a9a
+    size_bytes: 17478048
+    fetched_at: '2026-05-17T15:00:39+00:00'
+    storage:
+      r2:
+        provider: r2
+        bucket: arch-raw
+        key: raw/bea/bea-regional-state-personal-income-components-2024/2024/339a3d3d6a283eea3f5647ea5b33570da73801d4248c5e2209c1e196428d9a9a/SAINC.zip
+        uri: r2://arch-raw/raw/bea/bea-regional-state-personal-income-components-2024/2024/339a3d3d6a283eea3f5647ea5b33570da73801d4248c5e2209c1e196428d9a9a/SAINC.zip

--- a/packages/bea/regional_personal_income_state/source_package.yaml
+++ b/packages/bea/regional_personal_income_state/source_package.yaml
@@ -1,0 +1,12382 @@
+schema_version: arch.source_package.v1
+package_id: bea-regional-state-personal-income-components-2024
+label: BEA Regional 2024 state personal income components
+artifact:
+  source_name: bea
+  source_table: BEA Regional annual state personal income CSV ZIP
+  resource_package: db
+  resource_directory: data/bea/regional_personal_income_state
+  manifest: manifest.yaml
+  vintage: bea_regional_state_personal_income_2026_04_09
+  extracted_at: '2026-05-17'
+  extraction_method: zip archive CSV member full-row parse with selected-cell facts
+  parser: zip_delimited_text_full_rows
+  archive_member: SAINC5N__ALL_AREAS_1998_2025.csv
+  sheet_name: SAINC5N__ALL_AREAS_1998_2025.csv
+  artifact_year: 2024
+  selected_rows:
+  - GeoName: United States
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Alabama
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Alaska
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Arizona
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Arkansas
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: California
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Colorado
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Connecticut
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Delaware
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: District of Columbia
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Florida
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Georgia
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Hawaii
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Idaho
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Illinois
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Indiana
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Iowa
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Kansas
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Kentucky
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Louisiana
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Maine
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Maryland
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Massachusetts
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Michigan
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Minnesota
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Mississippi
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Missouri
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Montana
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Nebraska
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Nevada
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: New Hampshire
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: New Jersey
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: New Mexico
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: New York
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: North Carolina
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: North Dakota
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Ohio
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Oklahoma
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Oregon
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Pennsylvania
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Rhode Island
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: South Carolina
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: South Dakota
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Tennessee
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Texas
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Utah
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Vermont
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Virginia
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Washington
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: West Virginia
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Wisconsin
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: Wyoming
+    TableName: SAINC5N
+    LineCode: 10
+  - GeoName: United States
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Alabama
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Alaska
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Arizona
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Arkansas
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: California
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Colorado
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Connecticut
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Delaware
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: District of Columbia
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Florida
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Georgia
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Hawaii
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Idaho
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Illinois
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Indiana
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Iowa
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Kansas
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Kentucky
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Louisiana
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Maine
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Maryland
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Massachusetts
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Michigan
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Minnesota
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Mississippi
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Missouri
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Montana
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Nebraska
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Nevada
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: New Hampshire
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: New Jersey
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: New Mexico
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: New York
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: North Carolina
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: North Dakota
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Ohio
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Oklahoma
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Oregon
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Pennsylvania
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Rhode Island
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: South Carolina
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: South Dakota
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Tennessee
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Texas
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Utah
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Vermont
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Virginia
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Washington
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: West Virginia
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Wisconsin
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: Wyoming
+    TableName: SAINC5N
+    LineCode: 46
+  - GeoName: United States
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Alabama
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Alaska
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Arizona
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Arkansas
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: California
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Colorado
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Connecticut
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Delaware
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: District of Columbia
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Florida
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Georgia
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Hawaii
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Idaho
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Illinois
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Indiana
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Iowa
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Kansas
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Kentucky
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Louisiana
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Maine
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Maryland
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Massachusetts
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Michigan
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Minnesota
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Mississippi
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Missouri
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Montana
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Nebraska
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Nevada
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: New Hampshire
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: New Jersey
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: New Mexico
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: New York
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: North Carolina
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: North Dakota
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Ohio
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Oklahoma
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Oregon
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Pennsylvania
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Rhode Island
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: South Carolina
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: South Dakota
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Tennessee
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Texas
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Utah
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Vermont
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Virginia
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Washington
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: West Virginia
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Wisconsin
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: Wyoming
+    TableName: SAINC5N
+    LineCode: 47
+  - GeoName: United States
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Alabama
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Alaska
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Arizona
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Arkansas
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: California
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Colorado
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Connecticut
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Delaware
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: District of Columbia
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Florida
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Georgia
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Hawaii
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Idaho
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Illinois
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Indiana
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Iowa
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Kansas
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Kentucky
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Louisiana
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Maine
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Maryland
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Massachusetts
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Michigan
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Minnesota
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Mississippi
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Missouri
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Montana
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Nebraska
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Nevada
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: New Hampshire
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: New Jersey
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: New Mexico
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: New York
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: North Carolina
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: North Dakota
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Ohio
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Oklahoma
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Oregon
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Pennsylvania
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Rhode Island
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: South Carolina
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: South Dakota
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Tennessee
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Texas
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Utah
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Vermont
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Virginia
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Washington
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: West Virginia
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Wisconsin
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: Wyoming
+    TableName: SAINC5N
+    LineCode: 50
+  - GeoName: United States
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Alabama
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Alaska
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Arizona
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Arkansas
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: California
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Colorado
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Connecticut
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Delaware
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: District of Columbia
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Florida
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Georgia
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Hawaii
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Idaho
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Illinois
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Indiana
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Iowa
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Kansas
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Kentucky
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Louisiana
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Maine
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Maryland
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Massachusetts
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Michigan
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Minnesota
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Mississippi
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Missouri
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Montana
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Nebraska
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Nevada
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: New Hampshire
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: New Jersey
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: New Mexico
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: New York
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: North Carolina
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: North Dakota
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Ohio
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Oklahoma
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Oregon
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Pennsylvania
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Rhode Island
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: South Carolina
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: South Dakota
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Tennessee
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Texas
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Utah
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Vermont
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Virginia
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Washington
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: West Virginia
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Wisconsin
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: Wyoming
+    TableName: SAINC5N
+    LineCode: 60
+  - GeoName: United States
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Alabama
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Alaska
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Arizona
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Arkansas
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: California
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Colorado
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Connecticut
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Delaware
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: District of Columbia
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Florida
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Georgia
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Hawaii
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Idaho
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Illinois
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Indiana
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Iowa
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Kansas
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Kentucky
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Louisiana
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Maine
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Maryland
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Massachusetts
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Michigan
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Minnesota
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Mississippi
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Missouri
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Montana
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Nebraska
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Nevada
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: New Hampshire
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: New Jersey
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: New Mexico
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: New York
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: North Carolina
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: North Dakota
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Ohio
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Oklahoma
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Oregon
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Pennsylvania
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Rhode Island
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: South Carolina
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: South Dakota
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Tennessee
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Texas
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Utah
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Vermont
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Virginia
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Washington
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: West Virginia
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Wisconsin
+    TableName: SAINC5N
+    LineCode: 70
+  - GeoName: Wyoming
+    TableName: SAINC5N
+    LineCode: 70
+record_sets:
+- record_set_id: bea_regional.cy{year}.state_personal_income
+  record_set_spec_id: bea_regional.state_personal_income.v1
+  source_record_id_prefix: bea_regional.cy{year}.state_personal_income
+  sheet_name: SAINC5N__ALL_AREAS_1998_2025.csv
+  period_type: calendar_year
+  period: '{year}'
+  geography_id: 0100000US
+  geography_level: country
+  geography_name: United States
+  geography_vintage: current
+  entity: person
+  entity_role: income_recipient
+  domain: personal_income
+  groupby_dimension: bea_regional.geography
+  shared_filters:
+    bea_regional.table_name: SAINC5N
+  shared_constraints: &bea_regional_sainc5n_constraints
+  - variable: bea_regional.table_name
+    operator: ==
+    value: SAINC5N
+    label: BEA Regional table name
+  rows:
+  - value_id: us
+    label: United States
+    ordinal: 0
+    row_number: 2
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: United States
+    filters:
+      bea_regional.geo_name: United States
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: total
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: United States
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: al
+    label: Alabama
+    ordinal: 1
+    row_number: 3
+    geography_id: 0400000US01
+    geography_level: state
+    geography_name: Alabama
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Alabama
+    filters:
+      bea_regional.geo_name: Alabama
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Alabama
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: ak
+    label: Alaska
+    ordinal: 2
+    row_number: 4
+    geography_id: 0400000US02
+    geography_level: state
+    geography_name: Alaska
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Alaska
+    filters:
+      bea_regional.geo_name: Alaska
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Alaska
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: az
+    label: Arizona
+    ordinal: 3
+    row_number: 5
+    geography_id: 0400000US04
+    geography_level: state
+    geography_name: Arizona
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Arizona
+    filters:
+      bea_regional.geo_name: Arizona
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Arizona
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: ar
+    label: Arkansas
+    ordinal: 4
+    row_number: 6
+    geography_id: 0400000US05
+    geography_level: state
+    geography_name: Arkansas
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Arkansas
+    filters:
+      bea_regional.geo_name: Arkansas
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Arkansas
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: ca
+    label: California
+    ordinal: 5
+    row_number: 7
+    geography_id: 0400000US06
+    geography_level: state
+    geography_name: California
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: California
+    filters:
+      bea_regional.geo_name: California
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: California
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: co
+    label: Colorado
+    ordinal: 6
+    row_number: 8
+    geography_id: 0400000US08
+    geography_level: state
+    geography_name: Colorado
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Colorado
+    filters:
+      bea_regional.geo_name: Colorado
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Colorado
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: ct
+    label: Connecticut
+    ordinal: 7
+    row_number: 9
+    geography_id: 0400000US09
+    geography_level: state
+    geography_name: Connecticut
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Connecticut
+    filters:
+      bea_regional.geo_name: Connecticut
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Connecticut
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: de
+    label: Delaware
+    ordinal: 8
+    row_number: 10
+    geography_id: 0400000US10
+    geography_level: state
+    geography_name: Delaware
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Delaware
+    filters:
+      bea_regional.geo_name: Delaware
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Delaware
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: dc
+    label: District of Columbia
+    ordinal: 9
+    row_number: 11
+    geography_id: 0400000US11
+    geography_level: state
+    geography_name: District of Columbia
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: District of Columbia
+    filters:
+      bea_regional.geo_name: District of Columbia
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: District of Columbia
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: fl
+    label: Florida
+    ordinal: 10
+    row_number: 12
+    geography_id: 0400000US12
+    geography_level: state
+    geography_name: Florida
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Florida
+    filters:
+      bea_regional.geo_name: Florida
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Florida
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: ga
+    label: Georgia
+    ordinal: 11
+    row_number: 13
+    geography_id: 0400000US13
+    geography_level: state
+    geography_name: Georgia
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Georgia
+    filters:
+      bea_regional.geo_name: Georgia
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Georgia
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: hi
+    label: Hawaii
+    ordinal: 12
+    row_number: 14
+    geography_id: 0400000US15
+    geography_level: state
+    geography_name: Hawaii
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Hawaii
+    filters:
+      bea_regional.geo_name: Hawaii
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Hawaii
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: id
+    label: Idaho
+    ordinal: 13
+    row_number: 15
+    geography_id: 0400000US16
+    geography_level: state
+    geography_name: Idaho
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Idaho
+    filters:
+      bea_regional.geo_name: Idaho
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Idaho
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: il
+    label: Illinois
+    ordinal: 14
+    row_number: 16
+    geography_id: 0400000US17
+    geography_level: state
+    geography_name: Illinois
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Illinois
+    filters:
+      bea_regional.geo_name: Illinois
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Illinois
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: in
+    label: Indiana
+    ordinal: 15
+    row_number: 17
+    geography_id: 0400000US18
+    geography_level: state
+    geography_name: Indiana
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Indiana
+    filters:
+      bea_regional.geo_name: Indiana
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Indiana
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: ia
+    label: Iowa
+    ordinal: 16
+    row_number: 18
+    geography_id: 0400000US19
+    geography_level: state
+    geography_name: Iowa
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Iowa
+    filters:
+      bea_regional.geo_name: Iowa
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Iowa
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: ks
+    label: Kansas
+    ordinal: 17
+    row_number: 19
+    geography_id: 0400000US20
+    geography_level: state
+    geography_name: Kansas
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Kansas
+    filters:
+      bea_regional.geo_name: Kansas
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Kansas
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: ky
+    label: Kentucky
+    ordinal: 18
+    row_number: 20
+    geography_id: 0400000US21
+    geography_level: state
+    geography_name: Kentucky
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Kentucky
+    filters:
+      bea_regional.geo_name: Kentucky
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Kentucky
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: la
+    label: Louisiana
+    ordinal: 19
+    row_number: 21
+    geography_id: 0400000US22
+    geography_level: state
+    geography_name: Louisiana
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Louisiana
+    filters:
+      bea_regional.geo_name: Louisiana
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Louisiana
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: me
+    label: Maine
+    ordinal: 20
+    row_number: 22
+    geography_id: 0400000US23
+    geography_level: state
+    geography_name: Maine
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Maine
+    filters:
+      bea_regional.geo_name: Maine
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Maine
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: md
+    label: Maryland
+    ordinal: 21
+    row_number: 23
+    geography_id: 0400000US24
+    geography_level: state
+    geography_name: Maryland
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Maryland
+    filters:
+      bea_regional.geo_name: Maryland
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Maryland
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: ma
+    label: Massachusetts
+    ordinal: 22
+    row_number: 24
+    geography_id: 0400000US25
+    geography_level: state
+    geography_name: Massachusetts
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Massachusetts
+    filters:
+      bea_regional.geo_name: Massachusetts
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Massachusetts
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: mi
+    label: Michigan
+    ordinal: 23
+    row_number: 25
+    geography_id: 0400000US26
+    geography_level: state
+    geography_name: Michigan
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Michigan
+    filters:
+      bea_regional.geo_name: Michigan
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Michigan
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: mn
+    label: Minnesota
+    ordinal: 24
+    row_number: 26
+    geography_id: 0400000US27
+    geography_level: state
+    geography_name: Minnesota
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Minnesota
+    filters:
+      bea_regional.geo_name: Minnesota
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Minnesota
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: ms
+    label: Mississippi
+    ordinal: 25
+    row_number: 27
+    geography_id: 0400000US28
+    geography_level: state
+    geography_name: Mississippi
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Mississippi
+    filters:
+      bea_regional.geo_name: Mississippi
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Mississippi
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: mo
+    label: Missouri
+    ordinal: 26
+    row_number: 28
+    geography_id: 0400000US29
+    geography_level: state
+    geography_name: Missouri
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Missouri
+    filters:
+      bea_regional.geo_name: Missouri
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Missouri
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: mt
+    label: Montana
+    ordinal: 27
+    row_number: 29
+    geography_id: 0400000US30
+    geography_level: state
+    geography_name: Montana
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Montana
+    filters:
+      bea_regional.geo_name: Montana
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Montana
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: ne
+    label: Nebraska
+    ordinal: 28
+    row_number: 30
+    geography_id: 0400000US31
+    geography_level: state
+    geography_name: Nebraska
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Nebraska
+    filters:
+      bea_regional.geo_name: Nebraska
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Nebraska
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: nv
+    label: Nevada
+    ordinal: 29
+    row_number: 31
+    geography_id: 0400000US32
+    geography_level: state
+    geography_name: Nevada
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Nevada
+    filters:
+      bea_regional.geo_name: Nevada
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Nevada
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: nh
+    label: New Hampshire
+    ordinal: 30
+    row_number: 32
+    geography_id: 0400000US33
+    geography_level: state
+    geography_name: New Hampshire
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: New Hampshire
+    filters:
+      bea_regional.geo_name: New Hampshire
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: New Hampshire
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: nj
+    label: New Jersey
+    ordinal: 31
+    row_number: 33
+    geography_id: 0400000US34
+    geography_level: state
+    geography_name: New Jersey
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: New Jersey
+    filters:
+      bea_regional.geo_name: New Jersey
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: New Jersey
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: nm
+    label: New Mexico
+    ordinal: 32
+    row_number: 34
+    geography_id: 0400000US35
+    geography_level: state
+    geography_name: New Mexico
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: New Mexico
+    filters:
+      bea_regional.geo_name: New Mexico
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: New Mexico
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: ny
+    label: New York
+    ordinal: 33
+    row_number: 35
+    geography_id: 0400000US36
+    geography_level: state
+    geography_name: New York
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: New York
+    filters:
+      bea_regional.geo_name: New York
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: New York
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: nc
+    label: North Carolina
+    ordinal: 34
+    row_number: 36
+    geography_id: 0400000US37
+    geography_level: state
+    geography_name: North Carolina
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: North Carolina
+    filters:
+      bea_regional.geo_name: North Carolina
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: North Carolina
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: nd
+    label: North Dakota
+    ordinal: 35
+    row_number: 37
+    geography_id: 0400000US38
+    geography_level: state
+    geography_name: North Dakota
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: North Dakota
+    filters:
+      bea_regional.geo_name: North Dakota
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: North Dakota
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: oh
+    label: Ohio
+    ordinal: 36
+    row_number: 38
+    geography_id: 0400000US39
+    geography_level: state
+    geography_name: Ohio
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Ohio
+    filters:
+      bea_regional.geo_name: Ohio
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Ohio
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: ok
+    label: Oklahoma
+    ordinal: 37
+    row_number: 39
+    geography_id: 0400000US40
+    geography_level: state
+    geography_name: Oklahoma
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Oklahoma
+    filters:
+      bea_regional.geo_name: Oklahoma
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Oklahoma
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: or
+    label: Oregon
+    ordinal: 38
+    row_number: 40
+    geography_id: 0400000US41
+    geography_level: state
+    geography_name: Oregon
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Oregon
+    filters:
+      bea_regional.geo_name: Oregon
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Oregon
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: pa
+    label: Pennsylvania
+    ordinal: 39
+    row_number: 41
+    geography_id: 0400000US42
+    geography_level: state
+    geography_name: Pennsylvania
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Pennsylvania
+    filters:
+      bea_regional.geo_name: Pennsylvania
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Pennsylvania
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: ri
+    label: Rhode Island
+    ordinal: 40
+    row_number: 42
+    geography_id: 0400000US44
+    geography_level: state
+    geography_name: Rhode Island
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Rhode Island
+    filters:
+      bea_regional.geo_name: Rhode Island
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Rhode Island
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: sc
+    label: South Carolina
+    ordinal: 41
+    row_number: 43
+    geography_id: 0400000US45
+    geography_level: state
+    geography_name: South Carolina
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: South Carolina
+    filters:
+      bea_regional.geo_name: South Carolina
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: South Carolina
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: sd
+    label: South Dakota
+    ordinal: 42
+    row_number: 44
+    geography_id: 0400000US46
+    geography_level: state
+    geography_name: South Dakota
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: South Dakota
+    filters:
+      bea_regional.geo_name: South Dakota
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: South Dakota
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: tn
+    label: Tennessee
+    ordinal: 43
+    row_number: 45
+    geography_id: 0400000US47
+    geography_level: state
+    geography_name: Tennessee
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Tennessee
+    filters:
+      bea_regional.geo_name: Tennessee
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Tennessee
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: tx
+    label: Texas
+    ordinal: 44
+    row_number: 46
+    geography_id: 0400000US48
+    geography_level: state
+    geography_name: Texas
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Texas
+    filters:
+      bea_regional.geo_name: Texas
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Texas
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: ut
+    label: Utah
+    ordinal: 45
+    row_number: 47
+    geography_id: 0400000US49
+    geography_level: state
+    geography_name: Utah
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Utah
+    filters:
+      bea_regional.geo_name: Utah
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Utah
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: vt
+    label: Vermont
+    ordinal: 46
+    row_number: 48
+    geography_id: 0400000US50
+    geography_level: state
+    geography_name: Vermont
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Vermont
+    filters:
+      bea_regional.geo_name: Vermont
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Vermont
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: va
+    label: Virginia
+    ordinal: 47
+    row_number: 49
+    geography_id: 0400000US51
+    geography_level: state
+    geography_name: Virginia
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Virginia
+    filters:
+      bea_regional.geo_name: Virginia
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Virginia
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: wa
+    label: Washington
+    ordinal: 48
+    row_number: 50
+    geography_id: 0400000US53
+    geography_level: state
+    geography_name: Washington
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Washington
+    filters:
+      bea_regional.geo_name: Washington
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Washington
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: wv
+    label: West Virginia
+    ordinal: 49
+    row_number: 51
+    geography_id: 0400000US54
+    geography_level: state
+    geography_name: West Virginia
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: West Virginia
+    filters:
+      bea_regional.geo_name: West Virginia
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: West Virginia
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: wi
+    label: Wisconsin
+    ordinal: 50
+    row_number: 52
+    geography_id: 0400000US55
+    geography_level: state
+    geography_name: Wisconsin
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Wisconsin
+    filters:
+      bea_regional.geo_name: Wisconsin
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Wisconsin
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  - value_id: wy
+    label: Wyoming
+    ordinal: 51
+    row_number: 53
+    geography_id: 0400000US56
+    geography_level: state
+    geography_name: Wyoming
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Wyoming
+    filters:
+      bea_regional.geo_name: Wyoming
+      bea_regional.line_code: 10
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 10
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Wyoming
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 10
+      label: BEA Regional line code
+  measures:
+  - measure_id: amount
+    label: Personal income
+    ordinal: 0
+    column: AI
+    source_column_id: '2024'
+    concept: bea_regional.personal_income
+    source_concept: bea_regional.sainc5n_line_10_personal_income
+    concept_relation: source_label
+    concept_authority: bea
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+- record_set_id: bea_regional.cy{year}.state_dividends_interest_rent
+  record_set_spec_id: bea_regional.state_dividends_interest_rent.v1
+  source_record_id_prefix: bea_regional.cy{year}.state_dividends_interest_rent
+  sheet_name: SAINC5N__ALL_AREAS_1998_2025.csv
+  period_type: calendar_year
+  period: '{year}'
+  geography_id: 0100000US
+  geography_level: country
+  geography_name: United States
+  geography_vintage: current
+  entity: person
+  entity_role: income_recipient
+  domain: personal_income
+  groupby_dimension: bea_regional.geography
+  shared_filters:
+    bea_regional.table_name: SAINC5N
+  shared_constraints: *bea_regional_sainc5n_constraints
+  rows:
+  - value_id: us
+    label: United States
+    ordinal: 0
+    row_number: 54
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: United States
+    filters:
+      bea_regional.geo_name: United States
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: total
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: United States
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: al
+    label: Alabama
+    ordinal: 1
+    row_number: 55
+    geography_id: 0400000US01
+    geography_level: state
+    geography_name: Alabama
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Alabama
+    filters:
+      bea_regional.geo_name: Alabama
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Alabama
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: ak
+    label: Alaska
+    ordinal: 2
+    row_number: 56
+    geography_id: 0400000US02
+    geography_level: state
+    geography_name: Alaska
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Alaska
+    filters:
+      bea_regional.geo_name: Alaska
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Alaska
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: az
+    label: Arizona
+    ordinal: 3
+    row_number: 57
+    geography_id: 0400000US04
+    geography_level: state
+    geography_name: Arizona
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Arizona
+    filters:
+      bea_regional.geo_name: Arizona
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Arizona
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: ar
+    label: Arkansas
+    ordinal: 4
+    row_number: 58
+    geography_id: 0400000US05
+    geography_level: state
+    geography_name: Arkansas
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Arkansas
+    filters:
+      bea_regional.geo_name: Arkansas
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Arkansas
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: ca
+    label: California
+    ordinal: 5
+    row_number: 59
+    geography_id: 0400000US06
+    geography_level: state
+    geography_name: California
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: California
+    filters:
+      bea_regional.geo_name: California
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: California
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: co
+    label: Colorado
+    ordinal: 6
+    row_number: 60
+    geography_id: 0400000US08
+    geography_level: state
+    geography_name: Colorado
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Colorado
+    filters:
+      bea_regional.geo_name: Colorado
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Colorado
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: ct
+    label: Connecticut
+    ordinal: 7
+    row_number: 61
+    geography_id: 0400000US09
+    geography_level: state
+    geography_name: Connecticut
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Connecticut
+    filters:
+      bea_regional.geo_name: Connecticut
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Connecticut
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: de
+    label: Delaware
+    ordinal: 8
+    row_number: 62
+    geography_id: 0400000US10
+    geography_level: state
+    geography_name: Delaware
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Delaware
+    filters:
+      bea_regional.geo_name: Delaware
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Delaware
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: dc
+    label: District of Columbia
+    ordinal: 9
+    row_number: 63
+    geography_id: 0400000US11
+    geography_level: state
+    geography_name: District of Columbia
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: District of Columbia
+    filters:
+      bea_regional.geo_name: District of Columbia
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: District of Columbia
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: fl
+    label: Florida
+    ordinal: 10
+    row_number: 64
+    geography_id: 0400000US12
+    geography_level: state
+    geography_name: Florida
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Florida
+    filters:
+      bea_regional.geo_name: Florida
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Florida
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: ga
+    label: Georgia
+    ordinal: 11
+    row_number: 65
+    geography_id: 0400000US13
+    geography_level: state
+    geography_name: Georgia
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Georgia
+    filters:
+      bea_regional.geo_name: Georgia
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Georgia
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: hi
+    label: Hawaii
+    ordinal: 12
+    row_number: 66
+    geography_id: 0400000US15
+    geography_level: state
+    geography_name: Hawaii
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Hawaii
+    filters:
+      bea_regional.geo_name: Hawaii
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Hawaii
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: id
+    label: Idaho
+    ordinal: 13
+    row_number: 67
+    geography_id: 0400000US16
+    geography_level: state
+    geography_name: Idaho
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Idaho
+    filters:
+      bea_regional.geo_name: Idaho
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Idaho
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: il
+    label: Illinois
+    ordinal: 14
+    row_number: 68
+    geography_id: 0400000US17
+    geography_level: state
+    geography_name: Illinois
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Illinois
+    filters:
+      bea_regional.geo_name: Illinois
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Illinois
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: in
+    label: Indiana
+    ordinal: 15
+    row_number: 69
+    geography_id: 0400000US18
+    geography_level: state
+    geography_name: Indiana
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Indiana
+    filters:
+      bea_regional.geo_name: Indiana
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Indiana
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: ia
+    label: Iowa
+    ordinal: 16
+    row_number: 70
+    geography_id: 0400000US19
+    geography_level: state
+    geography_name: Iowa
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Iowa
+    filters:
+      bea_regional.geo_name: Iowa
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Iowa
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: ks
+    label: Kansas
+    ordinal: 17
+    row_number: 71
+    geography_id: 0400000US20
+    geography_level: state
+    geography_name: Kansas
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Kansas
+    filters:
+      bea_regional.geo_name: Kansas
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Kansas
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: ky
+    label: Kentucky
+    ordinal: 18
+    row_number: 72
+    geography_id: 0400000US21
+    geography_level: state
+    geography_name: Kentucky
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Kentucky
+    filters:
+      bea_regional.geo_name: Kentucky
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Kentucky
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: la
+    label: Louisiana
+    ordinal: 19
+    row_number: 73
+    geography_id: 0400000US22
+    geography_level: state
+    geography_name: Louisiana
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Louisiana
+    filters:
+      bea_regional.geo_name: Louisiana
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Louisiana
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: me
+    label: Maine
+    ordinal: 20
+    row_number: 74
+    geography_id: 0400000US23
+    geography_level: state
+    geography_name: Maine
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Maine
+    filters:
+      bea_regional.geo_name: Maine
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Maine
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: md
+    label: Maryland
+    ordinal: 21
+    row_number: 75
+    geography_id: 0400000US24
+    geography_level: state
+    geography_name: Maryland
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Maryland
+    filters:
+      bea_regional.geo_name: Maryland
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Maryland
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: ma
+    label: Massachusetts
+    ordinal: 22
+    row_number: 76
+    geography_id: 0400000US25
+    geography_level: state
+    geography_name: Massachusetts
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Massachusetts
+    filters:
+      bea_regional.geo_name: Massachusetts
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Massachusetts
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: mi
+    label: Michigan
+    ordinal: 23
+    row_number: 77
+    geography_id: 0400000US26
+    geography_level: state
+    geography_name: Michigan
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Michigan
+    filters:
+      bea_regional.geo_name: Michigan
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Michigan
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: mn
+    label: Minnesota
+    ordinal: 24
+    row_number: 78
+    geography_id: 0400000US27
+    geography_level: state
+    geography_name: Minnesota
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Minnesota
+    filters:
+      bea_regional.geo_name: Minnesota
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Minnesota
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: ms
+    label: Mississippi
+    ordinal: 25
+    row_number: 79
+    geography_id: 0400000US28
+    geography_level: state
+    geography_name: Mississippi
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Mississippi
+    filters:
+      bea_regional.geo_name: Mississippi
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Mississippi
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: mo
+    label: Missouri
+    ordinal: 26
+    row_number: 80
+    geography_id: 0400000US29
+    geography_level: state
+    geography_name: Missouri
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Missouri
+    filters:
+      bea_regional.geo_name: Missouri
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Missouri
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: mt
+    label: Montana
+    ordinal: 27
+    row_number: 81
+    geography_id: 0400000US30
+    geography_level: state
+    geography_name: Montana
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Montana
+    filters:
+      bea_regional.geo_name: Montana
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Montana
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: ne
+    label: Nebraska
+    ordinal: 28
+    row_number: 82
+    geography_id: 0400000US31
+    geography_level: state
+    geography_name: Nebraska
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Nebraska
+    filters:
+      bea_regional.geo_name: Nebraska
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Nebraska
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: nv
+    label: Nevada
+    ordinal: 29
+    row_number: 83
+    geography_id: 0400000US32
+    geography_level: state
+    geography_name: Nevada
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Nevada
+    filters:
+      bea_regional.geo_name: Nevada
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Nevada
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: nh
+    label: New Hampshire
+    ordinal: 30
+    row_number: 84
+    geography_id: 0400000US33
+    geography_level: state
+    geography_name: New Hampshire
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: New Hampshire
+    filters:
+      bea_regional.geo_name: New Hampshire
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: New Hampshire
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: nj
+    label: New Jersey
+    ordinal: 31
+    row_number: 85
+    geography_id: 0400000US34
+    geography_level: state
+    geography_name: New Jersey
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: New Jersey
+    filters:
+      bea_regional.geo_name: New Jersey
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: New Jersey
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: nm
+    label: New Mexico
+    ordinal: 32
+    row_number: 86
+    geography_id: 0400000US35
+    geography_level: state
+    geography_name: New Mexico
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: New Mexico
+    filters:
+      bea_regional.geo_name: New Mexico
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: New Mexico
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: ny
+    label: New York
+    ordinal: 33
+    row_number: 87
+    geography_id: 0400000US36
+    geography_level: state
+    geography_name: New York
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: New York
+    filters:
+      bea_regional.geo_name: New York
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: New York
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: nc
+    label: North Carolina
+    ordinal: 34
+    row_number: 88
+    geography_id: 0400000US37
+    geography_level: state
+    geography_name: North Carolina
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: North Carolina
+    filters:
+      bea_regional.geo_name: North Carolina
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: North Carolina
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: nd
+    label: North Dakota
+    ordinal: 35
+    row_number: 89
+    geography_id: 0400000US38
+    geography_level: state
+    geography_name: North Dakota
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: North Dakota
+    filters:
+      bea_regional.geo_name: North Dakota
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: North Dakota
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: oh
+    label: Ohio
+    ordinal: 36
+    row_number: 90
+    geography_id: 0400000US39
+    geography_level: state
+    geography_name: Ohio
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Ohio
+    filters:
+      bea_regional.geo_name: Ohio
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Ohio
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: ok
+    label: Oklahoma
+    ordinal: 37
+    row_number: 91
+    geography_id: 0400000US40
+    geography_level: state
+    geography_name: Oklahoma
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Oklahoma
+    filters:
+      bea_regional.geo_name: Oklahoma
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Oklahoma
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: or
+    label: Oregon
+    ordinal: 38
+    row_number: 92
+    geography_id: 0400000US41
+    geography_level: state
+    geography_name: Oregon
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Oregon
+    filters:
+      bea_regional.geo_name: Oregon
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Oregon
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: pa
+    label: Pennsylvania
+    ordinal: 39
+    row_number: 93
+    geography_id: 0400000US42
+    geography_level: state
+    geography_name: Pennsylvania
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Pennsylvania
+    filters:
+      bea_regional.geo_name: Pennsylvania
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Pennsylvania
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: ri
+    label: Rhode Island
+    ordinal: 40
+    row_number: 94
+    geography_id: 0400000US44
+    geography_level: state
+    geography_name: Rhode Island
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Rhode Island
+    filters:
+      bea_regional.geo_name: Rhode Island
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Rhode Island
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: sc
+    label: South Carolina
+    ordinal: 41
+    row_number: 95
+    geography_id: 0400000US45
+    geography_level: state
+    geography_name: South Carolina
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: South Carolina
+    filters:
+      bea_regional.geo_name: South Carolina
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: South Carolina
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: sd
+    label: South Dakota
+    ordinal: 42
+    row_number: 96
+    geography_id: 0400000US46
+    geography_level: state
+    geography_name: South Dakota
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: South Dakota
+    filters:
+      bea_regional.geo_name: South Dakota
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: South Dakota
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: tn
+    label: Tennessee
+    ordinal: 43
+    row_number: 97
+    geography_id: 0400000US47
+    geography_level: state
+    geography_name: Tennessee
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Tennessee
+    filters:
+      bea_regional.geo_name: Tennessee
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Tennessee
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: tx
+    label: Texas
+    ordinal: 44
+    row_number: 98
+    geography_id: 0400000US48
+    geography_level: state
+    geography_name: Texas
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Texas
+    filters:
+      bea_regional.geo_name: Texas
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Texas
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: ut
+    label: Utah
+    ordinal: 45
+    row_number: 99
+    geography_id: 0400000US49
+    geography_level: state
+    geography_name: Utah
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Utah
+    filters:
+      bea_regional.geo_name: Utah
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Utah
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: vt
+    label: Vermont
+    ordinal: 46
+    row_number: 100
+    geography_id: 0400000US50
+    geography_level: state
+    geography_name: Vermont
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Vermont
+    filters:
+      bea_regional.geo_name: Vermont
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Vermont
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: va
+    label: Virginia
+    ordinal: 47
+    row_number: 101
+    geography_id: 0400000US51
+    geography_level: state
+    geography_name: Virginia
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Virginia
+    filters:
+      bea_regional.geo_name: Virginia
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Virginia
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: wa
+    label: Washington
+    ordinal: 48
+    row_number: 102
+    geography_id: 0400000US53
+    geography_level: state
+    geography_name: Washington
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Washington
+    filters:
+      bea_regional.geo_name: Washington
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Washington
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: wv
+    label: West Virginia
+    ordinal: 49
+    row_number: 103
+    geography_id: 0400000US54
+    geography_level: state
+    geography_name: West Virginia
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: West Virginia
+    filters:
+      bea_regional.geo_name: West Virginia
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: West Virginia
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: wi
+    label: Wisconsin
+    ordinal: 50
+    row_number: 104
+    geography_id: 0400000US55
+    geography_level: state
+    geography_name: Wisconsin
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Wisconsin
+    filters:
+      bea_regional.geo_name: Wisconsin
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Wisconsin
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  - value_id: wy
+    label: Wyoming
+    ordinal: 51
+    row_number: 105
+    geography_id: 0400000US56
+    geography_level: state
+    geography_name: Wyoming
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Wyoming
+    filters:
+      bea_regional.geo_name: Wyoming
+      bea_regional.line_code: 46
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 46
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Wyoming
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 46
+      label: BEA Regional line code
+  measures:
+  - measure_id: amount
+    label: Dividends, interest, and rent
+    ordinal: 0
+    column: AI
+    source_column_id: '2024'
+    concept: bea_regional.dividends_interest_and_rent
+    source_concept: bea_regional.sainc5n_line_46_dividends_interest_and_rent
+    concept_relation: source_label
+    concept_authority: bea
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+- record_set_id: bea_regional.cy{year}.state_personal_current_transfer_receipts
+  record_set_spec_id: bea_regional.state_personal_current_transfer_receipts.v1
+  source_record_id_prefix: bea_regional.cy{year}.state_personal_current_transfer_receipts
+  sheet_name: SAINC5N__ALL_AREAS_1998_2025.csv
+  period_type: calendar_year
+  period: '{year}'
+  geography_id: 0100000US
+  geography_level: country
+  geography_name: United States
+  geography_vintage: current
+  entity: person
+  entity_role: income_recipient
+  domain: personal_income
+  groupby_dimension: bea_regional.geography
+  shared_filters:
+    bea_regional.table_name: SAINC5N
+  shared_constraints: *bea_regional_sainc5n_constraints
+  rows:
+  - value_id: us
+    label: United States
+    ordinal: 0
+    row_number: 106
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: United States
+    filters:
+      bea_regional.geo_name: United States
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: total
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: United States
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: al
+    label: Alabama
+    ordinal: 1
+    row_number: 107
+    geography_id: 0400000US01
+    geography_level: state
+    geography_name: Alabama
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Alabama
+    filters:
+      bea_regional.geo_name: Alabama
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Alabama
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: ak
+    label: Alaska
+    ordinal: 2
+    row_number: 108
+    geography_id: 0400000US02
+    geography_level: state
+    geography_name: Alaska
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Alaska
+    filters:
+      bea_regional.geo_name: Alaska
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Alaska
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: az
+    label: Arizona
+    ordinal: 3
+    row_number: 109
+    geography_id: 0400000US04
+    geography_level: state
+    geography_name: Arizona
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Arizona
+    filters:
+      bea_regional.geo_name: Arizona
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Arizona
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: ar
+    label: Arkansas
+    ordinal: 4
+    row_number: 110
+    geography_id: 0400000US05
+    geography_level: state
+    geography_name: Arkansas
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Arkansas
+    filters:
+      bea_regional.geo_name: Arkansas
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Arkansas
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: ca
+    label: California
+    ordinal: 5
+    row_number: 111
+    geography_id: 0400000US06
+    geography_level: state
+    geography_name: California
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: California
+    filters:
+      bea_regional.geo_name: California
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: California
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: co
+    label: Colorado
+    ordinal: 6
+    row_number: 112
+    geography_id: 0400000US08
+    geography_level: state
+    geography_name: Colorado
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Colorado
+    filters:
+      bea_regional.geo_name: Colorado
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Colorado
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: ct
+    label: Connecticut
+    ordinal: 7
+    row_number: 113
+    geography_id: 0400000US09
+    geography_level: state
+    geography_name: Connecticut
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Connecticut
+    filters:
+      bea_regional.geo_name: Connecticut
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Connecticut
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: de
+    label: Delaware
+    ordinal: 8
+    row_number: 114
+    geography_id: 0400000US10
+    geography_level: state
+    geography_name: Delaware
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Delaware
+    filters:
+      bea_regional.geo_name: Delaware
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Delaware
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: dc
+    label: District of Columbia
+    ordinal: 9
+    row_number: 115
+    geography_id: 0400000US11
+    geography_level: state
+    geography_name: District of Columbia
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: District of Columbia
+    filters:
+      bea_regional.geo_name: District of Columbia
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: District of Columbia
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: fl
+    label: Florida
+    ordinal: 10
+    row_number: 116
+    geography_id: 0400000US12
+    geography_level: state
+    geography_name: Florida
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Florida
+    filters:
+      bea_regional.geo_name: Florida
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Florida
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: ga
+    label: Georgia
+    ordinal: 11
+    row_number: 117
+    geography_id: 0400000US13
+    geography_level: state
+    geography_name: Georgia
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Georgia
+    filters:
+      bea_regional.geo_name: Georgia
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Georgia
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: hi
+    label: Hawaii
+    ordinal: 12
+    row_number: 118
+    geography_id: 0400000US15
+    geography_level: state
+    geography_name: Hawaii
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Hawaii
+    filters:
+      bea_regional.geo_name: Hawaii
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Hawaii
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: id
+    label: Idaho
+    ordinal: 13
+    row_number: 119
+    geography_id: 0400000US16
+    geography_level: state
+    geography_name: Idaho
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Idaho
+    filters:
+      bea_regional.geo_name: Idaho
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Idaho
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: il
+    label: Illinois
+    ordinal: 14
+    row_number: 120
+    geography_id: 0400000US17
+    geography_level: state
+    geography_name: Illinois
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Illinois
+    filters:
+      bea_regional.geo_name: Illinois
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Illinois
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: in
+    label: Indiana
+    ordinal: 15
+    row_number: 121
+    geography_id: 0400000US18
+    geography_level: state
+    geography_name: Indiana
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Indiana
+    filters:
+      bea_regional.geo_name: Indiana
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Indiana
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: ia
+    label: Iowa
+    ordinal: 16
+    row_number: 122
+    geography_id: 0400000US19
+    geography_level: state
+    geography_name: Iowa
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Iowa
+    filters:
+      bea_regional.geo_name: Iowa
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Iowa
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: ks
+    label: Kansas
+    ordinal: 17
+    row_number: 123
+    geography_id: 0400000US20
+    geography_level: state
+    geography_name: Kansas
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Kansas
+    filters:
+      bea_regional.geo_name: Kansas
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Kansas
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: ky
+    label: Kentucky
+    ordinal: 18
+    row_number: 124
+    geography_id: 0400000US21
+    geography_level: state
+    geography_name: Kentucky
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Kentucky
+    filters:
+      bea_regional.geo_name: Kentucky
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Kentucky
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: la
+    label: Louisiana
+    ordinal: 19
+    row_number: 125
+    geography_id: 0400000US22
+    geography_level: state
+    geography_name: Louisiana
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Louisiana
+    filters:
+      bea_regional.geo_name: Louisiana
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Louisiana
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: me
+    label: Maine
+    ordinal: 20
+    row_number: 126
+    geography_id: 0400000US23
+    geography_level: state
+    geography_name: Maine
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Maine
+    filters:
+      bea_regional.geo_name: Maine
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Maine
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: md
+    label: Maryland
+    ordinal: 21
+    row_number: 127
+    geography_id: 0400000US24
+    geography_level: state
+    geography_name: Maryland
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Maryland
+    filters:
+      bea_regional.geo_name: Maryland
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Maryland
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: ma
+    label: Massachusetts
+    ordinal: 22
+    row_number: 128
+    geography_id: 0400000US25
+    geography_level: state
+    geography_name: Massachusetts
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Massachusetts
+    filters:
+      bea_regional.geo_name: Massachusetts
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Massachusetts
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: mi
+    label: Michigan
+    ordinal: 23
+    row_number: 129
+    geography_id: 0400000US26
+    geography_level: state
+    geography_name: Michigan
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Michigan
+    filters:
+      bea_regional.geo_name: Michigan
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Michigan
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: mn
+    label: Minnesota
+    ordinal: 24
+    row_number: 130
+    geography_id: 0400000US27
+    geography_level: state
+    geography_name: Minnesota
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Minnesota
+    filters:
+      bea_regional.geo_name: Minnesota
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Minnesota
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: ms
+    label: Mississippi
+    ordinal: 25
+    row_number: 131
+    geography_id: 0400000US28
+    geography_level: state
+    geography_name: Mississippi
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Mississippi
+    filters:
+      bea_regional.geo_name: Mississippi
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Mississippi
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: mo
+    label: Missouri
+    ordinal: 26
+    row_number: 132
+    geography_id: 0400000US29
+    geography_level: state
+    geography_name: Missouri
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Missouri
+    filters:
+      bea_regional.geo_name: Missouri
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Missouri
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: mt
+    label: Montana
+    ordinal: 27
+    row_number: 133
+    geography_id: 0400000US30
+    geography_level: state
+    geography_name: Montana
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Montana
+    filters:
+      bea_regional.geo_name: Montana
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Montana
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: ne
+    label: Nebraska
+    ordinal: 28
+    row_number: 134
+    geography_id: 0400000US31
+    geography_level: state
+    geography_name: Nebraska
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Nebraska
+    filters:
+      bea_regional.geo_name: Nebraska
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Nebraska
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: nv
+    label: Nevada
+    ordinal: 29
+    row_number: 135
+    geography_id: 0400000US32
+    geography_level: state
+    geography_name: Nevada
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Nevada
+    filters:
+      bea_regional.geo_name: Nevada
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Nevada
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: nh
+    label: New Hampshire
+    ordinal: 30
+    row_number: 136
+    geography_id: 0400000US33
+    geography_level: state
+    geography_name: New Hampshire
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: New Hampshire
+    filters:
+      bea_regional.geo_name: New Hampshire
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: New Hampshire
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: nj
+    label: New Jersey
+    ordinal: 31
+    row_number: 137
+    geography_id: 0400000US34
+    geography_level: state
+    geography_name: New Jersey
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: New Jersey
+    filters:
+      bea_regional.geo_name: New Jersey
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: New Jersey
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: nm
+    label: New Mexico
+    ordinal: 32
+    row_number: 138
+    geography_id: 0400000US35
+    geography_level: state
+    geography_name: New Mexico
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: New Mexico
+    filters:
+      bea_regional.geo_name: New Mexico
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: New Mexico
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: ny
+    label: New York
+    ordinal: 33
+    row_number: 139
+    geography_id: 0400000US36
+    geography_level: state
+    geography_name: New York
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: New York
+    filters:
+      bea_regional.geo_name: New York
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: New York
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: nc
+    label: North Carolina
+    ordinal: 34
+    row_number: 140
+    geography_id: 0400000US37
+    geography_level: state
+    geography_name: North Carolina
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: North Carolina
+    filters:
+      bea_regional.geo_name: North Carolina
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: North Carolina
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: nd
+    label: North Dakota
+    ordinal: 35
+    row_number: 141
+    geography_id: 0400000US38
+    geography_level: state
+    geography_name: North Dakota
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: North Dakota
+    filters:
+      bea_regional.geo_name: North Dakota
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: North Dakota
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: oh
+    label: Ohio
+    ordinal: 36
+    row_number: 142
+    geography_id: 0400000US39
+    geography_level: state
+    geography_name: Ohio
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Ohio
+    filters:
+      bea_regional.geo_name: Ohio
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Ohio
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: ok
+    label: Oklahoma
+    ordinal: 37
+    row_number: 143
+    geography_id: 0400000US40
+    geography_level: state
+    geography_name: Oklahoma
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Oklahoma
+    filters:
+      bea_regional.geo_name: Oklahoma
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Oklahoma
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: or
+    label: Oregon
+    ordinal: 38
+    row_number: 144
+    geography_id: 0400000US41
+    geography_level: state
+    geography_name: Oregon
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Oregon
+    filters:
+      bea_regional.geo_name: Oregon
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Oregon
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: pa
+    label: Pennsylvania
+    ordinal: 39
+    row_number: 145
+    geography_id: 0400000US42
+    geography_level: state
+    geography_name: Pennsylvania
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Pennsylvania
+    filters:
+      bea_regional.geo_name: Pennsylvania
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Pennsylvania
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: ri
+    label: Rhode Island
+    ordinal: 40
+    row_number: 146
+    geography_id: 0400000US44
+    geography_level: state
+    geography_name: Rhode Island
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Rhode Island
+    filters:
+      bea_regional.geo_name: Rhode Island
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Rhode Island
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: sc
+    label: South Carolina
+    ordinal: 41
+    row_number: 147
+    geography_id: 0400000US45
+    geography_level: state
+    geography_name: South Carolina
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: South Carolina
+    filters:
+      bea_regional.geo_name: South Carolina
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: South Carolina
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: sd
+    label: South Dakota
+    ordinal: 42
+    row_number: 148
+    geography_id: 0400000US46
+    geography_level: state
+    geography_name: South Dakota
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: South Dakota
+    filters:
+      bea_regional.geo_name: South Dakota
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: South Dakota
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: tn
+    label: Tennessee
+    ordinal: 43
+    row_number: 149
+    geography_id: 0400000US47
+    geography_level: state
+    geography_name: Tennessee
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Tennessee
+    filters:
+      bea_regional.geo_name: Tennessee
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Tennessee
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: tx
+    label: Texas
+    ordinal: 44
+    row_number: 150
+    geography_id: 0400000US48
+    geography_level: state
+    geography_name: Texas
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Texas
+    filters:
+      bea_regional.geo_name: Texas
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Texas
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: ut
+    label: Utah
+    ordinal: 45
+    row_number: 151
+    geography_id: 0400000US49
+    geography_level: state
+    geography_name: Utah
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Utah
+    filters:
+      bea_regional.geo_name: Utah
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Utah
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: vt
+    label: Vermont
+    ordinal: 46
+    row_number: 152
+    geography_id: 0400000US50
+    geography_level: state
+    geography_name: Vermont
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Vermont
+    filters:
+      bea_regional.geo_name: Vermont
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Vermont
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: va
+    label: Virginia
+    ordinal: 47
+    row_number: 153
+    geography_id: 0400000US51
+    geography_level: state
+    geography_name: Virginia
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Virginia
+    filters:
+      bea_regional.geo_name: Virginia
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Virginia
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: wa
+    label: Washington
+    ordinal: 48
+    row_number: 154
+    geography_id: 0400000US53
+    geography_level: state
+    geography_name: Washington
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Washington
+    filters:
+      bea_regional.geo_name: Washington
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Washington
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: wv
+    label: West Virginia
+    ordinal: 49
+    row_number: 155
+    geography_id: 0400000US54
+    geography_level: state
+    geography_name: West Virginia
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: West Virginia
+    filters:
+      bea_regional.geo_name: West Virginia
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: West Virginia
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: wi
+    label: Wisconsin
+    ordinal: 50
+    row_number: 156
+    geography_id: 0400000US55
+    geography_level: state
+    geography_name: Wisconsin
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Wisconsin
+    filters:
+      bea_regional.geo_name: Wisconsin
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Wisconsin
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  - value_id: wy
+    label: Wyoming
+    ordinal: 51
+    row_number: 157
+    geography_id: 0400000US56
+    geography_level: state
+    geography_name: Wyoming
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Wyoming
+    filters:
+      bea_regional.geo_name: Wyoming
+      bea_regional.line_code: 47
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 47
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Wyoming
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 47
+      label: BEA Regional line code
+  measures:
+  - measure_id: amount
+    label: Personal current transfer receipts
+    ordinal: 0
+    column: AI
+    source_column_id: '2024'
+    concept: bea_regional.personal_current_transfer_receipts
+    source_concept: bea_regional.sainc5n_line_47_personal_current_transfer_receipts
+    concept_relation: source_label
+    concept_authority: bea
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+- record_set_id: bea_regional.cy{year}.state_wages_salaries
+  record_set_spec_id: bea_regional.state_wages_salaries.v1
+  source_record_id_prefix: bea_regional.cy{year}.state_wages_salaries
+  sheet_name: SAINC5N__ALL_AREAS_1998_2025.csv
+  period_type: calendar_year
+  period: '{year}'
+  geography_id: 0100000US
+  geography_level: country
+  geography_name: United States
+  geography_vintage: current
+  entity: person
+  entity_role: income_recipient
+  domain: personal_income
+  groupby_dimension: bea_regional.geography
+  shared_filters:
+    bea_regional.table_name: SAINC5N
+  shared_constraints: *bea_regional_sainc5n_constraints
+  rows:
+  - value_id: us
+    label: United States
+    ordinal: 0
+    row_number: 158
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: United States
+    filters:
+      bea_regional.geo_name: United States
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: total
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: United States
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: al
+    label: Alabama
+    ordinal: 1
+    row_number: 159
+    geography_id: 0400000US01
+    geography_level: state
+    geography_name: Alabama
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Alabama
+    filters:
+      bea_regional.geo_name: Alabama
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Alabama
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: ak
+    label: Alaska
+    ordinal: 2
+    row_number: 160
+    geography_id: 0400000US02
+    geography_level: state
+    geography_name: Alaska
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Alaska
+    filters:
+      bea_regional.geo_name: Alaska
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Alaska
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: az
+    label: Arizona
+    ordinal: 3
+    row_number: 161
+    geography_id: 0400000US04
+    geography_level: state
+    geography_name: Arizona
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Arizona
+    filters:
+      bea_regional.geo_name: Arizona
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Arizona
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: ar
+    label: Arkansas
+    ordinal: 4
+    row_number: 162
+    geography_id: 0400000US05
+    geography_level: state
+    geography_name: Arkansas
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Arkansas
+    filters:
+      bea_regional.geo_name: Arkansas
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Arkansas
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: ca
+    label: California
+    ordinal: 5
+    row_number: 163
+    geography_id: 0400000US06
+    geography_level: state
+    geography_name: California
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: California
+    filters:
+      bea_regional.geo_name: California
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: California
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: co
+    label: Colorado
+    ordinal: 6
+    row_number: 164
+    geography_id: 0400000US08
+    geography_level: state
+    geography_name: Colorado
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Colorado
+    filters:
+      bea_regional.geo_name: Colorado
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Colorado
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: ct
+    label: Connecticut
+    ordinal: 7
+    row_number: 165
+    geography_id: 0400000US09
+    geography_level: state
+    geography_name: Connecticut
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Connecticut
+    filters:
+      bea_regional.geo_name: Connecticut
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Connecticut
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: de
+    label: Delaware
+    ordinal: 8
+    row_number: 166
+    geography_id: 0400000US10
+    geography_level: state
+    geography_name: Delaware
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Delaware
+    filters:
+      bea_regional.geo_name: Delaware
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Delaware
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: dc
+    label: District of Columbia
+    ordinal: 9
+    row_number: 167
+    geography_id: 0400000US11
+    geography_level: state
+    geography_name: District of Columbia
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: District of Columbia
+    filters:
+      bea_regional.geo_name: District of Columbia
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: District of Columbia
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: fl
+    label: Florida
+    ordinal: 10
+    row_number: 168
+    geography_id: 0400000US12
+    geography_level: state
+    geography_name: Florida
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Florida
+    filters:
+      bea_regional.geo_name: Florida
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Florida
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: ga
+    label: Georgia
+    ordinal: 11
+    row_number: 169
+    geography_id: 0400000US13
+    geography_level: state
+    geography_name: Georgia
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Georgia
+    filters:
+      bea_regional.geo_name: Georgia
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Georgia
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: hi
+    label: Hawaii
+    ordinal: 12
+    row_number: 170
+    geography_id: 0400000US15
+    geography_level: state
+    geography_name: Hawaii
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Hawaii
+    filters:
+      bea_regional.geo_name: Hawaii
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Hawaii
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: id
+    label: Idaho
+    ordinal: 13
+    row_number: 171
+    geography_id: 0400000US16
+    geography_level: state
+    geography_name: Idaho
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Idaho
+    filters:
+      bea_regional.geo_name: Idaho
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Idaho
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: il
+    label: Illinois
+    ordinal: 14
+    row_number: 172
+    geography_id: 0400000US17
+    geography_level: state
+    geography_name: Illinois
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Illinois
+    filters:
+      bea_regional.geo_name: Illinois
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Illinois
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: in
+    label: Indiana
+    ordinal: 15
+    row_number: 173
+    geography_id: 0400000US18
+    geography_level: state
+    geography_name: Indiana
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Indiana
+    filters:
+      bea_regional.geo_name: Indiana
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Indiana
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: ia
+    label: Iowa
+    ordinal: 16
+    row_number: 174
+    geography_id: 0400000US19
+    geography_level: state
+    geography_name: Iowa
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Iowa
+    filters:
+      bea_regional.geo_name: Iowa
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Iowa
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: ks
+    label: Kansas
+    ordinal: 17
+    row_number: 175
+    geography_id: 0400000US20
+    geography_level: state
+    geography_name: Kansas
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Kansas
+    filters:
+      bea_regional.geo_name: Kansas
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Kansas
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: ky
+    label: Kentucky
+    ordinal: 18
+    row_number: 176
+    geography_id: 0400000US21
+    geography_level: state
+    geography_name: Kentucky
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Kentucky
+    filters:
+      bea_regional.geo_name: Kentucky
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Kentucky
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: la
+    label: Louisiana
+    ordinal: 19
+    row_number: 177
+    geography_id: 0400000US22
+    geography_level: state
+    geography_name: Louisiana
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Louisiana
+    filters:
+      bea_regional.geo_name: Louisiana
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Louisiana
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: me
+    label: Maine
+    ordinal: 20
+    row_number: 178
+    geography_id: 0400000US23
+    geography_level: state
+    geography_name: Maine
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Maine
+    filters:
+      bea_regional.geo_name: Maine
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Maine
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: md
+    label: Maryland
+    ordinal: 21
+    row_number: 179
+    geography_id: 0400000US24
+    geography_level: state
+    geography_name: Maryland
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Maryland
+    filters:
+      bea_regional.geo_name: Maryland
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Maryland
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: ma
+    label: Massachusetts
+    ordinal: 22
+    row_number: 180
+    geography_id: 0400000US25
+    geography_level: state
+    geography_name: Massachusetts
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Massachusetts
+    filters:
+      bea_regional.geo_name: Massachusetts
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Massachusetts
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: mi
+    label: Michigan
+    ordinal: 23
+    row_number: 181
+    geography_id: 0400000US26
+    geography_level: state
+    geography_name: Michigan
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Michigan
+    filters:
+      bea_regional.geo_name: Michigan
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Michigan
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: mn
+    label: Minnesota
+    ordinal: 24
+    row_number: 182
+    geography_id: 0400000US27
+    geography_level: state
+    geography_name: Minnesota
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Minnesota
+    filters:
+      bea_regional.geo_name: Minnesota
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Minnesota
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: ms
+    label: Mississippi
+    ordinal: 25
+    row_number: 183
+    geography_id: 0400000US28
+    geography_level: state
+    geography_name: Mississippi
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Mississippi
+    filters:
+      bea_regional.geo_name: Mississippi
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Mississippi
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: mo
+    label: Missouri
+    ordinal: 26
+    row_number: 184
+    geography_id: 0400000US29
+    geography_level: state
+    geography_name: Missouri
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Missouri
+    filters:
+      bea_regional.geo_name: Missouri
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Missouri
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: mt
+    label: Montana
+    ordinal: 27
+    row_number: 185
+    geography_id: 0400000US30
+    geography_level: state
+    geography_name: Montana
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Montana
+    filters:
+      bea_regional.geo_name: Montana
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Montana
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: ne
+    label: Nebraska
+    ordinal: 28
+    row_number: 186
+    geography_id: 0400000US31
+    geography_level: state
+    geography_name: Nebraska
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Nebraska
+    filters:
+      bea_regional.geo_name: Nebraska
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Nebraska
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: nv
+    label: Nevada
+    ordinal: 29
+    row_number: 187
+    geography_id: 0400000US32
+    geography_level: state
+    geography_name: Nevada
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Nevada
+    filters:
+      bea_regional.geo_name: Nevada
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Nevada
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: nh
+    label: New Hampshire
+    ordinal: 30
+    row_number: 188
+    geography_id: 0400000US33
+    geography_level: state
+    geography_name: New Hampshire
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: New Hampshire
+    filters:
+      bea_regional.geo_name: New Hampshire
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: New Hampshire
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: nj
+    label: New Jersey
+    ordinal: 31
+    row_number: 189
+    geography_id: 0400000US34
+    geography_level: state
+    geography_name: New Jersey
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: New Jersey
+    filters:
+      bea_regional.geo_name: New Jersey
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: New Jersey
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: nm
+    label: New Mexico
+    ordinal: 32
+    row_number: 190
+    geography_id: 0400000US35
+    geography_level: state
+    geography_name: New Mexico
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: New Mexico
+    filters:
+      bea_regional.geo_name: New Mexico
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: New Mexico
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: ny
+    label: New York
+    ordinal: 33
+    row_number: 191
+    geography_id: 0400000US36
+    geography_level: state
+    geography_name: New York
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: New York
+    filters:
+      bea_regional.geo_name: New York
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: New York
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: nc
+    label: North Carolina
+    ordinal: 34
+    row_number: 192
+    geography_id: 0400000US37
+    geography_level: state
+    geography_name: North Carolina
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: North Carolina
+    filters:
+      bea_regional.geo_name: North Carolina
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: North Carolina
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: nd
+    label: North Dakota
+    ordinal: 35
+    row_number: 193
+    geography_id: 0400000US38
+    geography_level: state
+    geography_name: North Dakota
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: North Dakota
+    filters:
+      bea_regional.geo_name: North Dakota
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: North Dakota
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: oh
+    label: Ohio
+    ordinal: 36
+    row_number: 194
+    geography_id: 0400000US39
+    geography_level: state
+    geography_name: Ohio
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Ohio
+    filters:
+      bea_regional.geo_name: Ohio
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Ohio
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: ok
+    label: Oklahoma
+    ordinal: 37
+    row_number: 195
+    geography_id: 0400000US40
+    geography_level: state
+    geography_name: Oklahoma
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Oklahoma
+    filters:
+      bea_regional.geo_name: Oklahoma
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Oklahoma
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: or
+    label: Oregon
+    ordinal: 38
+    row_number: 196
+    geography_id: 0400000US41
+    geography_level: state
+    geography_name: Oregon
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Oregon
+    filters:
+      bea_regional.geo_name: Oregon
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Oregon
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: pa
+    label: Pennsylvania
+    ordinal: 39
+    row_number: 197
+    geography_id: 0400000US42
+    geography_level: state
+    geography_name: Pennsylvania
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Pennsylvania
+    filters:
+      bea_regional.geo_name: Pennsylvania
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Pennsylvania
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: ri
+    label: Rhode Island
+    ordinal: 40
+    row_number: 198
+    geography_id: 0400000US44
+    geography_level: state
+    geography_name: Rhode Island
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Rhode Island
+    filters:
+      bea_regional.geo_name: Rhode Island
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Rhode Island
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: sc
+    label: South Carolina
+    ordinal: 41
+    row_number: 199
+    geography_id: 0400000US45
+    geography_level: state
+    geography_name: South Carolina
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: South Carolina
+    filters:
+      bea_regional.geo_name: South Carolina
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: South Carolina
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: sd
+    label: South Dakota
+    ordinal: 42
+    row_number: 200
+    geography_id: 0400000US46
+    geography_level: state
+    geography_name: South Dakota
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: South Dakota
+    filters:
+      bea_regional.geo_name: South Dakota
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: South Dakota
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: tn
+    label: Tennessee
+    ordinal: 43
+    row_number: 201
+    geography_id: 0400000US47
+    geography_level: state
+    geography_name: Tennessee
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Tennessee
+    filters:
+      bea_regional.geo_name: Tennessee
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Tennessee
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: tx
+    label: Texas
+    ordinal: 44
+    row_number: 202
+    geography_id: 0400000US48
+    geography_level: state
+    geography_name: Texas
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Texas
+    filters:
+      bea_regional.geo_name: Texas
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Texas
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: ut
+    label: Utah
+    ordinal: 45
+    row_number: 203
+    geography_id: 0400000US49
+    geography_level: state
+    geography_name: Utah
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Utah
+    filters:
+      bea_regional.geo_name: Utah
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Utah
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: vt
+    label: Vermont
+    ordinal: 46
+    row_number: 204
+    geography_id: 0400000US50
+    geography_level: state
+    geography_name: Vermont
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Vermont
+    filters:
+      bea_regional.geo_name: Vermont
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Vermont
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: va
+    label: Virginia
+    ordinal: 47
+    row_number: 205
+    geography_id: 0400000US51
+    geography_level: state
+    geography_name: Virginia
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Virginia
+    filters:
+      bea_regional.geo_name: Virginia
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Virginia
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: wa
+    label: Washington
+    ordinal: 48
+    row_number: 206
+    geography_id: 0400000US53
+    geography_level: state
+    geography_name: Washington
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Washington
+    filters:
+      bea_regional.geo_name: Washington
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Washington
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: wv
+    label: West Virginia
+    ordinal: 49
+    row_number: 207
+    geography_id: 0400000US54
+    geography_level: state
+    geography_name: West Virginia
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: West Virginia
+    filters:
+      bea_regional.geo_name: West Virginia
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: West Virginia
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: wi
+    label: Wisconsin
+    ordinal: 50
+    row_number: 208
+    geography_id: 0400000US55
+    geography_level: state
+    geography_name: Wisconsin
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Wisconsin
+    filters:
+      bea_regional.geo_name: Wisconsin
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Wisconsin
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  - value_id: wy
+    label: Wyoming
+    ordinal: 51
+    row_number: 209
+    geography_id: 0400000US56
+    geography_level: state
+    geography_name: Wyoming
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Wyoming
+    filters:
+      bea_regional.geo_name: Wyoming
+      bea_regional.line_code: 50
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 50
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Wyoming
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 50
+      label: BEA Regional line code
+  measures:
+  - measure_id: amount
+    label: Wages and salaries
+    ordinal: 0
+    column: AI
+    source_column_id: '2024'
+    concept: bea_regional.wages_and_salaries
+    source_concept: bea_regional.sainc5n_line_50_wages_and_salaries
+    concept_relation: source_label
+    concept_authority: bea
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+- record_set_id: bea_regional.cy{year}.state_supplements_to_wages_salaries
+  record_set_spec_id: bea_regional.state_supplements_to_wages_salaries.v1
+  source_record_id_prefix: bea_regional.cy{year}.state_supplements_to_wages_salaries
+  sheet_name: SAINC5N__ALL_AREAS_1998_2025.csv
+  period_type: calendar_year
+  period: '{year}'
+  geography_id: 0100000US
+  geography_level: country
+  geography_name: United States
+  geography_vintage: current
+  entity: person
+  entity_role: income_recipient
+  domain: personal_income
+  groupby_dimension: bea_regional.geography
+  shared_filters:
+    bea_regional.table_name: SAINC5N
+  shared_constraints: *bea_regional_sainc5n_constraints
+  rows:
+  - value_id: us
+    label: United States
+    ordinal: 0
+    row_number: 210
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: United States
+    filters:
+      bea_regional.geo_name: United States
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: total
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: United States
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: al
+    label: Alabama
+    ordinal: 1
+    row_number: 211
+    geography_id: 0400000US01
+    geography_level: state
+    geography_name: Alabama
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Alabama
+    filters:
+      bea_regional.geo_name: Alabama
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Alabama
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: ak
+    label: Alaska
+    ordinal: 2
+    row_number: 212
+    geography_id: 0400000US02
+    geography_level: state
+    geography_name: Alaska
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Alaska
+    filters:
+      bea_regional.geo_name: Alaska
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Alaska
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: az
+    label: Arizona
+    ordinal: 3
+    row_number: 213
+    geography_id: 0400000US04
+    geography_level: state
+    geography_name: Arizona
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Arizona
+    filters:
+      bea_regional.geo_name: Arizona
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Arizona
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: ar
+    label: Arkansas
+    ordinal: 4
+    row_number: 214
+    geography_id: 0400000US05
+    geography_level: state
+    geography_name: Arkansas
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Arkansas
+    filters:
+      bea_regional.geo_name: Arkansas
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Arkansas
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: ca
+    label: California
+    ordinal: 5
+    row_number: 215
+    geography_id: 0400000US06
+    geography_level: state
+    geography_name: California
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: California
+    filters:
+      bea_regional.geo_name: California
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: California
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: co
+    label: Colorado
+    ordinal: 6
+    row_number: 216
+    geography_id: 0400000US08
+    geography_level: state
+    geography_name: Colorado
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Colorado
+    filters:
+      bea_regional.geo_name: Colorado
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Colorado
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: ct
+    label: Connecticut
+    ordinal: 7
+    row_number: 217
+    geography_id: 0400000US09
+    geography_level: state
+    geography_name: Connecticut
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Connecticut
+    filters:
+      bea_regional.geo_name: Connecticut
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Connecticut
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: de
+    label: Delaware
+    ordinal: 8
+    row_number: 218
+    geography_id: 0400000US10
+    geography_level: state
+    geography_name: Delaware
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Delaware
+    filters:
+      bea_regional.geo_name: Delaware
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Delaware
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: dc
+    label: District of Columbia
+    ordinal: 9
+    row_number: 219
+    geography_id: 0400000US11
+    geography_level: state
+    geography_name: District of Columbia
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: District of Columbia
+    filters:
+      bea_regional.geo_name: District of Columbia
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: District of Columbia
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: fl
+    label: Florida
+    ordinal: 10
+    row_number: 220
+    geography_id: 0400000US12
+    geography_level: state
+    geography_name: Florida
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Florida
+    filters:
+      bea_regional.geo_name: Florida
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Florida
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: ga
+    label: Georgia
+    ordinal: 11
+    row_number: 221
+    geography_id: 0400000US13
+    geography_level: state
+    geography_name: Georgia
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Georgia
+    filters:
+      bea_regional.geo_name: Georgia
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Georgia
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: hi
+    label: Hawaii
+    ordinal: 12
+    row_number: 222
+    geography_id: 0400000US15
+    geography_level: state
+    geography_name: Hawaii
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Hawaii
+    filters:
+      bea_regional.geo_name: Hawaii
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Hawaii
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: id
+    label: Idaho
+    ordinal: 13
+    row_number: 223
+    geography_id: 0400000US16
+    geography_level: state
+    geography_name: Idaho
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Idaho
+    filters:
+      bea_regional.geo_name: Idaho
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Idaho
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: il
+    label: Illinois
+    ordinal: 14
+    row_number: 224
+    geography_id: 0400000US17
+    geography_level: state
+    geography_name: Illinois
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Illinois
+    filters:
+      bea_regional.geo_name: Illinois
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Illinois
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: in
+    label: Indiana
+    ordinal: 15
+    row_number: 225
+    geography_id: 0400000US18
+    geography_level: state
+    geography_name: Indiana
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Indiana
+    filters:
+      bea_regional.geo_name: Indiana
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Indiana
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: ia
+    label: Iowa
+    ordinal: 16
+    row_number: 226
+    geography_id: 0400000US19
+    geography_level: state
+    geography_name: Iowa
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Iowa
+    filters:
+      bea_regional.geo_name: Iowa
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Iowa
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: ks
+    label: Kansas
+    ordinal: 17
+    row_number: 227
+    geography_id: 0400000US20
+    geography_level: state
+    geography_name: Kansas
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Kansas
+    filters:
+      bea_regional.geo_name: Kansas
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Kansas
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: ky
+    label: Kentucky
+    ordinal: 18
+    row_number: 228
+    geography_id: 0400000US21
+    geography_level: state
+    geography_name: Kentucky
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Kentucky
+    filters:
+      bea_regional.geo_name: Kentucky
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Kentucky
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: la
+    label: Louisiana
+    ordinal: 19
+    row_number: 229
+    geography_id: 0400000US22
+    geography_level: state
+    geography_name: Louisiana
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Louisiana
+    filters:
+      bea_regional.geo_name: Louisiana
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Louisiana
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: me
+    label: Maine
+    ordinal: 20
+    row_number: 230
+    geography_id: 0400000US23
+    geography_level: state
+    geography_name: Maine
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Maine
+    filters:
+      bea_regional.geo_name: Maine
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Maine
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: md
+    label: Maryland
+    ordinal: 21
+    row_number: 231
+    geography_id: 0400000US24
+    geography_level: state
+    geography_name: Maryland
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Maryland
+    filters:
+      bea_regional.geo_name: Maryland
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Maryland
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: ma
+    label: Massachusetts
+    ordinal: 22
+    row_number: 232
+    geography_id: 0400000US25
+    geography_level: state
+    geography_name: Massachusetts
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Massachusetts
+    filters:
+      bea_regional.geo_name: Massachusetts
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Massachusetts
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: mi
+    label: Michigan
+    ordinal: 23
+    row_number: 233
+    geography_id: 0400000US26
+    geography_level: state
+    geography_name: Michigan
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Michigan
+    filters:
+      bea_regional.geo_name: Michigan
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Michigan
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: mn
+    label: Minnesota
+    ordinal: 24
+    row_number: 234
+    geography_id: 0400000US27
+    geography_level: state
+    geography_name: Minnesota
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Minnesota
+    filters:
+      bea_regional.geo_name: Minnesota
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Minnesota
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: ms
+    label: Mississippi
+    ordinal: 25
+    row_number: 235
+    geography_id: 0400000US28
+    geography_level: state
+    geography_name: Mississippi
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Mississippi
+    filters:
+      bea_regional.geo_name: Mississippi
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Mississippi
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: mo
+    label: Missouri
+    ordinal: 26
+    row_number: 236
+    geography_id: 0400000US29
+    geography_level: state
+    geography_name: Missouri
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Missouri
+    filters:
+      bea_regional.geo_name: Missouri
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Missouri
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: mt
+    label: Montana
+    ordinal: 27
+    row_number: 237
+    geography_id: 0400000US30
+    geography_level: state
+    geography_name: Montana
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Montana
+    filters:
+      bea_regional.geo_name: Montana
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Montana
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: ne
+    label: Nebraska
+    ordinal: 28
+    row_number: 238
+    geography_id: 0400000US31
+    geography_level: state
+    geography_name: Nebraska
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Nebraska
+    filters:
+      bea_regional.geo_name: Nebraska
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Nebraska
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: nv
+    label: Nevada
+    ordinal: 29
+    row_number: 239
+    geography_id: 0400000US32
+    geography_level: state
+    geography_name: Nevada
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Nevada
+    filters:
+      bea_regional.geo_name: Nevada
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Nevada
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: nh
+    label: New Hampshire
+    ordinal: 30
+    row_number: 240
+    geography_id: 0400000US33
+    geography_level: state
+    geography_name: New Hampshire
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: New Hampshire
+    filters:
+      bea_regional.geo_name: New Hampshire
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: New Hampshire
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: nj
+    label: New Jersey
+    ordinal: 31
+    row_number: 241
+    geography_id: 0400000US34
+    geography_level: state
+    geography_name: New Jersey
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: New Jersey
+    filters:
+      bea_regional.geo_name: New Jersey
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: New Jersey
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: nm
+    label: New Mexico
+    ordinal: 32
+    row_number: 242
+    geography_id: 0400000US35
+    geography_level: state
+    geography_name: New Mexico
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: New Mexico
+    filters:
+      bea_regional.geo_name: New Mexico
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: New Mexico
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: ny
+    label: New York
+    ordinal: 33
+    row_number: 243
+    geography_id: 0400000US36
+    geography_level: state
+    geography_name: New York
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: New York
+    filters:
+      bea_regional.geo_name: New York
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: New York
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: nc
+    label: North Carolina
+    ordinal: 34
+    row_number: 244
+    geography_id: 0400000US37
+    geography_level: state
+    geography_name: North Carolina
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: North Carolina
+    filters:
+      bea_regional.geo_name: North Carolina
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: North Carolina
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: nd
+    label: North Dakota
+    ordinal: 35
+    row_number: 245
+    geography_id: 0400000US38
+    geography_level: state
+    geography_name: North Dakota
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: North Dakota
+    filters:
+      bea_regional.geo_name: North Dakota
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: North Dakota
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: oh
+    label: Ohio
+    ordinal: 36
+    row_number: 246
+    geography_id: 0400000US39
+    geography_level: state
+    geography_name: Ohio
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Ohio
+    filters:
+      bea_regional.geo_name: Ohio
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Ohio
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: ok
+    label: Oklahoma
+    ordinal: 37
+    row_number: 247
+    geography_id: 0400000US40
+    geography_level: state
+    geography_name: Oklahoma
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Oklahoma
+    filters:
+      bea_regional.geo_name: Oklahoma
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Oklahoma
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: or
+    label: Oregon
+    ordinal: 38
+    row_number: 248
+    geography_id: 0400000US41
+    geography_level: state
+    geography_name: Oregon
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Oregon
+    filters:
+      bea_regional.geo_name: Oregon
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Oregon
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: pa
+    label: Pennsylvania
+    ordinal: 39
+    row_number: 249
+    geography_id: 0400000US42
+    geography_level: state
+    geography_name: Pennsylvania
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Pennsylvania
+    filters:
+      bea_regional.geo_name: Pennsylvania
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Pennsylvania
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: ri
+    label: Rhode Island
+    ordinal: 40
+    row_number: 250
+    geography_id: 0400000US44
+    geography_level: state
+    geography_name: Rhode Island
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Rhode Island
+    filters:
+      bea_regional.geo_name: Rhode Island
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Rhode Island
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: sc
+    label: South Carolina
+    ordinal: 41
+    row_number: 251
+    geography_id: 0400000US45
+    geography_level: state
+    geography_name: South Carolina
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: South Carolina
+    filters:
+      bea_regional.geo_name: South Carolina
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: South Carolina
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: sd
+    label: South Dakota
+    ordinal: 42
+    row_number: 252
+    geography_id: 0400000US46
+    geography_level: state
+    geography_name: South Dakota
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: South Dakota
+    filters:
+      bea_regional.geo_name: South Dakota
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: South Dakota
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: tn
+    label: Tennessee
+    ordinal: 43
+    row_number: 253
+    geography_id: 0400000US47
+    geography_level: state
+    geography_name: Tennessee
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Tennessee
+    filters:
+      bea_regional.geo_name: Tennessee
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Tennessee
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: tx
+    label: Texas
+    ordinal: 44
+    row_number: 254
+    geography_id: 0400000US48
+    geography_level: state
+    geography_name: Texas
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Texas
+    filters:
+      bea_regional.geo_name: Texas
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Texas
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: ut
+    label: Utah
+    ordinal: 45
+    row_number: 255
+    geography_id: 0400000US49
+    geography_level: state
+    geography_name: Utah
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Utah
+    filters:
+      bea_regional.geo_name: Utah
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Utah
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: vt
+    label: Vermont
+    ordinal: 46
+    row_number: 256
+    geography_id: 0400000US50
+    geography_level: state
+    geography_name: Vermont
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Vermont
+    filters:
+      bea_regional.geo_name: Vermont
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Vermont
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: va
+    label: Virginia
+    ordinal: 47
+    row_number: 257
+    geography_id: 0400000US51
+    geography_level: state
+    geography_name: Virginia
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Virginia
+    filters:
+      bea_regional.geo_name: Virginia
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Virginia
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: wa
+    label: Washington
+    ordinal: 48
+    row_number: 258
+    geography_id: 0400000US53
+    geography_level: state
+    geography_name: Washington
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Washington
+    filters:
+      bea_regional.geo_name: Washington
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Washington
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: wv
+    label: West Virginia
+    ordinal: 49
+    row_number: 259
+    geography_id: 0400000US54
+    geography_level: state
+    geography_name: West Virginia
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: West Virginia
+    filters:
+      bea_regional.geo_name: West Virginia
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: West Virginia
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: wi
+    label: Wisconsin
+    ordinal: 50
+    row_number: 260
+    geography_id: 0400000US55
+    geography_level: state
+    geography_name: Wisconsin
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Wisconsin
+    filters:
+      bea_regional.geo_name: Wisconsin
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Wisconsin
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  - value_id: wy
+    label: Wyoming
+    ordinal: 51
+    row_number: 261
+    geography_id: 0400000US56
+    geography_level: state
+    geography_name: Wyoming
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Wyoming
+    filters:
+      bea_regional.geo_name: Wyoming
+      bea_regional.line_code: 60
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 60
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Wyoming
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 60
+      label: BEA Regional line code
+  measures:
+  - measure_id: amount
+    label: Supplements to wages and salaries
+    ordinal: 0
+    column: AI
+    source_column_id: '2024'
+    concept: bea_regional.supplements_to_wages_and_salaries
+    source_concept: bea_regional.sainc5n_line_60_supplements_to_wages_and_salaries
+    concept_relation: source_label
+    concept_authority: bea
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+- record_set_id: bea_regional.cy{year}.state_proprietors_income
+  record_set_spec_id: bea_regional.state_proprietors_income.v1
+  source_record_id_prefix: bea_regional.cy{year}.state_proprietors_income
+  sheet_name: SAINC5N__ALL_AREAS_1998_2025.csv
+  period_type: calendar_year
+  period: '{year}'
+  geography_id: 0100000US
+  geography_level: country
+  geography_name: United States
+  geography_vintage: current
+  entity: person
+  entity_role: income_recipient
+  domain: personal_income
+  groupby_dimension: bea_regional.geography
+  shared_filters:
+    bea_regional.table_name: SAINC5N
+  shared_constraints: *bea_regional_sainc5n_constraints
+  rows:
+  - value_id: us
+    label: United States
+    ordinal: 0
+    row_number: 262
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: United States
+    filters:
+      bea_regional.geo_name: United States
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: total
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: United States
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: al
+    label: Alabama
+    ordinal: 1
+    row_number: 263
+    geography_id: 0400000US01
+    geography_level: state
+    geography_name: Alabama
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Alabama
+    filters:
+      bea_regional.geo_name: Alabama
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Alabama
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: ak
+    label: Alaska
+    ordinal: 2
+    row_number: 264
+    geography_id: 0400000US02
+    geography_level: state
+    geography_name: Alaska
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Alaska
+    filters:
+      bea_regional.geo_name: Alaska
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Alaska
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: az
+    label: Arizona
+    ordinal: 3
+    row_number: 265
+    geography_id: 0400000US04
+    geography_level: state
+    geography_name: Arizona
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Arizona
+    filters:
+      bea_regional.geo_name: Arizona
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Arizona
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: ar
+    label: Arkansas
+    ordinal: 4
+    row_number: 266
+    geography_id: 0400000US05
+    geography_level: state
+    geography_name: Arkansas
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Arkansas
+    filters:
+      bea_regional.geo_name: Arkansas
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Arkansas
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: ca
+    label: California
+    ordinal: 5
+    row_number: 267
+    geography_id: 0400000US06
+    geography_level: state
+    geography_name: California
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: California
+    filters:
+      bea_regional.geo_name: California
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: California
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: co
+    label: Colorado
+    ordinal: 6
+    row_number: 268
+    geography_id: 0400000US08
+    geography_level: state
+    geography_name: Colorado
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Colorado
+    filters:
+      bea_regional.geo_name: Colorado
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Colorado
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: ct
+    label: Connecticut
+    ordinal: 7
+    row_number: 269
+    geography_id: 0400000US09
+    geography_level: state
+    geography_name: Connecticut
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Connecticut
+    filters:
+      bea_regional.geo_name: Connecticut
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Connecticut
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: de
+    label: Delaware
+    ordinal: 8
+    row_number: 270
+    geography_id: 0400000US10
+    geography_level: state
+    geography_name: Delaware
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Delaware
+    filters:
+      bea_regional.geo_name: Delaware
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Delaware
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: dc
+    label: District of Columbia
+    ordinal: 9
+    row_number: 271
+    geography_id: 0400000US11
+    geography_level: state
+    geography_name: District of Columbia
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: District of Columbia
+    filters:
+      bea_regional.geo_name: District of Columbia
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: District of Columbia
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: fl
+    label: Florida
+    ordinal: 10
+    row_number: 272
+    geography_id: 0400000US12
+    geography_level: state
+    geography_name: Florida
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Florida
+    filters:
+      bea_regional.geo_name: Florida
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Florida
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: ga
+    label: Georgia
+    ordinal: 11
+    row_number: 273
+    geography_id: 0400000US13
+    geography_level: state
+    geography_name: Georgia
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Georgia
+    filters:
+      bea_regional.geo_name: Georgia
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Georgia
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: hi
+    label: Hawaii
+    ordinal: 12
+    row_number: 274
+    geography_id: 0400000US15
+    geography_level: state
+    geography_name: Hawaii
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Hawaii
+    filters:
+      bea_regional.geo_name: Hawaii
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Hawaii
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: id
+    label: Idaho
+    ordinal: 13
+    row_number: 275
+    geography_id: 0400000US16
+    geography_level: state
+    geography_name: Idaho
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Idaho
+    filters:
+      bea_regional.geo_name: Idaho
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Idaho
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: il
+    label: Illinois
+    ordinal: 14
+    row_number: 276
+    geography_id: 0400000US17
+    geography_level: state
+    geography_name: Illinois
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Illinois
+    filters:
+      bea_regional.geo_name: Illinois
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Illinois
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: in
+    label: Indiana
+    ordinal: 15
+    row_number: 277
+    geography_id: 0400000US18
+    geography_level: state
+    geography_name: Indiana
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Indiana
+    filters:
+      bea_regional.geo_name: Indiana
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Indiana
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: ia
+    label: Iowa
+    ordinal: 16
+    row_number: 278
+    geography_id: 0400000US19
+    geography_level: state
+    geography_name: Iowa
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Iowa
+    filters:
+      bea_regional.geo_name: Iowa
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Iowa
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: ks
+    label: Kansas
+    ordinal: 17
+    row_number: 279
+    geography_id: 0400000US20
+    geography_level: state
+    geography_name: Kansas
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Kansas
+    filters:
+      bea_regional.geo_name: Kansas
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Kansas
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: ky
+    label: Kentucky
+    ordinal: 18
+    row_number: 280
+    geography_id: 0400000US21
+    geography_level: state
+    geography_name: Kentucky
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Kentucky
+    filters:
+      bea_regional.geo_name: Kentucky
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Kentucky
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: la
+    label: Louisiana
+    ordinal: 19
+    row_number: 281
+    geography_id: 0400000US22
+    geography_level: state
+    geography_name: Louisiana
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Louisiana
+    filters:
+      bea_regional.geo_name: Louisiana
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Louisiana
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: me
+    label: Maine
+    ordinal: 20
+    row_number: 282
+    geography_id: 0400000US23
+    geography_level: state
+    geography_name: Maine
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Maine
+    filters:
+      bea_regional.geo_name: Maine
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Maine
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: md
+    label: Maryland
+    ordinal: 21
+    row_number: 283
+    geography_id: 0400000US24
+    geography_level: state
+    geography_name: Maryland
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Maryland
+    filters:
+      bea_regional.geo_name: Maryland
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Maryland
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: ma
+    label: Massachusetts
+    ordinal: 22
+    row_number: 284
+    geography_id: 0400000US25
+    geography_level: state
+    geography_name: Massachusetts
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Massachusetts
+    filters:
+      bea_regional.geo_name: Massachusetts
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Massachusetts
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: mi
+    label: Michigan
+    ordinal: 23
+    row_number: 285
+    geography_id: 0400000US26
+    geography_level: state
+    geography_name: Michigan
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Michigan
+    filters:
+      bea_regional.geo_name: Michigan
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Michigan
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: mn
+    label: Minnesota
+    ordinal: 24
+    row_number: 286
+    geography_id: 0400000US27
+    geography_level: state
+    geography_name: Minnesota
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Minnesota
+    filters:
+      bea_regional.geo_name: Minnesota
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Minnesota
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: ms
+    label: Mississippi
+    ordinal: 25
+    row_number: 287
+    geography_id: 0400000US28
+    geography_level: state
+    geography_name: Mississippi
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Mississippi
+    filters:
+      bea_regional.geo_name: Mississippi
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Mississippi
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: mo
+    label: Missouri
+    ordinal: 26
+    row_number: 288
+    geography_id: 0400000US29
+    geography_level: state
+    geography_name: Missouri
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Missouri
+    filters:
+      bea_regional.geo_name: Missouri
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Missouri
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: mt
+    label: Montana
+    ordinal: 27
+    row_number: 289
+    geography_id: 0400000US30
+    geography_level: state
+    geography_name: Montana
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Montana
+    filters:
+      bea_regional.geo_name: Montana
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Montana
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: ne
+    label: Nebraska
+    ordinal: 28
+    row_number: 290
+    geography_id: 0400000US31
+    geography_level: state
+    geography_name: Nebraska
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Nebraska
+    filters:
+      bea_regional.geo_name: Nebraska
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Nebraska
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: nv
+    label: Nevada
+    ordinal: 29
+    row_number: 291
+    geography_id: 0400000US32
+    geography_level: state
+    geography_name: Nevada
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Nevada
+    filters:
+      bea_regional.geo_name: Nevada
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Nevada
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: nh
+    label: New Hampshire
+    ordinal: 30
+    row_number: 292
+    geography_id: 0400000US33
+    geography_level: state
+    geography_name: New Hampshire
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: New Hampshire
+    filters:
+      bea_regional.geo_name: New Hampshire
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: New Hampshire
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: nj
+    label: New Jersey
+    ordinal: 31
+    row_number: 293
+    geography_id: 0400000US34
+    geography_level: state
+    geography_name: New Jersey
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: New Jersey
+    filters:
+      bea_regional.geo_name: New Jersey
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: New Jersey
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: nm
+    label: New Mexico
+    ordinal: 32
+    row_number: 294
+    geography_id: 0400000US35
+    geography_level: state
+    geography_name: New Mexico
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: New Mexico
+    filters:
+      bea_regional.geo_name: New Mexico
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: New Mexico
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: ny
+    label: New York
+    ordinal: 33
+    row_number: 295
+    geography_id: 0400000US36
+    geography_level: state
+    geography_name: New York
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: New York
+    filters:
+      bea_regional.geo_name: New York
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: New York
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: nc
+    label: North Carolina
+    ordinal: 34
+    row_number: 296
+    geography_id: 0400000US37
+    geography_level: state
+    geography_name: North Carolina
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: North Carolina
+    filters:
+      bea_regional.geo_name: North Carolina
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: North Carolina
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: nd
+    label: North Dakota
+    ordinal: 35
+    row_number: 297
+    geography_id: 0400000US38
+    geography_level: state
+    geography_name: North Dakota
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: North Dakota
+    filters:
+      bea_regional.geo_name: North Dakota
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: North Dakota
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: oh
+    label: Ohio
+    ordinal: 36
+    row_number: 298
+    geography_id: 0400000US39
+    geography_level: state
+    geography_name: Ohio
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Ohio
+    filters:
+      bea_regional.geo_name: Ohio
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Ohio
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: ok
+    label: Oklahoma
+    ordinal: 37
+    row_number: 299
+    geography_id: 0400000US40
+    geography_level: state
+    geography_name: Oklahoma
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Oklahoma
+    filters:
+      bea_regional.geo_name: Oklahoma
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Oklahoma
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: or
+    label: Oregon
+    ordinal: 38
+    row_number: 300
+    geography_id: 0400000US41
+    geography_level: state
+    geography_name: Oregon
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Oregon
+    filters:
+      bea_regional.geo_name: Oregon
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Oregon
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: pa
+    label: Pennsylvania
+    ordinal: 39
+    row_number: 301
+    geography_id: 0400000US42
+    geography_level: state
+    geography_name: Pennsylvania
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Pennsylvania
+    filters:
+      bea_regional.geo_name: Pennsylvania
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Pennsylvania
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: ri
+    label: Rhode Island
+    ordinal: 40
+    row_number: 302
+    geography_id: 0400000US44
+    geography_level: state
+    geography_name: Rhode Island
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Rhode Island
+    filters:
+      bea_regional.geo_name: Rhode Island
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Rhode Island
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: sc
+    label: South Carolina
+    ordinal: 41
+    row_number: 303
+    geography_id: 0400000US45
+    geography_level: state
+    geography_name: South Carolina
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: South Carolina
+    filters:
+      bea_regional.geo_name: South Carolina
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: South Carolina
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: sd
+    label: South Dakota
+    ordinal: 42
+    row_number: 304
+    geography_id: 0400000US46
+    geography_level: state
+    geography_name: South Dakota
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: South Dakota
+    filters:
+      bea_regional.geo_name: South Dakota
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: South Dakota
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: tn
+    label: Tennessee
+    ordinal: 43
+    row_number: 305
+    geography_id: 0400000US47
+    geography_level: state
+    geography_name: Tennessee
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Tennessee
+    filters:
+      bea_regional.geo_name: Tennessee
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Tennessee
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: tx
+    label: Texas
+    ordinal: 44
+    row_number: 306
+    geography_id: 0400000US48
+    geography_level: state
+    geography_name: Texas
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Texas
+    filters:
+      bea_regional.geo_name: Texas
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Texas
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: ut
+    label: Utah
+    ordinal: 45
+    row_number: 307
+    geography_id: 0400000US49
+    geography_level: state
+    geography_name: Utah
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Utah
+    filters:
+      bea_regional.geo_name: Utah
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Utah
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: vt
+    label: Vermont
+    ordinal: 46
+    row_number: 308
+    geography_id: 0400000US50
+    geography_level: state
+    geography_name: Vermont
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Vermont
+    filters:
+      bea_regional.geo_name: Vermont
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Vermont
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: va
+    label: Virginia
+    ordinal: 47
+    row_number: 309
+    geography_id: 0400000US51
+    geography_level: state
+    geography_name: Virginia
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Virginia
+    filters:
+      bea_regional.geo_name: Virginia
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Virginia
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: wa
+    label: Washington
+    ordinal: 48
+    row_number: 310
+    geography_id: 0400000US53
+    geography_level: state
+    geography_name: Washington
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Washington
+    filters:
+      bea_regional.geo_name: Washington
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Washington
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: wv
+    label: West Virginia
+    ordinal: 49
+    row_number: 311
+    geography_id: 0400000US54
+    geography_level: state
+    geography_name: West Virginia
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: West Virginia
+    filters:
+      bea_regional.geo_name: West Virginia
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: West Virginia
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: wi
+    label: Wisconsin
+    ordinal: 50
+    row_number: 312
+    geography_id: 0400000US55
+    geography_level: state
+    geography_name: Wisconsin
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Wisconsin
+    filters:
+      bea_regional.geo_name: Wisconsin
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Wisconsin
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  - value_id: wy
+    label: Wyoming
+    ordinal: 51
+    row_number: 313
+    geography_id: 0400000US56
+    geography_level: state
+    geography_name: Wyoming
+    geography_vintage: current
+    expected_row_header_column: B
+    expected_row_header: Wyoming
+    filters:
+      bea_regional.geo_name: Wyoming
+      bea_regional.line_code: 70
+    guard_cells:
+    - column: D
+      row: start
+      expected_value: SAINC5N
+      label: BEA regional table name
+    - column: E
+      row: start
+      expected_value: 70
+      label: BEA regional line code
+    - column: H
+      row: start
+      expected_value: Thousands of dollars
+      label: source unit
+    table_record_kind: detail
+    constraints:
+    - variable: bea_regional.geo_name
+      operator: ==
+      value: Wyoming
+      label: BEA Regional geography name
+    - variable: bea_regional.line_code
+      operator: ==
+      value: 70
+      label: BEA Regional line code
+  measures:
+  - measure_id: amount
+    label: Proprietors' income
+    ordinal: 0
+    column: AI
+    source_column_id: '2024'
+    concept: bea_regional.proprietors_income
+    source_concept: bea_regional.sainc5n_line_70_proprietors_income
+    concept_relation: source_label
+    concept_authority: bea
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number

--- a/tests/test_arch_source_package.py
+++ b/tests/test_arch_source_package.py
@@ -342,6 +342,58 @@ def test_bea_nipa_personal_income_disposition_builds_amounts_and_rates():
     assert saving_rate.measure.unit == "percent"
 
 
+def test_bea_regional_state_personal_income_components_build_2024_facts():
+    package = load_source_package("bea-regional-state-personal-income-components-2024")
+    facts = package.build_facts(2024)
+    facts_by_record = {fact.source_record_id: fact for fact in facts}
+
+    assert len(facts) == 312
+    assert validate_facts(facts).valid
+    california_wages = facts_by_record[
+        "bea_regional.cy2024.state_wages_salaries.ca.amount"
+    ]
+    assert california_wages.value == 1_769_665_607_000
+    assert california_wages.geography.id == "0400000US06"
+    assert california_wages.measure.concept == "bea_regional.wages_and_salaries"
+    assert {
+        (constraint.variable, constraint.operator, constraint.value)
+        for constraint in california_wages.constraints
+    } == {
+        ("bea_regional.table_name", "==", "SAINC5N"),
+        ("bea_regional.geo_name", "==", "California"),
+        ("bea_regional.line_code", "==", 50),
+    }
+    assert california_wages.source.source_file == "SAINC.zip"
+    assert california_wages.source.raw_r2_uri
+    assert (
+        facts_by_record[
+            "bea_regional.cy2024.state_personal_current_transfer_receipts.us.amount"
+        ].value
+        == 4_555_385_000_000
+    )
+    assert (
+        facts_by_record["bea_regional.cy2024.state_proprietors_income.tx.amount"].value
+        == 273_877_560_000
+    )
+    assert validate_consumer_fact_contract(facts).valid
+
+
+def test_bea_regional_state_personal_income_components_validate_counts():
+    report = validate_source_package(
+        "bea-regional-state-personal-income-components-2024",
+        year=2024,
+    )
+
+    assert report.valid
+    assert report.counts == {
+        "measure_count": 6,
+        "record_set_count": 6,
+        "row_count": 312,
+        "source_record_count": 312,
+        "source_region_count": 6,
+    }
+
+
 def test_cbo_income_by_source_package_preserves_cbo_projection_concepts():
     package = load_source_package("cbo-revenue-projections-income-by-source-2026-02")
     rows = package.build_source_rows(2024)


### PR DESCRIPTION
## Summary

- add a BEA Regional SAINC state personal-income source package for 2024
- include the pinned `SAINC.zip` raw artifact manifest with R2 provenance
- expose 312 consumer facts across US + 51 states/DC for six BEA regional concepts: personal income, dividends/interest/rent, transfer receipts, wages/salaries, supplements, and proprietors income
- register the source-package alias and add tests for counts, lineage validity, and spot values

## Checks

- `uv run --python 3.13 ruff check arch/source_package.py tests/test_arch_source_package.py`
- `uv run --python 3.13 pytest -q tests/test_arch_source_package.py -k "bea_regional_state"`
- `uv run --python 3.13 arch validate-package bea-regional-state-personal-income-components-2024 --year 2024`
- `uv run --python 3.13 arch build-suite bea-regional-state-personal-income-components-2024 --year 2024 --out /tmp/arch-bea-regional-state-2024 --replace`
