### PR TITLE
Add SOI congressional district source package

### DIFF
--- a/arch/source_package.py
+++ b/arch/source_package.py
@@ -131,6 +131,9 @@ SOURCE_PACKAGE_ALIASES = {
     ),
     "soi-table-4-3": Path("irs_soi/table_4_3"),
     "soi-state-2022": Path("irs_soi/state_2022"),
+    "soi-congressional-district-2022": Path(
+        "irs_soi/congressional_district_2022"
+    ),
     "soi-historic-table-2": Path("irs_soi/historic_table_2"),
     "soi-historic-table-2-state-agi-2022": Path(
         "irs_soi/historic_table_2_state_agi_2022"

--- a/db/data/irs_soi/congressional_district_2022/manifest.yaml
+++ b/db/data/irs_soi/congressional_district_2022/manifest.yaml
@@ -1,0 +1,18 @@
+source_id: irs_soi
+package_id: soi-congressional-district-2022
+dataset: irs_soi_congressional_district_2022
+source_page: https://www.irs.gov/statistics/soi-tax-stats-county-data-2022
+table: IRS SOI Congressional District Data 2022
+files:
+  2022:
+    filename: 22incd.csv
+    source_url: https://www.irs.gov/pub/irs-soi/22incd.csv
+    sha256: 137522878af78d624cfddc0e17cd36ae76a21b7bed166c7bb96ad3243a18a668
+    size_bytes: 7710982
+    fetched_at: '2026-05-11T12:41:32+00:00'
+    storage:
+      r2:
+        provider: r2
+        bucket: arch-raw
+        key: raw/irs_soi/soi-congressional-district-2022/2022/137522878af78d624cfddc0e17cd36ae76a21b7bed166c7bb96ad3243a18a668/22incd.csv
+        uri: r2://arch-raw/raw/irs_soi/soi-congressional-district-2022/2022/137522878af78d624cfddc0e17cd36ae76a21b7bed166c7bb96ad3243a18a668/22incd.csv

--- a/packages/irs_soi/congressional_district_2022/source_package.yaml
+++ b/packages/irs_soi/congressional_district_2022/source_package.yaml
@@ -1,0 +1,13997 @@
+schema_version: arch.source_package.v1
+package_id: soi-congressional-district-2022
+label: IRS SOI 2022 congressional district return totals
+artifact:
+  source_name: irs_soi
+  source_table: Congressional District Data 2022
+  resource_package: db
+  resource_directory: data/irs_soi/congressional_district_2022
+  manifest: manifest.yaml
+  vintage: tax_year_{year}
+  extracted_at: '2026-05-11'
+  extraction_method: full CSV row parse with all-return national, state, and congressional district facts
+  parser: delimited_text_full_rows
+  sheet_name: incd2022
+  artifact_year: 2022
+  selected_rows:
+  - STATE: US
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: AL
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: AL
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: AL
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: AL
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: AL
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: AL
+    CONG_DISTRICT: 5
+    agi_stub: 0
+  - STATE: AL
+    CONG_DISTRICT: 6
+    agi_stub: 0
+  - STATE: AL
+    CONG_DISTRICT: 7
+    agi_stub: 0
+  - STATE: AK
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: AZ
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: AZ
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: AZ
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: AZ
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: AZ
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: AZ
+    CONG_DISTRICT: 5
+    agi_stub: 0
+  - STATE: AZ
+    CONG_DISTRICT: 6
+    agi_stub: 0
+  - STATE: AZ
+    CONG_DISTRICT: 7
+    agi_stub: 0
+  - STATE: AZ
+    CONG_DISTRICT: 8
+    agi_stub: 0
+  - STATE: AZ
+    CONG_DISTRICT: 9
+    agi_stub: 0
+  - STATE: AR
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: AR
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: AR
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: AR
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: AR
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 5
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 6
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 7
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 8
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 9
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 10
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 11
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 12
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 13
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 14
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 15
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 16
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 17
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 18
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 19
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 20
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 21
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 22
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 23
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 24
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 25
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 26
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 27
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 28
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 29
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 30
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 31
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 32
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 33
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 34
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 35
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 36
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 37
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 38
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 39
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 40
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 41
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 42
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 43
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 44
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 45
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 46
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 47
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 48
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 49
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 50
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 51
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 52
+    agi_stub: 0
+  - STATE: CA
+    CONG_DISTRICT: 53
+    agi_stub: 0
+  - STATE: CO
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: CO
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: CO
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: CO
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: CO
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: CO
+    CONG_DISTRICT: 5
+    agi_stub: 0
+  - STATE: CO
+    CONG_DISTRICT: 6
+    agi_stub: 0
+  - STATE: CO
+    CONG_DISTRICT: 7
+    agi_stub: 0
+  - STATE: CT
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: CT
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: CT
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: CT
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: CT
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: CT
+    CONG_DISTRICT: 5
+    agi_stub: 0
+  - STATE: DE
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: DC
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: FL
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: FL
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: FL
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: FL
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: FL
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: FL
+    CONG_DISTRICT: 5
+    agi_stub: 0
+  - STATE: FL
+    CONG_DISTRICT: 6
+    agi_stub: 0
+  - STATE: FL
+    CONG_DISTRICT: 7
+    agi_stub: 0
+  - STATE: FL
+    CONG_DISTRICT: 8
+    agi_stub: 0
+  - STATE: FL
+    CONG_DISTRICT: 9
+    agi_stub: 0
+  - STATE: FL
+    CONG_DISTRICT: 10
+    agi_stub: 0
+  - STATE: FL
+    CONG_DISTRICT: 11
+    agi_stub: 0
+  - STATE: FL
+    CONG_DISTRICT: 12
+    agi_stub: 0
+  - STATE: FL
+    CONG_DISTRICT: 13
+    agi_stub: 0
+  - STATE: FL
+    CONG_DISTRICT: 14
+    agi_stub: 0
+  - STATE: FL
+    CONG_DISTRICT: 15
+    agi_stub: 0
+  - STATE: FL
+    CONG_DISTRICT: 16
+    agi_stub: 0
+  - STATE: FL
+    CONG_DISTRICT: 17
+    agi_stub: 0
+  - STATE: FL
+    CONG_DISTRICT: 18
+    agi_stub: 0
+  - STATE: FL
+    CONG_DISTRICT: 19
+    agi_stub: 0
+  - STATE: FL
+    CONG_DISTRICT: 20
+    agi_stub: 0
+  - STATE: FL
+    CONG_DISTRICT: 21
+    agi_stub: 0
+  - STATE: FL
+    CONG_DISTRICT: 22
+    agi_stub: 0
+  - STATE: FL
+    CONG_DISTRICT: 23
+    agi_stub: 0
+  - STATE: FL
+    CONG_DISTRICT: 24
+    agi_stub: 0
+  - STATE: FL
+    CONG_DISTRICT: 25
+    agi_stub: 0
+  - STATE: FL
+    CONG_DISTRICT: 26
+    agi_stub: 0
+  - STATE: FL
+    CONG_DISTRICT: 27
+    agi_stub: 0
+  - STATE: GA
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: GA
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: GA
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: GA
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: GA
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: GA
+    CONG_DISTRICT: 5
+    agi_stub: 0
+  - STATE: GA
+    CONG_DISTRICT: 6
+    agi_stub: 0
+  - STATE: GA
+    CONG_DISTRICT: 7
+    agi_stub: 0
+  - STATE: GA
+    CONG_DISTRICT: 8
+    agi_stub: 0
+  - STATE: GA
+    CONG_DISTRICT: 9
+    agi_stub: 0
+  - STATE: GA
+    CONG_DISTRICT: 10
+    agi_stub: 0
+  - STATE: GA
+    CONG_DISTRICT: 11
+    agi_stub: 0
+  - STATE: GA
+    CONG_DISTRICT: 12
+    agi_stub: 0
+  - STATE: GA
+    CONG_DISTRICT: 13
+    agi_stub: 0
+  - STATE: GA
+    CONG_DISTRICT: 14
+    agi_stub: 0
+  - STATE: HI
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: HI
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: HI
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: ID
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: ID
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: ID
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: IL
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: IL
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: IL
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: IL
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: IL
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: IL
+    CONG_DISTRICT: 5
+    agi_stub: 0
+  - STATE: IL
+    CONG_DISTRICT: 6
+    agi_stub: 0
+  - STATE: IL
+    CONG_DISTRICT: 7
+    agi_stub: 0
+  - STATE: IL
+    CONG_DISTRICT: 8
+    agi_stub: 0
+  - STATE: IL
+    CONG_DISTRICT: 9
+    agi_stub: 0
+  - STATE: IL
+    CONG_DISTRICT: 10
+    agi_stub: 0
+  - STATE: IL
+    CONG_DISTRICT: 11
+    agi_stub: 0
+  - STATE: IL
+    CONG_DISTRICT: 12
+    agi_stub: 0
+  - STATE: IL
+    CONG_DISTRICT: 13
+    agi_stub: 0
+  - STATE: IL
+    CONG_DISTRICT: 14
+    agi_stub: 0
+  - STATE: IL
+    CONG_DISTRICT: 15
+    agi_stub: 0
+  - STATE: IL
+    CONG_DISTRICT: 16
+    agi_stub: 0
+  - STATE: IL
+    CONG_DISTRICT: 17
+    agi_stub: 0
+  - STATE: IL
+    CONG_DISTRICT: 18
+    agi_stub: 0
+  - STATE: IN
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: IN
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: IN
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: IN
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: IN
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: IN
+    CONG_DISTRICT: 5
+    agi_stub: 0
+  - STATE: IN
+    CONG_DISTRICT: 6
+    agi_stub: 0
+  - STATE: IN
+    CONG_DISTRICT: 7
+    agi_stub: 0
+  - STATE: IN
+    CONG_DISTRICT: 8
+    agi_stub: 0
+  - STATE: IN
+    CONG_DISTRICT: 9
+    agi_stub: 0
+  - STATE: IA
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: IA
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: IA
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: IA
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: IA
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: KS
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: KS
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: KS
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: KS
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: KS
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: KY
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: KY
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: KY
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: KY
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: KY
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: KY
+    CONG_DISTRICT: 5
+    agi_stub: 0
+  - STATE: KY
+    CONG_DISTRICT: 6
+    agi_stub: 0
+  - STATE: LA
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: LA
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: LA
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: LA
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: LA
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: LA
+    CONG_DISTRICT: 5
+    agi_stub: 0
+  - STATE: LA
+    CONG_DISTRICT: 6
+    agi_stub: 0
+  - STATE: ME
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: ME
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: ME
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: MD
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: MD
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: MD
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: MD
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: MD
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: MD
+    CONG_DISTRICT: 5
+    agi_stub: 0
+  - STATE: MD
+    CONG_DISTRICT: 6
+    agi_stub: 0
+  - STATE: MD
+    CONG_DISTRICT: 7
+    agi_stub: 0
+  - STATE: MD
+    CONG_DISTRICT: 8
+    agi_stub: 0
+  - STATE: MA
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: MA
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: MA
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: MA
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: MA
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: MA
+    CONG_DISTRICT: 5
+    agi_stub: 0
+  - STATE: MA
+    CONG_DISTRICT: 6
+    agi_stub: 0
+  - STATE: MA
+    CONG_DISTRICT: 7
+    agi_stub: 0
+  - STATE: MA
+    CONG_DISTRICT: 8
+    agi_stub: 0
+  - STATE: MA
+    CONG_DISTRICT: 9
+    agi_stub: 0
+  - STATE: MI
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: MI
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: MI
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: MI
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: MI
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: MI
+    CONG_DISTRICT: 5
+    agi_stub: 0
+  - STATE: MI
+    CONG_DISTRICT: 6
+    agi_stub: 0
+  - STATE: MI
+    CONG_DISTRICT: 7
+    agi_stub: 0
+  - STATE: MI
+    CONG_DISTRICT: 8
+    agi_stub: 0
+  - STATE: MI
+    CONG_DISTRICT: 9
+    agi_stub: 0
+  - STATE: MI
+    CONG_DISTRICT: 10
+    agi_stub: 0
+  - STATE: MI
+    CONG_DISTRICT: 11
+    agi_stub: 0
+  - STATE: MI
+    CONG_DISTRICT: 12
+    agi_stub: 0
+  - STATE: MI
+    CONG_DISTRICT: 13
+    agi_stub: 0
+  - STATE: MI
+    CONG_DISTRICT: 14
+    agi_stub: 0
+  - STATE: MN
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: MN
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: MN
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: MN
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: MN
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: MN
+    CONG_DISTRICT: 5
+    agi_stub: 0
+  - STATE: MN
+    CONG_DISTRICT: 6
+    agi_stub: 0
+  - STATE: MN
+    CONG_DISTRICT: 7
+    agi_stub: 0
+  - STATE: MN
+    CONG_DISTRICT: 8
+    agi_stub: 0
+  - STATE: MS
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: MS
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: MS
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: MS
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: MS
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: MO
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: MO
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: MO
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: MO
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: MO
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: MO
+    CONG_DISTRICT: 5
+    agi_stub: 0
+  - STATE: MO
+    CONG_DISTRICT: 6
+    agi_stub: 0
+  - STATE: MO
+    CONG_DISTRICT: 7
+    agi_stub: 0
+  - STATE: MO
+    CONG_DISTRICT: 8
+    agi_stub: 0
+  - STATE: MT
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: NE
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: NE
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: NE
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: NE
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: NV
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: NV
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: NV
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: NV
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: NV
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: NH
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: NH
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: NH
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: NJ
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: NJ
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: NJ
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: NJ
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: NJ
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: NJ
+    CONG_DISTRICT: 5
+    agi_stub: 0
+  - STATE: NJ
+    CONG_DISTRICT: 6
+    agi_stub: 0
+  - STATE: NJ
+    CONG_DISTRICT: 7
+    agi_stub: 0
+  - STATE: NJ
+    CONG_DISTRICT: 8
+    agi_stub: 0
+  - STATE: NJ
+    CONG_DISTRICT: 9
+    agi_stub: 0
+  - STATE: NJ
+    CONG_DISTRICT: 10
+    agi_stub: 0
+  - STATE: NJ
+    CONG_DISTRICT: 11
+    agi_stub: 0
+  - STATE: NJ
+    CONG_DISTRICT: 12
+    agi_stub: 0
+  - STATE: NM
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: NM
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: NM
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: NM
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: NY
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: NY
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: NY
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: NY
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: NY
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: NY
+    CONG_DISTRICT: 5
+    agi_stub: 0
+  - STATE: NY
+    CONG_DISTRICT: 6
+    agi_stub: 0
+  - STATE: NY
+    CONG_DISTRICT: 7
+    agi_stub: 0
+  - STATE: NY
+    CONG_DISTRICT: 8
+    agi_stub: 0
+  - STATE: NY
+    CONG_DISTRICT: 9
+    agi_stub: 0
+  - STATE: NY
+    CONG_DISTRICT: 10
+    agi_stub: 0
+  - STATE: NY
+    CONG_DISTRICT: 11
+    agi_stub: 0
+  - STATE: NY
+    CONG_DISTRICT: 12
+    agi_stub: 0
+  - STATE: NY
+    CONG_DISTRICT: 13
+    agi_stub: 0
+  - STATE: NY
+    CONG_DISTRICT: 14
+    agi_stub: 0
+  - STATE: NY
+    CONG_DISTRICT: 15
+    agi_stub: 0
+  - STATE: NY
+    CONG_DISTRICT: 16
+    agi_stub: 0
+  - STATE: NY
+    CONG_DISTRICT: 17
+    agi_stub: 0
+  - STATE: NY
+    CONG_DISTRICT: 18
+    agi_stub: 0
+  - STATE: NY
+    CONG_DISTRICT: 19
+    agi_stub: 0
+  - STATE: NY
+    CONG_DISTRICT: 20
+    agi_stub: 0
+  - STATE: NY
+    CONG_DISTRICT: 21
+    agi_stub: 0
+  - STATE: NY
+    CONG_DISTRICT: 22
+    agi_stub: 0
+  - STATE: NY
+    CONG_DISTRICT: 23
+    agi_stub: 0
+  - STATE: NY
+    CONG_DISTRICT: 24
+    agi_stub: 0
+  - STATE: NY
+    CONG_DISTRICT: 25
+    agi_stub: 0
+  - STATE: NY
+    CONG_DISTRICT: 26
+    agi_stub: 0
+  - STATE: NY
+    CONG_DISTRICT: 27
+    agi_stub: 0
+  - STATE: NC
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: NC
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: NC
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: NC
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: NC
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: NC
+    CONG_DISTRICT: 5
+    agi_stub: 0
+  - STATE: NC
+    CONG_DISTRICT: 6
+    agi_stub: 0
+  - STATE: NC
+    CONG_DISTRICT: 7
+    agi_stub: 0
+  - STATE: NC
+    CONG_DISTRICT: 8
+    agi_stub: 0
+  - STATE: NC
+    CONG_DISTRICT: 9
+    agi_stub: 0
+  - STATE: NC
+    CONG_DISTRICT: 10
+    agi_stub: 0
+  - STATE: NC
+    CONG_DISTRICT: 11
+    agi_stub: 0
+  - STATE: NC
+    CONG_DISTRICT: 12
+    agi_stub: 0
+  - STATE: NC
+    CONG_DISTRICT: 13
+    agi_stub: 0
+  - STATE: ND
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: OH
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: OH
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: OH
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: OH
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: OH
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: OH
+    CONG_DISTRICT: 5
+    agi_stub: 0
+  - STATE: OH
+    CONG_DISTRICT: 6
+    agi_stub: 0
+  - STATE: OH
+    CONG_DISTRICT: 7
+    agi_stub: 0
+  - STATE: OH
+    CONG_DISTRICT: 8
+    agi_stub: 0
+  - STATE: OH
+    CONG_DISTRICT: 9
+    agi_stub: 0
+  - STATE: OH
+    CONG_DISTRICT: 10
+    agi_stub: 0
+  - STATE: OH
+    CONG_DISTRICT: 11
+    agi_stub: 0
+  - STATE: OH
+    CONG_DISTRICT: 12
+    agi_stub: 0
+  - STATE: OH
+    CONG_DISTRICT: 13
+    agi_stub: 0
+  - STATE: OH
+    CONG_DISTRICT: 14
+    agi_stub: 0
+  - STATE: OH
+    CONG_DISTRICT: 15
+    agi_stub: 0
+  - STATE: OH
+    CONG_DISTRICT: 16
+    agi_stub: 0
+  - STATE: OK
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: OK
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: OK
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: OK
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: OK
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: OK
+    CONG_DISTRICT: 5
+    agi_stub: 0
+  - STATE: OR
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: OR
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: OR
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: OR
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: OR
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: OR
+    CONG_DISTRICT: 5
+    agi_stub: 0
+  - STATE: PA
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: PA
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: PA
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: PA
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: PA
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: PA
+    CONG_DISTRICT: 5
+    agi_stub: 0
+  - STATE: PA
+    CONG_DISTRICT: 6
+    agi_stub: 0
+  - STATE: PA
+    CONG_DISTRICT: 7
+    agi_stub: 0
+  - STATE: PA
+    CONG_DISTRICT: 8
+    agi_stub: 0
+  - STATE: PA
+    CONG_DISTRICT: 9
+    agi_stub: 0
+  - STATE: PA
+    CONG_DISTRICT: 10
+    agi_stub: 0
+  - STATE: PA
+    CONG_DISTRICT: 11
+    agi_stub: 0
+  - STATE: PA
+    CONG_DISTRICT: 12
+    agi_stub: 0
+  - STATE: PA
+    CONG_DISTRICT: 13
+    agi_stub: 0
+  - STATE: PA
+    CONG_DISTRICT: 14
+    agi_stub: 0
+  - STATE: PA
+    CONG_DISTRICT: 15
+    agi_stub: 0
+  - STATE: PA
+    CONG_DISTRICT: 16
+    agi_stub: 0
+  - STATE: PA
+    CONG_DISTRICT: 17
+    agi_stub: 0
+  - STATE: PA
+    CONG_DISTRICT: 18
+    agi_stub: 0
+  - STATE: RI
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: RI
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: RI
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: SC
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: SC
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: SC
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: SC
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: SC
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: SC
+    CONG_DISTRICT: 5
+    agi_stub: 0
+  - STATE: SC
+    CONG_DISTRICT: 6
+    agi_stub: 0
+  - STATE: SC
+    CONG_DISTRICT: 7
+    agi_stub: 0
+  - STATE: SD
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: TN
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: TN
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: TN
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: TN
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: TN
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: TN
+    CONG_DISTRICT: 5
+    agi_stub: 0
+  - STATE: TN
+    CONG_DISTRICT: 6
+    agi_stub: 0
+  - STATE: TN
+    CONG_DISTRICT: 7
+    agi_stub: 0
+  - STATE: TN
+    CONG_DISTRICT: 8
+    agi_stub: 0
+  - STATE: TN
+    CONG_DISTRICT: 9
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 5
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 6
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 7
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 8
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 9
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 10
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 11
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 12
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 13
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 14
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 15
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 16
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 17
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 18
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 19
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 20
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 21
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 22
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 23
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 24
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 25
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 26
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 27
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 28
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 29
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 30
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 31
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 32
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 33
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 34
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 35
+    agi_stub: 0
+  - STATE: TX
+    CONG_DISTRICT: 36
+    agi_stub: 0
+  - STATE: UT
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: UT
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: UT
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: UT
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: UT
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: VT
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: VA
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: VA
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: VA
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: VA
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: VA
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: VA
+    CONG_DISTRICT: 5
+    agi_stub: 0
+  - STATE: VA
+    CONG_DISTRICT: 6
+    agi_stub: 0
+  - STATE: VA
+    CONG_DISTRICT: 7
+    agi_stub: 0
+  - STATE: VA
+    CONG_DISTRICT: 8
+    agi_stub: 0
+  - STATE: VA
+    CONG_DISTRICT: 9
+    agi_stub: 0
+  - STATE: VA
+    CONG_DISTRICT: 10
+    agi_stub: 0
+  - STATE: VA
+    CONG_DISTRICT: 11
+    agi_stub: 0
+  - STATE: WA
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: WA
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: WA
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: WA
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: WA
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: WA
+    CONG_DISTRICT: 5
+    agi_stub: 0
+  - STATE: WA
+    CONG_DISTRICT: 6
+    agi_stub: 0
+  - STATE: WA
+    CONG_DISTRICT: 7
+    agi_stub: 0
+  - STATE: WA
+    CONG_DISTRICT: 8
+    agi_stub: 0
+  - STATE: WA
+    CONG_DISTRICT: 9
+    agi_stub: 0
+  - STATE: WA
+    CONG_DISTRICT: 10
+    agi_stub: 0
+  - STATE: WV
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: WV
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: WV
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: WV
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: WI
+    CONG_DISTRICT: 0
+    agi_stub: 0
+  - STATE: WI
+    CONG_DISTRICT: 1
+    agi_stub: 0
+  - STATE: WI
+    CONG_DISTRICT: 2
+    agi_stub: 0
+  - STATE: WI
+    CONG_DISTRICT: 3
+    agi_stub: 0
+  - STATE: WI
+    CONG_DISTRICT: 4
+    agi_stub: 0
+  - STATE: WI
+    CONG_DISTRICT: 5
+    agi_stub: 0
+  - STATE: WI
+    CONG_DISTRICT: 6
+    agi_stub: 0
+  - STATE: WI
+    CONG_DISTRICT: 7
+    agi_stub: 0
+  - STATE: WI
+    CONG_DISTRICT: 8
+    agi_stub: 0
+  - STATE: WY
+    CONG_DISTRICT: 0
+    agi_stub: 0
+record_sets:
+- record_set_id: irs_soi.ty{year}.congressional_district_2022.all_returns
+  record_set_spec_id: irs_soi.congressional_district_2022.all_returns.v1
+  source_record_id_prefix: irs_soi.ty{year}.congressional_district_2022.all_returns
+  sheet_name: incd2022
+  period_type: tax_year
+  period: '{year}'
+  geography_id: 0100000US
+  geography_level: country
+  geography_name: United States
+  geography_vintage: 2020_census
+  entity: tax_unit
+  entity_role: filing_unit
+  domain: all_individual_income_tax_returns
+  groupby_dimension: irs_soi.congressional_district
+  shared_filters:
+    filing_status: all
+  rows:
+  - value_id: us
+    label: United States all returns
+    ordinal: 0
+    row_number: 2
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: US
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 0
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: al_total
+    label: Alabama all congressional districts
+    ordinal: 1
+    row_number: 3
+    geography_id: 0400000US01
+    geography_level: state
+    geography_name: Alabama
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: AL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 1
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: al_01
+    label: Alabama Congressional District 1
+    ordinal: 2
+    row_number: 4
+    geography_id: 5001700US0101
+    geography_level: congressional_district
+    geography_name: Alabama Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: AL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 1
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: al_02
+    label: Alabama Congressional District 2
+    ordinal: 3
+    row_number: 5
+    geography_id: 5001700US0102
+    geography_level: congressional_district
+    geography_name: Alabama Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: AL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 1
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: al_03
+    label: Alabama Congressional District 3
+    ordinal: 4
+    row_number: 6
+    geography_id: 5001700US0103
+    geography_level: congressional_district
+    geography_name: Alabama Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: AL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 1
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: al_04
+    label: Alabama Congressional District 4
+    ordinal: 5
+    row_number: 7
+    geography_id: 5001700US0104
+    geography_level: congressional_district
+    geography_name: Alabama Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: AL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 1
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: al_05
+    label: Alabama Congressional District 5
+    ordinal: 6
+    row_number: 8
+    geography_id: 5001700US0105
+    geography_level: congressional_district
+    geography_name: Alabama Congressional District 5
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: AL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 1
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 5
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: al_06
+    label: Alabama Congressional District 6
+    ordinal: 7
+    row_number: 9
+    geography_id: 5001700US0106
+    geography_level: congressional_district
+    geography_name: Alabama Congressional District 6
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: AL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 1
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 6
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: al_07
+    label: Alabama Congressional District 7
+    ordinal: 8
+    row_number: 10
+    geography_id: 5001700US0107
+    geography_level: congressional_district
+    geography_name: Alabama Congressional District 7
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: AL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 1
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 7
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ak_total
+    label: Alaska all congressional districts
+    ordinal: 9
+    row_number: 11
+    geography_id: 0400000US02
+    geography_level: state
+    geography_name: Alaska
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: AK
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 2
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: az_total
+    label: Arizona all congressional districts
+    ordinal: 10
+    row_number: 12
+    geography_id: 0400000US04
+    geography_level: state
+    geography_name: Arizona
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: AZ
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 4
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: az_01
+    label: Arizona Congressional District 1
+    ordinal: 11
+    row_number: 13
+    geography_id: 5001700US0401
+    geography_level: congressional_district
+    geography_name: Arizona Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: AZ
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 4
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: az_02
+    label: Arizona Congressional District 2
+    ordinal: 12
+    row_number: 14
+    geography_id: 5001700US0402
+    geography_level: congressional_district
+    geography_name: Arizona Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: AZ
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 4
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: az_03
+    label: Arizona Congressional District 3
+    ordinal: 13
+    row_number: 15
+    geography_id: 5001700US0403
+    geography_level: congressional_district
+    geography_name: Arizona Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: AZ
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 4
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: az_04
+    label: Arizona Congressional District 4
+    ordinal: 14
+    row_number: 16
+    geography_id: 5001700US0404
+    geography_level: congressional_district
+    geography_name: Arizona Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: AZ
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 4
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: az_05
+    label: Arizona Congressional District 5
+    ordinal: 15
+    row_number: 17
+    geography_id: 5001700US0405
+    geography_level: congressional_district
+    geography_name: Arizona Congressional District 5
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: AZ
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 4
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 5
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: az_06
+    label: Arizona Congressional District 6
+    ordinal: 16
+    row_number: 18
+    geography_id: 5001700US0406
+    geography_level: congressional_district
+    geography_name: Arizona Congressional District 6
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: AZ
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 4
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 6
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: az_07
+    label: Arizona Congressional District 7
+    ordinal: 17
+    row_number: 19
+    geography_id: 5001700US0407
+    geography_level: congressional_district
+    geography_name: Arizona Congressional District 7
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: AZ
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 4
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 7
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: az_08
+    label: Arizona Congressional District 8
+    ordinal: 18
+    row_number: 20
+    geography_id: 5001700US0408
+    geography_level: congressional_district
+    geography_name: Arizona Congressional District 8
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: AZ
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 4
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 8
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: az_09
+    label: Arizona Congressional District 9
+    ordinal: 19
+    row_number: 21
+    geography_id: 5001700US0409
+    geography_level: congressional_district
+    geography_name: Arizona Congressional District 9
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: AZ
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 4
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 9
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ar_total
+    label: Arkansas all congressional districts
+    ordinal: 20
+    row_number: 22
+    geography_id: 0400000US05
+    geography_level: state
+    geography_name: Arkansas
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: AR
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 5
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ar_01
+    label: Arkansas Congressional District 1
+    ordinal: 21
+    row_number: 23
+    geography_id: 5001700US0501
+    geography_level: congressional_district
+    geography_name: Arkansas Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: AR
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 5
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ar_02
+    label: Arkansas Congressional District 2
+    ordinal: 22
+    row_number: 24
+    geography_id: 5001700US0502
+    geography_level: congressional_district
+    geography_name: Arkansas Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: AR
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 5
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ar_03
+    label: Arkansas Congressional District 3
+    ordinal: 23
+    row_number: 25
+    geography_id: 5001700US0503
+    geography_level: congressional_district
+    geography_name: Arkansas Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: AR
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 5
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ar_04
+    label: Arkansas Congressional District 4
+    ordinal: 24
+    row_number: 26
+    geography_id: 5001700US0504
+    geography_level: congressional_district
+    geography_name: Arkansas Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: AR
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 5
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_total
+    label: California all congressional districts
+    ordinal: 25
+    row_number: 27
+    geography_id: 0400000US06
+    geography_level: state
+    geography_name: California
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_01
+    label: California Congressional District 1
+    ordinal: 26
+    row_number: 28
+    geography_id: 5001700US0601
+    geography_level: congressional_district
+    geography_name: California Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_02
+    label: California Congressional District 2
+    ordinal: 27
+    row_number: 29
+    geography_id: 5001700US0602
+    geography_level: congressional_district
+    geography_name: California Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_03
+    label: California Congressional District 3
+    ordinal: 28
+    row_number: 30
+    geography_id: 5001700US0603
+    geography_level: congressional_district
+    geography_name: California Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_04
+    label: California Congressional District 4
+    ordinal: 29
+    row_number: 31
+    geography_id: 5001700US0604
+    geography_level: congressional_district
+    geography_name: California Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_05
+    label: California Congressional District 5
+    ordinal: 30
+    row_number: 32
+    geography_id: 5001700US0605
+    geography_level: congressional_district
+    geography_name: California Congressional District 5
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 5
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_06
+    label: California Congressional District 6
+    ordinal: 31
+    row_number: 33
+    geography_id: 5001700US0606
+    geography_level: congressional_district
+    geography_name: California Congressional District 6
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 6
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_07
+    label: California Congressional District 7
+    ordinal: 32
+    row_number: 34
+    geography_id: 5001700US0607
+    geography_level: congressional_district
+    geography_name: California Congressional District 7
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 7
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_08
+    label: California Congressional District 8
+    ordinal: 33
+    row_number: 35
+    geography_id: 5001700US0608
+    geography_level: congressional_district
+    geography_name: California Congressional District 8
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 8
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_09
+    label: California Congressional District 9
+    ordinal: 34
+    row_number: 36
+    geography_id: 5001700US0609
+    geography_level: congressional_district
+    geography_name: California Congressional District 9
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 9
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_10
+    label: California Congressional District 10
+    ordinal: 35
+    row_number: 37
+    geography_id: 5001700US0610
+    geography_level: congressional_district
+    geography_name: California Congressional District 10
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 10
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_11
+    label: California Congressional District 11
+    ordinal: 36
+    row_number: 38
+    geography_id: 5001700US0611
+    geography_level: congressional_district
+    geography_name: California Congressional District 11
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 11
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_12
+    label: California Congressional District 12
+    ordinal: 37
+    row_number: 39
+    geography_id: 5001700US0612
+    geography_level: congressional_district
+    geography_name: California Congressional District 12
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 12
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_13
+    label: California Congressional District 13
+    ordinal: 38
+    row_number: 40
+    geography_id: 5001700US0613
+    geography_level: congressional_district
+    geography_name: California Congressional District 13
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 13
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_14
+    label: California Congressional District 14
+    ordinal: 39
+    row_number: 41
+    geography_id: 5001700US0614
+    geography_level: congressional_district
+    geography_name: California Congressional District 14
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 14
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_15
+    label: California Congressional District 15
+    ordinal: 40
+    row_number: 42
+    geography_id: 5001700US0615
+    geography_level: congressional_district
+    geography_name: California Congressional District 15
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 15
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_16
+    label: California Congressional District 16
+    ordinal: 41
+    row_number: 43
+    geography_id: 5001700US0616
+    geography_level: congressional_district
+    geography_name: California Congressional District 16
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 16
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_17
+    label: California Congressional District 17
+    ordinal: 42
+    row_number: 44
+    geography_id: 5001700US0617
+    geography_level: congressional_district
+    geography_name: California Congressional District 17
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 17
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_18
+    label: California Congressional District 18
+    ordinal: 43
+    row_number: 45
+    geography_id: 5001700US0618
+    geography_level: congressional_district
+    geography_name: California Congressional District 18
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 18
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_19
+    label: California Congressional District 19
+    ordinal: 44
+    row_number: 46
+    geography_id: 5001700US0619
+    geography_level: congressional_district
+    geography_name: California Congressional District 19
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 19
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_20
+    label: California Congressional District 20
+    ordinal: 45
+    row_number: 47
+    geography_id: 5001700US0620
+    geography_level: congressional_district
+    geography_name: California Congressional District 20
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 20
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_21
+    label: California Congressional District 21
+    ordinal: 46
+    row_number: 48
+    geography_id: 5001700US0621
+    geography_level: congressional_district
+    geography_name: California Congressional District 21
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 21
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_22
+    label: California Congressional District 22
+    ordinal: 47
+    row_number: 49
+    geography_id: 5001700US0622
+    geography_level: congressional_district
+    geography_name: California Congressional District 22
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 22
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_23
+    label: California Congressional District 23
+    ordinal: 48
+    row_number: 50
+    geography_id: 5001700US0623
+    geography_level: congressional_district
+    geography_name: California Congressional District 23
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 23
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_24
+    label: California Congressional District 24
+    ordinal: 49
+    row_number: 51
+    geography_id: 5001700US0624
+    geography_level: congressional_district
+    geography_name: California Congressional District 24
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 24
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_25
+    label: California Congressional District 25
+    ordinal: 50
+    row_number: 52
+    geography_id: 5001700US0625
+    geography_level: congressional_district
+    geography_name: California Congressional District 25
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 25
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_26
+    label: California Congressional District 26
+    ordinal: 51
+    row_number: 53
+    geography_id: 5001700US0626
+    geography_level: congressional_district
+    geography_name: California Congressional District 26
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 26
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_27
+    label: California Congressional District 27
+    ordinal: 52
+    row_number: 54
+    geography_id: 5001700US0627
+    geography_level: congressional_district
+    geography_name: California Congressional District 27
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 27
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_28
+    label: California Congressional District 28
+    ordinal: 53
+    row_number: 55
+    geography_id: 5001700US0628
+    geography_level: congressional_district
+    geography_name: California Congressional District 28
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 28
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_29
+    label: California Congressional District 29
+    ordinal: 54
+    row_number: 56
+    geography_id: 5001700US0629
+    geography_level: congressional_district
+    geography_name: California Congressional District 29
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 29
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_30
+    label: California Congressional District 30
+    ordinal: 55
+    row_number: 57
+    geography_id: 5001700US0630
+    geography_level: congressional_district
+    geography_name: California Congressional District 30
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 30
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_31
+    label: California Congressional District 31
+    ordinal: 56
+    row_number: 58
+    geography_id: 5001700US0631
+    geography_level: congressional_district
+    geography_name: California Congressional District 31
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 31
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_32
+    label: California Congressional District 32
+    ordinal: 57
+    row_number: 59
+    geography_id: 5001700US0632
+    geography_level: congressional_district
+    geography_name: California Congressional District 32
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 32
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_33
+    label: California Congressional District 33
+    ordinal: 58
+    row_number: 60
+    geography_id: 5001700US0633
+    geography_level: congressional_district
+    geography_name: California Congressional District 33
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 33
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_34
+    label: California Congressional District 34
+    ordinal: 59
+    row_number: 61
+    geography_id: 5001700US0634
+    geography_level: congressional_district
+    geography_name: California Congressional District 34
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 34
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_35
+    label: California Congressional District 35
+    ordinal: 60
+    row_number: 62
+    geography_id: 5001700US0635
+    geography_level: congressional_district
+    geography_name: California Congressional District 35
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 35
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_36
+    label: California Congressional District 36
+    ordinal: 61
+    row_number: 63
+    geography_id: 5001700US0636
+    geography_level: congressional_district
+    geography_name: California Congressional District 36
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 36
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_37
+    label: California Congressional District 37
+    ordinal: 62
+    row_number: 64
+    geography_id: 5001700US0637
+    geography_level: congressional_district
+    geography_name: California Congressional District 37
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 37
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_38
+    label: California Congressional District 38
+    ordinal: 63
+    row_number: 65
+    geography_id: 5001700US0638
+    geography_level: congressional_district
+    geography_name: California Congressional District 38
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 38
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_39
+    label: California Congressional District 39
+    ordinal: 64
+    row_number: 66
+    geography_id: 5001700US0639
+    geography_level: congressional_district
+    geography_name: California Congressional District 39
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 39
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_40
+    label: California Congressional District 40
+    ordinal: 65
+    row_number: 67
+    geography_id: 5001700US0640
+    geography_level: congressional_district
+    geography_name: California Congressional District 40
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 40
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_41
+    label: California Congressional District 41
+    ordinal: 66
+    row_number: 68
+    geography_id: 5001700US0641
+    geography_level: congressional_district
+    geography_name: California Congressional District 41
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 41
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_42
+    label: California Congressional District 42
+    ordinal: 67
+    row_number: 69
+    geography_id: 5001700US0642
+    geography_level: congressional_district
+    geography_name: California Congressional District 42
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 42
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_43
+    label: California Congressional District 43
+    ordinal: 68
+    row_number: 70
+    geography_id: 5001700US0643
+    geography_level: congressional_district
+    geography_name: California Congressional District 43
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 43
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_44
+    label: California Congressional District 44
+    ordinal: 69
+    row_number: 71
+    geography_id: 5001700US0644
+    geography_level: congressional_district
+    geography_name: California Congressional District 44
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 44
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_45
+    label: California Congressional District 45
+    ordinal: 70
+    row_number: 72
+    geography_id: 5001700US0645
+    geography_level: congressional_district
+    geography_name: California Congressional District 45
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 45
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_46
+    label: California Congressional District 46
+    ordinal: 71
+    row_number: 73
+    geography_id: 5001700US0646
+    geography_level: congressional_district
+    geography_name: California Congressional District 46
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 46
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_47
+    label: California Congressional District 47
+    ordinal: 72
+    row_number: 74
+    geography_id: 5001700US0647
+    geography_level: congressional_district
+    geography_name: California Congressional District 47
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 47
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_48
+    label: California Congressional District 48
+    ordinal: 73
+    row_number: 75
+    geography_id: 5001700US0648
+    geography_level: congressional_district
+    geography_name: California Congressional District 48
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 48
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_49
+    label: California Congressional District 49
+    ordinal: 74
+    row_number: 76
+    geography_id: 5001700US0649
+    geography_level: congressional_district
+    geography_name: California Congressional District 49
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 49
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_50
+    label: California Congressional District 50
+    ordinal: 75
+    row_number: 77
+    geography_id: 5001700US0650
+    geography_level: congressional_district
+    geography_name: California Congressional District 50
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 50
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_51
+    label: California Congressional District 51
+    ordinal: 76
+    row_number: 78
+    geography_id: 5001700US0651
+    geography_level: congressional_district
+    geography_name: California Congressional District 51
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 51
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_52
+    label: California Congressional District 52
+    ordinal: 77
+    row_number: 79
+    geography_id: 5001700US0652
+    geography_level: congressional_district
+    geography_name: California Congressional District 52
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 52
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ca_53
+    label: California Congressional District 53
+    ordinal: 78
+    row_number: 80
+    geography_id: 5001700US0653
+    geography_level: congressional_district
+    geography_name: California Congressional District 53
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 6
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 53
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: co_total
+    label: Colorado all congressional districts
+    ordinal: 79
+    row_number: 81
+    geography_id: 0400000US08
+    geography_level: state
+    geography_name: Colorado
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: CO
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 8
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: co_01
+    label: Colorado Congressional District 1
+    ordinal: 80
+    row_number: 82
+    geography_id: 5001700US0801
+    geography_level: congressional_district
+    geography_name: Colorado Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CO
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 8
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: co_02
+    label: Colorado Congressional District 2
+    ordinal: 81
+    row_number: 83
+    geography_id: 5001700US0802
+    geography_level: congressional_district
+    geography_name: Colorado Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CO
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 8
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: co_03
+    label: Colorado Congressional District 3
+    ordinal: 82
+    row_number: 84
+    geography_id: 5001700US0803
+    geography_level: congressional_district
+    geography_name: Colorado Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CO
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 8
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: co_04
+    label: Colorado Congressional District 4
+    ordinal: 83
+    row_number: 85
+    geography_id: 5001700US0804
+    geography_level: congressional_district
+    geography_name: Colorado Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CO
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 8
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: co_05
+    label: Colorado Congressional District 5
+    ordinal: 84
+    row_number: 86
+    geography_id: 5001700US0805
+    geography_level: congressional_district
+    geography_name: Colorado Congressional District 5
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CO
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 8
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 5
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: co_06
+    label: Colorado Congressional District 6
+    ordinal: 85
+    row_number: 87
+    geography_id: 5001700US0806
+    geography_level: congressional_district
+    geography_name: Colorado Congressional District 6
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CO
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 8
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 6
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: co_07
+    label: Colorado Congressional District 7
+    ordinal: 86
+    row_number: 88
+    geography_id: 5001700US0807
+    geography_level: congressional_district
+    geography_name: Colorado Congressional District 7
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CO
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 8
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 7
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ct_total
+    label: Connecticut all congressional districts
+    ordinal: 87
+    row_number: 89
+    geography_id: 0400000US09
+    geography_level: state
+    geography_name: Connecticut
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: CT
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 9
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ct_01
+    label: Connecticut Congressional District 1
+    ordinal: 88
+    row_number: 90
+    geography_id: 5001700US0901
+    geography_level: congressional_district
+    geography_name: Connecticut Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CT
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 9
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ct_02
+    label: Connecticut Congressional District 2
+    ordinal: 89
+    row_number: 91
+    geography_id: 5001700US0902
+    geography_level: congressional_district
+    geography_name: Connecticut Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CT
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 9
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ct_03
+    label: Connecticut Congressional District 3
+    ordinal: 90
+    row_number: 92
+    geography_id: 5001700US0903
+    geography_level: congressional_district
+    geography_name: Connecticut Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CT
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 9
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ct_04
+    label: Connecticut Congressional District 4
+    ordinal: 91
+    row_number: 93
+    geography_id: 5001700US0904
+    geography_level: congressional_district
+    geography_name: Connecticut Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CT
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 9
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ct_05
+    label: Connecticut Congressional District 5
+    ordinal: 92
+    row_number: 94
+    geography_id: 5001700US0905
+    geography_level: congressional_district
+    geography_name: Connecticut Congressional District 5
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: CT
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 9
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 5
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: de_total
+    label: Delaware all congressional districts
+    ordinal: 93
+    row_number: 95
+    geography_id: 0400000US10
+    geography_level: state
+    geography_name: Delaware
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: DE
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 10
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: dc_total
+    label: District of Columbia all congressional districts
+    ordinal: 94
+    row_number: 96
+    geography_id: 0400000US11
+    geography_level: state
+    geography_name: District of Columbia
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: DC
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 11
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: fl_total
+    label: Florida all congressional districts
+    ordinal: 95
+    row_number: 97
+    geography_id: 0400000US12
+    geography_level: state
+    geography_name: Florida
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: FL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 12
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: fl_01
+    label: Florida Congressional District 1
+    ordinal: 96
+    row_number: 98
+    geography_id: 5001700US1201
+    geography_level: congressional_district
+    geography_name: Florida Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: FL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 12
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: fl_02
+    label: Florida Congressional District 2
+    ordinal: 97
+    row_number: 99
+    geography_id: 5001700US1202
+    geography_level: congressional_district
+    geography_name: Florida Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: FL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 12
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: fl_03
+    label: Florida Congressional District 3
+    ordinal: 98
+    row_number: 100
+    geography_id: 5001700US1203
+    geography_level: congressional_district
+    geography_name: Florida Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: FL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 12
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: fl_04
+    label: Florida Congressional District 4
+    ordinal: 99
+    row_number: 101
+    geography_id: 5001700US1204
+    geography_level: congressional_district
+    geography_name: Florida Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: FL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 12
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: fl_05
+    label: Florida Congressional District 5
+    ordinal: 100
+    row_number: 102
+    geography_id: 5001700US1205
+    geography_level: congressional_district
+    geography_name: Florida Congressional District 5
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: FL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 12
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 5
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: fl_06
+    label: Florida Congressional District 6
+    ordinal: 101
+    row_number: 103
+    geography_id: 5001700US1206
+    geography_level: congressional_district
+    geography_name: Florida Congressional District 6
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: FL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 12
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 6
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: fl_07
+    label: Florida Congressional District 7
+    ordinal: 102
+    row_number: 104
+    geography_id: 5001700US1207
+    geography_level: congressional_district
+    geography_name: Florida Congressional District 7
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: FL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 12
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 7
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: fl_08
+    label: Florida Congressional District 8
+    ordinal: 103
+    row_number: 105
+    geography_id: 5001700US1208
+    geography_level: congressional_district
+    geography_name: Florida Congressional District 8
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: FL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 12
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 8
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: fl_09
+    label: Florida Congressional District 9
+    ordinal: 104
+    row_number: 106
+    geography_id: 5001700US1209
+    geography_level: congressional_district
+    geography_name: Florida Congressional District 9
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: FL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 12
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 9
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: fl_10
+    label: Florida Congressional District 10
+    ordinal: 105
+    row_number: 107
+    geography_id: 5001700US1210
+    geography_level: congressional_district
+    geography_name: Florida Congressional District 10
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: FL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 12
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 10
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: fl_11
+    label: Florida Congressional District 11
+    ordinal: 106
+    row_number: 108
+    geography_id: 5001700US1211
+    geography_level: congressional_district
+    geography_name: Florida Congressional District 11
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: FL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 12
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 11
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: fl_12
+    label: Florida Congressional District 12
+    ordinal: 107
+    row_number: 109
+    geography_id: 5001700US1212
+    geography_level: congressional_district
+    geography_name: Florida Congressional District 12
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: FL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 12
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 12
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: fl_13
+    label: Florida Congressional District 13
+    ordinal: 108
+    row_number: 110
+    geography_id: 5001700US1213
+    geography_level: congressional_district
+    geography_name: Florida Congressional District 13
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: FL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 12
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 13
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: fl_14
+    label: Florida Congressional District 14
+    ordinal: 109
+    row_number: 111
+    geography_id: 5001700US1214
+    geography_level: congressional_district
+    geography_name: Florida Congressional District 14
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: FL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 12
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 14
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: fl_15
+    label: Florida Congressional District 15
+    ordinal: 110
+    row_number: 112
+    geography_id: 5001700US1215
+    geography_level: congressional_district
+    geography_name: Florida Congressional District 15
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: FL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 12
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 15
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: fl_16
+    label: Florida Congressional District 16
+    ordinal: 111
+    row_number: 113
+    geography_id: 5001700US1216
+    geography_level: congressional_district
+    geography_name: Florida Congressional District 16
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: FL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 12
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 16
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: fl_17
+    label: Florida Congressional District 17
+    ordinal: 112
+    row_number: 114
+    geography_id: 5001700US1217
+    geography_level: congressional_district
+    geography_name: Florida Congressional District 17
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: FL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 12
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 17
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: fl_18
+    label: Florida Congressional District 18
+    ordinal: 113
+    row_number: 115
+    geography_id: 5001700US1218
+    geography_level: congressional_district
+    geography_name: Florida Congressional District 18
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: FL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 12
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 18
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: fl_19
+    label: Florida Congressional District 19
+    ordinal: 114
+    row_number: 116
+    geography_id: 5001700US1219
+    geography_level: congressional_district
+    geography_name: Florida Congressional District 19
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: FL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 12
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 19
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: fl_20
+    label: Florida Congressional District 20
+    ordinal: 115
+    row_number: 117
+    geography_id: 5001700US1220
+    geography_level: congressional_district
+    geography_name: Florida Congressional District 20
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: FL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 12
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 20
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: fl_21
+    label: Florida Congressional District 21
+    ordinal: 116
+    row_number: 118
+    geography_id: 5001700US1221
+    geography_level: congressional_district
+    geography_name: Florida Congressional District 21
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: FL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 12
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 21
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: fl_22
+    label: Florida Congressional District 22
+    ordinal: 117
+    row_number: 119
+    geography_id: 5001700US1222
+    geography_level: congressional_district
+    geography_name: Florida Congressional District 22
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: FL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 12
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 22
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: fl_23
+    label: Florida Congressional District 23
+    ordinal: 118
+    row_number: 120
+    geography_id: 5001700US1223
+    geography_level: congressional_district
+    geography_name: Florida Congressional District 23
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: FL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 12
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 23
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: fl_24
+    label: Florida Congressional District 24
+    ordinal: 119
+    row_number: 121
+    geography_id: 5001700US1224
+    geography_level: congressional_district
+    geography_name: Florida Congressional District 24
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: FL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 12
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 24
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: fl_25
+    label: Florida Congressional District 25
+    ordinal: 120
+    row_number: 122
+    geography_id: 5001700US1225
+    geography_level: congressional_district
+    geography_name: Florida Congressional District 25
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: FL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 12
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 25
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: fl_26
+    label: Florida Congressional District 26
+    ordinal: 121
+    row_number: 123
+    geography_id: 5001700US1226
+    geography_level: congressional_district
+    geography_name: Florida Congressional District 26
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: FL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 12
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 26
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: fl_27
+    label: Florida Congressional District 27
+    ordinal: 122
+    row_number: 124
+    geography_id: 5001700US1227
+    geography_level: congressional_district
+    geography_name: Florida Congressional District 27
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: FL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 12
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 27
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ga_total
+    label: Georgia all congressional districts
+    ordinal: 123
+    row_number: 125
+    geography_id: 0400000US13
+    geography_level: state
+    geography_name: Georgia
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: GA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 13
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ga_01
+    label: Georgia Congressional District 1
+    ordinal: 124
+    row_number: 126
+    geography_id: 5001700US1301
+    geography_level: congressional_district
+    geography_name: Georgia Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: GA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 13
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ga_02
+    label: Georgia Congressional District 2
+    ordinal: 125
+    row_number: 127
+    geography_id: 5001700US1302
+    geography_level: congressional_district
+    geography_name: Georgia Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: GA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 13
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ga_03
+    label: Georgia Congressional District 3
+    ordinal: 126
+    row_number: 128
+    geography_id: 5001700US1303
+    geography_level: congressional_district
+    geography_name: Georgia Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: GA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 13
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ga_04
+    label: Georgia Congressional District 4
+    ordinal: 127
+    row_number: 129
+    geography_id: 5001700US1304
+    geography_level: congressional_district
+    geography_name: Georgia Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: GA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 13
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ga_05
+    label: Georgia Congressional District 5
+    ordinal: 128
+    row_number: 130
+    geography_id: 5001700US1305
+    geography_level: congressional_district
+    geography_name: Georgia Congressional District 5
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: GA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 13
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 5
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ga_06
+    label: Georgia Congressional District 6
+    ordinal: 129
+    row_number: 131
+    geography_id: 5001700US1306
+    geography_level: congressional_district
+    geography_name: Georgia Congressional District 6
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: GA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 13
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 6
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ga_07
+    label: Georgia Congressional District 7
+    ordinal: 130
+    row_number: 132
+    geography_id: 5001700US1307
+    geography_level: congressional_district
+    geography_name: Georgia Congressional District 7
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: GA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 13
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 7
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ga_08
+    label: Georgia Congressional District 8
+    ordinal: 131
+    row_number: 133
+    geography_id: 5001700US1308
+    geography_level: congressional_district
+    geography_name: Georgia Congressional District 8
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: GA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 13
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 8
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ga_09
+    label: Georgia Congressional District 9
+    ordinal: 132
+    row_number: 134
+    geography_id: 5001700US1309
+    geography_level: congressional_district
+    geography_name: Georgia Congressional District 9
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: GA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 13
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 9
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ga_10
+    label: Georgia Congressional District 10
+    ordinal: 133
+    row_number: 135
+    geography_id: 5001700US1310
+    geography_level: congressional_district
+    geography_name: Georgia Congressional District 10
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: GA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 13
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 10
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ga_11
+    label: Georgia Congressional District 11
+    ordinal: 134
+    row_number: 136
+    geography_id: 5001700US1311
+    geography_level: congressional_district
+    geography_name: Georgia Congressional District 11
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: GA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 13
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 11
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ga_12
+    label: Georgia Congressional District 12
+    ordinal: 135
+    row_number: 137
+    geography_id: 5001700US1312
+    geography_level: congressional_district
+    geography_name: Georgia Congressional District 12
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: GA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 13
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 12
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ga_13
+    label: Georgia Congressional District 13
+    ordinal: 136
+    row_number: 138
+    geography_id: 5001700US1313
+    geography_level: congressional_district
+    geography_name: Georgia Congressional District 13
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: GA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 13
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 13
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ga_14
+    label: Georgia Congressional District 14
+    ordinal: 137
+    row_number: 139
+    geography_id: 5001700US1314
+    geography_level: congressional_district
+    geography_name: Georgia Congressional District 14
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: GA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 13
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 14
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: hi_total
+    label: Hawaii all congressional districts
+    ordinal: 138
+    row_number: 140
+    geography_id: 0400000US15
+    geography_level: state
+    geography_name: Hawaii
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: HI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 15
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: hi_01
+    label: Hawaii Congressional District 1
+    ordinal: 139
+    row_number: 141
+    geography_id: 5001700US1501
+    geography_level: congressional_district
+    geography_name: Hawaii Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: HI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 15
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: hi_02
+    label: Hawaii Congressional District 2
+    ordinal: 140
+    row_number: 142
+    geography_id: 5001700US1502
+    geography_level: congressional_district
+    geography_name: Hawaii Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: HI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 15
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: id_total
+    label: Idaho all congressional districts
+    ordinal: 141
+    row_number: 143
+    geography_id: 0400000US16
+    geography_level: state
+    geography_name: Idaho
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: ID
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 16
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: id_01
+    label: Idaho Congressional District 1
+    ordinal: 142
+    row_number: 144
+    geography_id: 5001700US1601
+    geography_level: congressional_district
+    geography_name: Idaho Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: ID
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 16
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: id_02
+    label: Idaho Congressional District 2
+    ordinal: 143
+    row_number: 145
+    geography_id: 5001700US1602
+    geography_level: congressional_district
+    geography_name: Idaho Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: ID
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 16
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: il_total
+    label: Illinois all congressional districts
+    ordinal: 144
+    row_number: 146
+    geography_id: 0400000US17
+    geography_level: state
+    geography_name: Illinois
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: IL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 17
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: il_01
+    label: Illinois Congressional District 1
+    ordinal: 145
+    row_number: 147
+    geography_id: 5001700US1701
+    geography_level: congressional_district
+    geography_name: Illinois Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 17
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: il_02
+    label: Illinois Congressional District 2
+    ordinal: 146
+    row_number: 148
+    geography_id: 5001700US1702
+    geography_level: congressional_district
+    geography_name: Illinois Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 17
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: il_03
+    label: Illinois Congressional District 3
+    ordinal: 147
+    row_number: 149
+    geography_id: 5001700US1703
+    geography_level: congressional_district
+    geography_name: Illinois Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 17
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: il_04
+    label: Illinois Congressional District 4
+    ordinal: 148
+    row_number: 150
+    geography_id: 5001700US1704
+    geography_level: congressional_district
+    geography_name: Illinois Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 17
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: il_05
+    label: Illinois Congressional District 5
+    ordinal: 149
+    row_number: 151
+    geography_id: 5001700US1705
+    geography_level: congressional_district
+    geography_name: Illinois Congressional District 5
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 17
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 5
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: il_06
+    label: Illinois Congressional District 6
+    ordinal: 150
+    row_number: 152
+    geography_id: 5001700US1706
+    geography_level: congressional_district
+    geography_name: Illinois Congressional District 6
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 17
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 6
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: il_07
+    label: Illinois Congressional District 7
+    ordinal: 151
+    row_number: 153
+    geography_id: 5001700US1707
+    geography_level: congressional_district
+    geography_name: Illinois Congressional District 7
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 17
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 7
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: il_08
+    label: Illinois Congressional District 8
+    ordinal: 152
+    row_number: 154
+    geography_id: 5001700US1708
+    geography_level: congressional_district
+    geography_name: Illinois Congressional District 8
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 17
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 8
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: il_09
+    label: Illinois Congressional District 9
+    ordinal: 153
+    row_number: 155
+    geography_id: 5001700US1709
+    geography_level: congressional_district
+    geography_name: Illinois Congressional District 9
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 17
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 9
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: il_10
+    label: Illinois Congressional District 10
+    ordinal: 154
+    row_number: 156
+    geography_id: 5001700US1710
+    geography_level: congressional_district
+    geography_name: Illinois Congressional District 10
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 17
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 10
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: il_11
+    label: Illinois Congressional District 11
+    ordinal: 155
+    row_number: 157
+    geography_id: 5001700US1711
+    geography_level: congressional_district
+    geography_name: Illinois Congressional District 11
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 17
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 11
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: il_12
+    label: Illinois Congressional District 12
+    ordinal: 156
+    row_number: 158
+    geography_id: 5001700US1712
+    geography_level: congressional_district
+    geography_name: Illinois Congressional District 12
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 17
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 12
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: il_13
+    label: Illinois Congressional District 13
+    ordinal: 157
+    row_number: 159
+    geography_id: 5001700US1713
+    geography_level: congressional_district
+    geography_name: Illinois Congressional District 13
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 17
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 13
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: il_14
+    label: Illinois Congressional District 14
+    ordinal: 158
+    row_number: 160
+    geography_id: 5001700US1714
+    geography_level: congressional_district
+    geography_name: Illinois Congressional District 14
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 17
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 14
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: il_15
+    label: Illinois Congressional District 15
+    ordinal: 159
+    row_number: 161
+    geography_id: 5001700US1715
+    geography_level: congressional_district
+    geography_name: Illinois Congressional District 15
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 17
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 15
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: il_16
+    label: Illinois Congressional District 16
+    ordinal: 160
+    row_number: 162
+    geography_id: 5001700US1716
+    geography_level: congressional_district
+    geography_name: Illinois Congressional District 16
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 17
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 16
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: il_17
+    label: Illinois Congressional District 17
+    ordinal: 161
+    row_number: 163
+    geography_id: 5001700US1717
+    geography_level: congressional_district
+    geography_name: Illinois Congressional District 17
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 17
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 17
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: il_18
+    label: Illinois Congressional District 18
+    ordinal: 162
+    row_number: 164
+    geography_id: 5001700US1718
+    geography_level: congressional_district
+    geography_name: Illinois Congressional District 18
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IL
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 17
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 18
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: in_total
+    label: Indiana all congressional districts
+    ordinal: 163
+    row_number: 165
+    geography_id: 0400000US18
+    geography_level: state
+    geography_name: Indiana
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: IN
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 18
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: in_01
+    label: Indiana Congressional District 1
+    ordinal: 164
+    row_number: 166
+    geography_id: 5001700US1801
+    geography_level: congressional_district
+    geography_name: Indiana Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IN
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 18
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: in_02
+    label: Indiana Congressional District 2
+    ordinal: 165
+    row_number: 167
+    geography_id: 5001700US1802
+    geography_level: congressional_district
+    geography_name: Indiana Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IN
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 18
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: in_03
+    label: Indiana Congressional District 3
+    ordinal: 166
+    row_number: 168
+    geography_id: 5001700US1803
+    geography_level: congressional_district
+    geography_name: Indiana Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IN
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 18
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: in_04
+    label: Indiana Congressional District 4
+    ordinal: 167
+    row_number: 169
+    geography_id: 5001700US1804
+    geography_level: congressional_district
+    geography_name: Indiana Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IN
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 18
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: in_05
+    label: Indiana Congressional District 5
+    ordinal: 168
+    row_number: 170
+    geography_id: 5001700US1805
+    geography_level: congressional_district
+    geography_name: Indiana Congressional District 5
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IN
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 18
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 5
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: in_06
+    label: Indiana Congressional District 6
+    ordinal: 169
+    row_number: 171
+    geography_id: 5001700US1806
+    geography_level: congressional_district
+    geography_name: Indiana Congressional District 6
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IN
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 18
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 6
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: in_07
+    label: Indiana Congressional District 7
+    ordinal: 170
+    row_number: 172
+    geography_id: 5001700US1807
+    geography_level: congressional_district
+    geography_name: Indiana Congressional District 7
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IN
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 18
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 7
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: in_08
+    label: Indiana Congressional District 8
+    ordinal: 171
+    row_number: 173
+    geography_id: 5001700US1808
+    geography_level: congressional_district
+    geography_name: Indiana Congressional District 8
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IN
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 18
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 8
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: in_09
+    label: Indiana Congressional District 9
+    ordinal: 172
+    row_number: 174
+    geography_id: 5001700US1809
+    geography_level: congressional_district
+    geography_name: Indiana Congressional District 9
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IN
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 18
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 9
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ia_total
+    label: Iowa all congressional districts
+    ordinal: 173
+    row_number: 175
+    geography_id: 0400000US19
+    geography_level: state
+    geography_name: Iowa
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: IA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 19
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ia_01
+    label: Iowa Congressional District 1
+    ordinal: 174
+    row_number: 176
+    geography_id: 5001700US1901
+    geography_level: congressional_district
+    geography_name: Iowa Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 19
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ia_02
+    label: Iowa Congressional District 2
+    ordinal: 175
+    row_number: 177
+    geography_id: 5001700US1902
+    geography_level: congressional_district
+    geography_name: Iowa Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 19
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ia_03
+    label: Iowa Congressional District 3
+    ordinal: 176
+    row_number: 178
+    geography_id: 5001700US1903
+    geography_level: congressional_district
+    geography_name: Iowa Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 19
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ia_04
+    label: Iowa Congressional District 4
+    ordinal: 177
+    row_number: 179
+    geography_id: 5001700US1904
+    geography_level: congressional_district
+    geography_name: Iowa Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: IA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 19
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ks_total
+    label: Kansas all congressional districts
+    ordinal: 178
+    row_number: 180
+    geography_id: 0400000US20
+    geography_level: state
+    geography_name: Kansas
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: KS
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 20
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ks_01
+    label: Kansas Congressional District 1
+    ordinal: 179
+    row_number: 181
+    geography_id: 5001700US2001
+    geography_level: congressional_district
+    geography_name: Kansas Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: KS
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 20
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ks_02
+    label: Kansas Congressional District 2
+    ordinal: 180
+    row_number: 182
+    geography_id: 5001700US2002
+    geography_level: congressional_district
+    geography_name: Kansas Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: KS
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 20
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ks_03
+    label: Kansas Congressional District 3
+    ordinal: 181
+    row_number: 183
+    geography_id: 5001700US2003
+    geography_level: congressional_district
+    geography_name: Kansas Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: KS
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 20
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ks_04
+    label: Kansas Congressional District 4
+    ordinal: 182
+    row_number: 184
+    geography_id: 5001700US2004
+    geography_level: congressional_district
+    geography_name: Kansas Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: KS
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 20
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ky_total
+    label: Kentucky all congressional districts
+    ordinal: 183
+    row_number: 185
+    geography_id: 0400000US21
+    geography_level: state
+    geography_name: Kentucky
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: KY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 21
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ky_01
+    label: Kentucky Congressional District 1
+    ordinal: 184
+    row_number: 186
+    geography_id: 5001700US2101
+    geography_level: congressional_district
+    geography_name: Kentucky Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: KY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 21
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ky_02
+    label: Kentucky Congressional District 2
+    ordinal: 185
+    row_number: 187
+    geography_id: 5001700US2102
+    geography_level: congressional_district
+    geography_name: Kentucky Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: KY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 21
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ky_03
+    label: Kentucky Congressional District 3
+    ordinal: 186
+    row_number: 188
+    geography_id: 5001700US2103
+    geography_level: congressional_district
+    geography_name: Kentucky Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: KY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 21
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ky_04
+    label: Kentucky Congressional District 4
+    ordinal: 187
+    row_number: 189
+    geography_id: 5001700US2104
+    geography_level: congressional_district
+    geography_name: Kentucky Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: KY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 21
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ky_05
+    label: Kentucky Congressional District 5
+    ordinal: 188
+    row_number: 190
+    geography_id: 5001700US2105
+    geography_level: congressional_district
+    geography_name: Kentucky Congressional District 5
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: KY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 21
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 5
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ky_06
+    label: Kentucky Congressional District 6
+    ordinal: 189
+    row_number: 191
+    geography_id: 5001700US2106
+    geography_level: congressional_district
+    geography_name: Kentucky Congressional District 6
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: KY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 21
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 6
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: la_total
+    label: Louisiana all congressional districts
+    ordinal: 190
+    row_number: 192
+    geography_id: 0400000US22
+    geography_level: state
+    geography_name: Louisiana
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: LA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 22
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: la_01
+    label: Louisiana Congressional District 1
+    ordinal: 191
+    row_number: 193
+    geography_id: 5001700US2201
+    geography_level: congressional_district
+    geography_name: Louisiana Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: LA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 22
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: la_02
+    label: Louisiana Congressional District 2
+    ordinal: 192
+    row_number: 194
+    geography_id: 5001700US2202
+    geography_level: congressional_district
+    geography_name: Louisiana Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: LA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 22
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: la_03
+    label: Louisiana Congressional District 3
+    ordinal: 193
+    row_number: 195
+    geography_id: 5001700US2203
+    geography_level: congressional_district
+    geography_name: Louisiana Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: LA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 22
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: la_04
+    label: Louisiana Congressional District 4
+    ordinal: 194
+    row_number: 196
+    geography_id: 5001700US2204
+    geography_level: congressional_district
+    geography_name: Louisiana Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: LA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 22
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: la_05
+    label: Louisiana Congressional District 5
+    ordinal: 195
+    row_number: 197
+    geography_id: 5001700US2205
+    geography_level: congressional_district
+    geography_name: Louisiana Congressional District 5
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: LA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 22
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 5
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: la_06
+    label: Louisiana Congressional District 6
+    ordinal: 196
+    row_number: 198
+    geography_id: 5001700US2206
+    geography_level: congressional_district
+    geography_name: Louisiana Congressional District 6
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: LA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 22
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 6
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: me_total
+    label: Maine all congressional districts
+    ordinal: 197
+    row_number: 199
+    geography_id: 0400000US23
+    geography_level: state
+    geography_name: Maine
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: ME
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 23
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: me_01
+    label: Maine Congressional District 1
+    ordinal: 198
+    row_number: 200
+    geography_id: 5001700US2301
+    geography_level: congressional_district
+    geography_name: Maine Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: ME
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 23
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: me_02
+    label: Maine Congressional District 2
+    ordinal: 199
+    row_number: 201
+    geography_id: 5001700US2302
+    geography_level: congressional_district
+    geography_name: Maine Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: ME
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 23
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: md_total
+    label: Maryland all congressional districts
+    ordinal: 200
+    row_number: 202
+    geography_id: 0400000US24
+    geography_level: state
+    geography_name: Maryland
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: MD
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 24
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: md_01
+    label: Maryland Congressional District 1
+    ordinal: 201
+    row_number: 203
+    geography_id: 5001700US2401
+    geography_level: congressional_district
+    geography_name: Maryland Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MD
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 24
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: md_02
+    label: Maryland Congressional District 2
+    ordinal: 202
+    row_number: 204
+    geography_id: 5001700US2402
+    geography_level: congressional_district
+    geography_name: Maryland Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MD
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 24
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: md_03
+    label: Maryland Congressional District 3
+    ordinal: 203
+    row_number: 205
+    geography_id: 5001700US2403
+    geography_level: congressional_district
+    geography_name: Maryland Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MD
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 24
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: md_04
+    label: Maryland Congressional District 4
+    ordinal: 204
+    row_number: 206
+    geography_id: 5001700US2404
+    geography_level: congressional_district
+    geography_name: Maryland Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MD
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 24
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: md_05
+    label: Maryland Congressional District 5
+    ordinal: 205
+    row_number: 207
+    geography_id: 5001700US2405
+    geography_level: congressional_district
+    geography_name: Maryland Congressional District 5
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MD
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 24
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 5
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: md_06
+    label: Maryland Congressional District 6
+    ordinal: 206
+    row_number: 208
+    geography_id: 5001700US2406
+    geography_level: congressional_district
+    geography_name: Maryland Congressional District 6
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MD
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 24
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 6
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: md_07
+    label: Maryland Congressional District 7
+    ordinal: 207
+    row_number: 209
+    geography_id: 5001700US2407
+    geography_level: congressional_district
+    geography_name: Maryland Congressional District 7
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MD
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 24
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 7
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: md_08
+    label: Maryland Congressional District 8
+    ordinal: 208
+    row_number: 210
+    geography_id: 5001700US2408
+    geography_level: congressional_district
+    geography_name: Maryland Congressional District 8
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MD
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 24
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 8
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ma_total
+    label: Massachusetts all congressional districts
+    ordinal: 209
+    row_number: 211
+    geography_id: 0400000US25
+    geography_level: state
+    geography_name: Massachusetts
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: MA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 25
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ma_01
+    label: Massachusetts Congressional District 1
+    ordinal: 210
+    row_number: 212
+    geography_id: 5001700US2501
+    geography_level: congressional_district
+    geography_name: Massachusetts Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 25
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ma_02
+    label: Massachusetts Congressional District 2
+    ordinal: 211
+    row_number: 213
+    geography_id: 5001700US2502
+    geography_level: congressional_district
+    geography_name: Massachusetts Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 25
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ma_03
+    label: Massachusetts Congressional District 3
+    ordinal: 212
+    row_number: 214
+    geography_id: 5001700US2503
+    geography_level: congressional_district
+    geography_name: Massachusetts Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 25
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ma_04
+    label: Massachusetts Congressional District 4
+    ordinal: 213
+    row_number: 215
+    geography_id: 5001700US2504
+    geography_level: congressional_district
+    geography_name: Massachusetts Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 25
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ma_05
+    label: Massachusetts Congressional District 5
+    ordinal: 214
+    row_number: 216
+    geography_id: 5001700US2505
+    geography_level: congressional_district
+    geography_name: Massachusetts Congressional District 5
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 25
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 5
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ma_06
+    label: Massachusetts Congressional District 6
+    ordinal: 215
+    row_number: 217
+    geography_id: 5001700US2506
+    geography_level: congressional_district
+    geography_name: Massachusetts Congressional District 6
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 25
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 6
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ma_07
+    label: Massachusetts Congressional District 7
+    ordinal: 216
+    row_number: 218
+    geography_id: 5001700US2507
+    geography_level: congressional_district
+    geography_name: Massachusetts Congressional District 7
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 25
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 7
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ma_08
+    label: Massachusetts Congressional District 8
+    ordinal: 217
+    row_number: 219
+    geography_id: 5001700US2508
+    geography_level: congressional_district
+    geography_name: Massachusetts Congressional District 8
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 25
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 8
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ma_09
+    label: Massachusetts Congressional District 9
+    ordinal: 218
+    row_number: 220
+    geography_id: 5001700US2509
+    geography_level: congressional_district
+    geography_name: Massachusetts Congressional District 9
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 25
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 9
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mi_total
+    label: Michigan all congressional districts
+    ordinal: 219
+    row_number: 221
+    geography_id: 0400000US26
+    geography_level: state
+    geography_name: Michigan
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: MI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 26
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mi_01
+    label: Michigan Congressional District 1
+    ordinal: 220
+    row_number: 222
+    geography_id: 5001700US2601
+    geography_level: congressional_district
+    geography_name: Michigan Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 26
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mi_02
+    label: Michigan Congressional District 2
+    ordinal: 221
+    row_number: 223
+    geography_id: 5001700US2602
+    geography_level: congressional_district
+    geography_name: Michigan Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 26
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mi_03
+    label: Michigan Congressional District 3
+    ordinal: 222
+    row_number: 224
+    geography_id: 5001700US2603
+    geography_level: congressional_district
+    geography_name: Michigan Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 26
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mi_04
+    label: Michigan Congressional District 4
+    ordinal: 223
+    row_number: 225
+    geography_id: 5001700US2604
+    geography_level: congressional_district
+    geography_name: Michigan Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 26
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mi_05
+    label: Michigan Congressional District 5
+    ordinal: 224
+    row_number: 226
+    geography_id: 5001700US2605
+    geography_level: congressional_district
+    geography_name: Michigan Congressional District 5
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 26
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 5
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mi_06
+    label: Michigan Congressional District 6
+    ordinal: 225
+    row_number: 227
+    geography_id: 5001700US2606
+    geography_level: congressional_district
+    geography_name: Michigan Congressional District 6
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 26
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 6
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mi_07
+    label: Michigan Congressional District 7
+    ordinal: 226
+    row_number: 228
+    geography_id: 5001700US2607
+    geography_level: congressional_district
+    geography_name: Michigan Congressional District 7
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 26
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 7
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mi_08
+    label: Michigan Congressional District 8
+    ordinal: 227
+    row_number: 229
+    geography_id: 5001700US2608
+    geography_level: congressional_district
+    geography_name: Michigan Congressional District 8
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 26
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 8
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mi_09
+    label: Michigan Congressional District 9
+    ordinal: 228
+    row_number: 230
+    geography_id: 5001700US2609
+    geography_level: congressional_district
+    geography_name: Michigan Congressional District 9
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 26
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 9
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mi_10
+    label: Michigan Congressional District 10
+    ordinal: 229
+    row_number: 231
+    geography_id: 5001700US2610
+    geography_level: congressional_district
+    geography_name: Michigan Congressional District 10
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 26
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 10
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mi_11
+    label: Michigan Congressional District 11
+    ordinal: 230
+    row_number: 232
+    geography_id: 5001700US2611
+    geography_level: congressional_district
+    geography_name: Michigan Congressional District 11
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 26
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 11
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mi_12
+    label: Michigan Congressional District 12
+    ordinal: 231
+    row_number: 233
+    geography_id: 5001700US2612
+    geography_level: congressional_district
+    geography_name: Michigan Congressional District 12
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 26
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 12
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mi_13
+    label: Michigan Congressional District 13
+    ordinal: 232
+    row_number: 234
+    geography_id: 5001700US2613
+    geography_level: congressional_district
+    geography_name: Michigan Congressional District 13
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 26
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 13
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mi_14
+    label: Michigan Congressional District 14
+    ordinal: 233
+    row_number: 235
+    geography_id: 5001700US2614
+    geography_level: congressional_district
+    geography_name: Michigan Congressional District 14
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 26
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 14
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mn_total
+    label: Minnesota all congressional districts
+    ordinal: 234
+    row_number: 236
+    geography_id: 0400000US27
+    geography_level: state
+    geography_name: Minnesota
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: MN
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 27
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mn_01
+    label: Minnesota Congressional District 1
+    ordinal: 235
+    row_number: 237
+    geography_id: 5001700US2701
+    geography_level: congressional_district
+    geography_name: Minnesota Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MN
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 27
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mn_02
+    label: Minnesota Congressional District 2
+    ordinal: 236
+    row_number: 238
+    geography_id: 5001700US2702
+    geography_level: congressional_district
+    geography_name: Minnesota Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MN
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 27
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mn_03
+    label: Minnesota Congressional District 3
+    ordinal: 237
+    row_number: 239
+    geography_id: 5001700US2703
+    geography_level: congressional_district
+    geography_name: Minnesota Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MN
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 27
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mn_04
+    label: Minnesota Congressional District 4
+    ordinal: 238
+    row_number: 240
+    geography_id: 5001700US2704
+    geography_level: congressional_district
+    geography_name: Minnesota Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MN
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 27
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mn_05
+    label: Minnesota Congressional District 5
+    ordinal: 239
+    row_number: 241
+    geography_id: 5001700US2705
+    geography_level: congressional_district
+    geography_name: Minnesota Congressional District 5
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MN
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 27
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 5
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mn_06
+    label: Minnesota Congressional District 6
+    ordinal: 240
+    row_number: 242
+    geography_id: 5001700US2706
+    geography_level: congressional_district
+    geography_name: Minnesota Congressional District 6
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MN
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 27
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 6
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mn_07
+    label: Minnesota Congressional District 7
+    ordinal: 241
+    row_number: 243
+    geography_id: 5001700US2707
+    geography_level: congressional_district
+    geography_name: Minnesota Congressional District 7
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MN
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 27
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 7
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mn_08
+    label: Minnesota Congressional District 8
+    ordinal: 242
+    row_number: 244
+    geography_id: 5001700US2708
+    geography_level: congressional_district
+    geography_name: Minnesota Congressional District 8
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MN
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 27
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 8
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ms_total
+    label: Mississippi all congressional districts
+    ordinal: 243
+    row_number: 245
+    geography_id: 0400000US28
+    geography_level: state
+    geography_name: Mississippi
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: MS
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 28
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ms_01
+    label: Mississippi Congressional District 1
+    ordinal: 244
+    row_number: 246
+    geography_id: 5001700US2801
+    geography_level: congressional_district
+    geography_name: Mississippi Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MS
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 28
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ms_02
+    label: Mississippi Congressional District 2
+    ordinal: 245
+    row_number: 247
+    geography_id: 5001700US2802
+    geography_level: congressional_district
+    geography_name: Mississippi Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MS
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 28
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ms_03
+    label: Mississippi Congressional District 3
+    ordinal: 246
+    row_number: 248
+    geography_id: 5001700US2803
+    geography_level: congressional_district
+    geography_name: Mississippi Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MS
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 28
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ms_04
+    label: Mississippi Congressional District 4
+    ordinal: 247
+    row_number: 249
+    geography_id: 5001700US2804
+    geography_level: congressional_district
+    geography_name: Mississippi Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MS
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 28
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mo_total
+    label: Missouri all congressional districts
+    ordinal: 248
+    row_number: 250
+    geography_id: 0400000US29
+    geography_level: state
+    geography_name: Missouri
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: MO
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 29
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mo_01
+    label: Missouri Congressional District 1
+    ordinal: 249
+    row_number: 251
+    geography_id: 5001700US2901
+    geography_level: congressional_district
+    geography_name: Missouri Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MO
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 29
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mo_02
+    label: Missouri Congressional District 2
+    ordinal: 250
+    row_number: 252
+    geography_id: 5001700US2902
+    geography_level: congressional_district
+    geography_name: Missouri Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MO
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 29
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mo_03
+    label: Missouri Congressional District 3
+    ordinal: 251
+    row_number: 253
+    geography_id: 5001700US2903
+    geography_level: congressional_district
+    geography_name: Missouri Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MO
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 29
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mo_04
+    label: Missouri Congressional District 4
+    ordinal: 252
+    row_number: 254
+    geography_id: 5001700US2904
+    geography_level: congressional_district
+    geography_name: Missouri Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MO
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 29
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mo_05
+    label: Missouri Congressional District 5
+    ordinal: 253
+    row_number: 255
+    geography_id: 5001700US2905
+    geography_level: congressional_district
+    geography_name: Missouri Congressional District 5
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MO
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 29
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 5
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mo_06
+    label: Missouri Congressional District 6
+    ordinal: 254
+    row_number: 256
+    geography_id: 5001700US2906
+    geography_level: congressional_district
+    geography_name: Missouri Congressional District 6
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MO
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 29
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 6
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mo_07
+    label: Missouri Congressional District 7
+    ordinal: 255
+    row_number: 257
+    geography_id: 5001700US2907
+    geography_level: congressional_district
+    geography_name: Missouri Congressional District 7
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MO
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 29
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 7
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mo_08
+    label: Missouri Congressional District 8
+    ordinal: 256
+    row_number: 258
+    geography_id: 5001700US2908
+    geography_level: congressional_district
+    geography_name: Missouri Congressional District 8
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: MO
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 29
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 8
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: mt_total
+    label: Montana all congressional districts
+    ordinal: 257
+    row_number: 259
+    geography_id: 0400000US30
+    geography_level: state
+    geography_name: Montana
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: MT
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 30
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ne_total
+    label: Nebraska all congressional districts
+    ordinal: 258
+    row_number: 260
+    geography_id: 0400000US31
+    geography_level: state
+    geography_name: Nebraska
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: NE
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 31
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ne_01
+    label: Nebraska Congressional District 1
+    ordinal: 259
+    row_number: 261
+    geography_id: 5001700US3101
+    geography_level: congressional_district
+    geography_name: Nebraska Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NE
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 31
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ne_02
+    label: Nebraska Congressional District 2
+    ordinal: 260
+    row_number: 262
+    geography_id: 5001700US3102
+    geography_level: congressional_district
+    geography_name: Nebraska Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NE
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 31
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ne_03
+    label: Nebraska Congressional District 3
+    ordinal: 261
+    row_number: 263
+    geography_id: 5001700US3103
+    geography_level: congressional_district
+    geography_name: Nebraska Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NE
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 31
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nv_total
+    label: Nevada all congressional districts
+    ordinal: 262
+    row_number: 264
+    geography_id: 0400000US32
+    geography_level: state
+    geography_name: Nevada
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: NV
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 32
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nv_01
+    label: Nevada Congressional District 1
+    ordinal: 263
+    row_number: 265
+    geography_id: 5001700US3201
+    geography_level: congressional_district
+    geography_name: Nevada Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NV
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 32
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nv_02
+    label: Nevada Congressional District 2
+    ordinal: 264
+    row_number: 266
+    geography_id: 5001700US3202
+    geography_level: congressional_district
+    geography_name: Nevada Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NV
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 32
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nv_03
+    label: Nevada Congressional District 3
+    ordinal: 265
+    row_number: 267
+    geography_id: 5001700US3203
+    geography_level: congressional_district
+    geography_name: Nevada Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NV
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 32
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nv_04
+    label: Nevada Congressional District 4
+    ordinal: 266
+    row_number: 268
+    geography_id: 5001700US3204
+    geography_level: congressional_district
+    geography_name: Nevada Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NV
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 32
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nh_total
+    label: New Hampshire all congressional districts
+    ordinal: 267
+    row_number: 269
+    geography_id: 0400000US33
+    geography_level: state
+    geography_name: New Hampshire
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: NH
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 33
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nh_01
+    label: New Hampshire Congressional District 1
+    ordinal: 268
+    row_number: 270
+    geography_id: 5001700US3301
+    geography_level: congressional_district
+    geography_name: New Hampshire Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NH
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 33
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nh_02
+    label: New Hampshire Congressional District 2
+    ordinal: 269
+    row_number: 271
+    geography_id: 5001700US3302
+    geography_level: congressional_district
+    geography_name: New Hampshire Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NH
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 33
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nj_total
+    label: New Jersey all congressional districts
+    ordinal: 270
+    row_number: 272
+    geography_id: 0400000US34
+    geography_level: state
+    geography_name: New Jersey
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: NJ
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 34
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nj_01
+    label: New Jersey Congressional District 1
+    ordinal: 271
+    row_number: 273
+    geography_id: 5001700US3401
+    geography_level: congressional_district
+    geography_name: New Jersey Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NJ
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 34
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nj_02
+    label: New Jersey Congressional District 2
+    ordinal: 272
+    row_number: 274
+    geography_id: 5001700US3402
+    geography_level: congressional_district
+    geography_name: New Jersey Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NJ
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 34
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nj_03
+    label: New Jersey Congressional District 3
+    ordinal: 273
+    row_number: 275
+    geography_id: 5001700US3403
+    geography_level: congressional_district
+    geography_name: New Jersey Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NJ
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 34
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nj_04
+    label: New Jersey Congressional District 4
+    ordinal: 274
+    row_number: 276
+    geography_id: 5001700US3404
+    geography_level: congressional_district
+    geography_name: New Jersey Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NJ
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 34
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nj_05
+    label: New Jersey Congressional District 5
+    ordinal: 275
+    row_number: 277
+    geography_id: 5001700US3405
+    geography_level: congressional_district
+    geography_name: New Jersey Congressional District 5
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NJ
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 34
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 5
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nj_06
+    label: New Jersey Congressional District 6
+    ordinal: 276
+    row_number: 278
+    geography_id: 5001700US3406
+    geography_level: congressional_district
+    geography_name: New Jersey Congressional District 6
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NJ
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 34
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 6
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nj_07
+    label: New Jersey Congressional District 7
+    ordinal: 277
+    row_number: 279
+    geography_id: 5001700US3407
+    geography_level: congressional_district
+    geography_name: New Jersey Congressional District 7
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NJ
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 34
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 7
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nj_08
+    label: New Jersey Congressional District 8
+    ordinal: 278
+    row_number: 280
+    geography_id: 5001700US3408
+    geography_level: congressional_district
+    geography_name: New Jersey Congressional District 8
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NJ
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 34
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 8
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nj_09
+    label: New Jersey Congressional District 9
+    ordinal: 279
+    row_number: 281
+    geography_id: 5001700US3409
+    geography_level: congressional_district
+    geography_name: New Jersey Congressional District 9
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NJ
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 34
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 9
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nj_10
+    label: New Jersey Congressional District 10
+    ordinal: 280
+    row_number: 282
+    geography_id: 5001700US3410
+    geography_level: congressional_district
+    geography_name: New Jersey Congressional District 10
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NJ
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 34
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 10
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nj_11
+    label: New Jersey Congressional District 11
+    ordinal: 281
+    row_number: 283
+    geography_id: 5001700US3411
+    geography_level: congressional_district
+    geography_name: New Jersey Congressional District 11
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NJ
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 34
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 11
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nj_12
+    label: New Jersey Congressional District 12
+    ordinal: 282
+    row_number: 284
+    geography_id: 5001700US3412
+    geography_level: congressional_district
+    geography_name: New Jersey Congressional District 12
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NJ
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 34
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 12
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nm_total
+    label: New Mexico all congressional districts
+    ordinal: 283
+    row_number: 285
+    geography_id: 0400000US35
+    geography_level: state
+    geography_name: New Mexico
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: NM
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 35
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nm_01
+    label: New Mexico Congressional District 1
+    ordinal: 284
+    row_number: 286
+    geography_id: 5001700US3501
+    geography_level: congressional_district
+    geography_name: New Mexico Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NM
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 35
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nm_02
+    label: New Mexico Congressional District 2
+    ordinal: 285
+    row_number: 287
+    geography_id: 5001700US3502
+    geography_level: congressional_district
+    geography_name: New Mexico Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NM
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 35
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nm_03
+    label: New Mexico Congressional District 3
+    ordinal: 286
+    row_number: 288
+    geography_id: 5001700US3503
+    geography_level: congressional_district
+    geography_name: New Mexico Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NM
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 35
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ny_total
+    label: New York all congressional districts
+    ordinal: 287
+    row_number: 289
+    geography_id: 0400000US36
+    geography_level: state
+    geography_name: New York
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: NY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 36
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ny_01
+    label: New York Congressional District 1
+    ordinal: 288
+    row_number: 290
+    geography_id: 5001700US3601
+    geography_level: congressional_district
+    geography_name: New York Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 36
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ny_02
+    label: New York Congressional District 2
+    ordinal: 289
+    row_number: 291
+    geography_id: 5001700US3602
+    geography_level: congressional_district
+    geography_name: New York Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 36
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ny_03
+    label: New York Congressional District 3
+    ordinal: 290
+    row_number: 292
+    geography_id: 5001700US3603
+    geography_level: congressional_district
+    geography_name: New York Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 36
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ny_04
+    label: New York Congressional District 4
+    ordinal: 291
+    row_number: 293
+    geography_id: 5001700US3604
+    geography_level: congressional_district
+    geography_name: New York Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 36
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ny_05
+    label: New York Congressional District 5
+    ordinal: 292
+    row_number: 294
+    geography_id: 5001700US3605
+    geography_level: congressional_district
+    geography_name: New York Congressional District 5
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 36
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 5
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ny_06
+    label: New York Congressional District 6
+    ordinal: 293
+    row_number: 295
+    geography_id: 5001700US3606
+    geography_level: congressional_district
+    geography_name: New York Congressional District 6
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 36
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 6
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ny_07
+    label: New York Congressional District 7
+    ordinal: 294
+    row_number: 296
+    geography_id: 5001700US3607
+    geography_level: congressional_district
+    geography_name: New York Congressional District 7
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 36
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 7
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ny_08
+    label: New York Congressional District 8
+    ordinal: 295
+    row_number: 297
+    geography_id: 5001700US3608
+    geography_level: congressional_district
+    geography_name: New York Congressional District 8
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 36
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 8
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ny_09
+    label: New York Congressional District 9
+    ordinal: 296
+    row_number: 298
+    geography_id: 5001700US3609
+    geography_level: congressional_district
+    geography_name: New York Congressional District 9
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 36
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 9
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ny_10
+    label: New York Congressional District 10
+    ordinal: 297
+    row_number: 299
+    geography_id: 5001700US3610
+    geography_level: congressional_district
+    geography_name: New York Congressional District 10
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 36
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 10
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ny_11
+    label: New York Congressional District 11
+    ordinal: 298
+    row_number: 300
+    geography_id: 5001700US3611
+    geography_level: congressional_district
+    geography_name: New York Congressional District 11
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 36
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 11
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ny_12
+    label: New York Congressional District 12
+    ordinal: 299
+    row_number: 301
+    geography_id: 5001700US3612
+    geography_level: congressional_district
+    geography_name: New York Congressional District 12
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 36
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 12
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ny_13
+    label: New York Congressional District 13
+    ordinal: 300
+    row_number: 302
+    geography_id: 5001700US3613
+    geography_level: congressional_district
+    geography_name: New York Congressional District 13
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 36
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 13
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ny_14
+    label: New York Congressional District 14
+    ordinal: 301
+    row_number: 303
+    geography_id: 5001700US3614
+    geography_level: congressional_district
+    geography_name: New York Congressional District 14
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 36
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 14
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ny_15
+    label: New York Congressional District 15
+    ordinal: 302
+    row_number: 304
+    geography_id: 5001700US3615
+    geography_level: congressional_district
+    geography_name: New York Congressional District 15
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 36
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 15
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ny_16
+    label: New York Congressional District 16
+    ordinal: 303
+    row_number: 305
+    geography_id: 5001700US3616
+    geography_level: congressional_district
+    geography_name: New York Congressional District 16
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 36
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 16
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ny_17
+    label: New York Congressional District 17
+    ordinal: 304
+    row_number: 306
+    geography_id: 5001700US3617
+    geography_level: congressional_district
+    geography_name: New York Congressional District 17
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 36
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 17
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ny_18
+    label: New York Congressional District 18
+    ordinal: 305
+    row_number: 307
+    geography_id: 5001700US3618
+    geography_level: congressional_district
+    geography_name: New York Congressional District 18
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 36
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 18
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ny_19
+    label: New York Congressional District 19
+    ordinal: 306
+    row_number: 308
+    geography_id: 5001700US3619
+    geography_level: congressional_district
+    geography_name: New York Congressional District 19
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 36
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 19
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ny_20
+    label: New York Congressional District 20
+    ordinal: 307
+    row_number: 309
+    geography_id: 5001700US3620
+    geography_level: congressional_district
+    geography_name: New York Congressional District 20
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 36
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 20
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ny_21
+    label: New York Congressional District 21
+    ordinal: 308
+    row_number: 310
+    geography_id: 5001700US3621
+    geography_level: congressional_district
+    geography_name: New York Congressional District 21
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 36
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 21
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ny_22
+    label: New York Congressional District 22
+    ordinal: 309
+    row_number: 311
+    geography_id: 5001700US3622
+    geography_level: congressional_district
+    geography_name: New York Congressional District 22
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 36
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 22
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ny_23
+    label: New York Congressional District 23
+    ordinal: 310
+    row_number: 312
+    geography_id: 5001700US3623
+    geography_level: congressional_district
+    geography_name: New York Congressional District 23
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 36
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 23
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ny_24
+    label: New York Congressional District 24
+    ordinal: 311
+    row_number: 313
+    geography_id: 5001700US3624
+    geography_level: congressional_district
+    geography_name: New York Congressional District 24
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 36
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 24
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ny_25
+    label: New York Congressional District 25
+    ordinal: 312
+    row_number: 314
+    geography_id: 5001700US3625
+    geography_level: congressional_district
+    geography_name: New York Congressional District 25
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 36
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 25
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ny_26
+    label: New York Congressional District 26
+    ordinal: 313
+    row_number: 315
+    geography_id: 5001700US3626
+    geography_level: congressional_district
+    geography_name: New York Congressional District 26
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 36
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 26
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ny_27
+    label: New York Congressional District 27
+    ordinal: 314
+    row_number: 316
+    geography_id: 5001700US3627
+    geography_level: congressional_district
+    geography_name: New York Congressional District 27
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 36
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 27
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nc_total
+    label: North Carolina all congressional districts
+    ordinal: 315
+    row_number: 317
+    geography_id: 0400000US37
+    geography_level: state
+    geography_name: North Carolina
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: NC
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 37
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nc_01
+    label: North Carolina Congressional District 1
+    ordinal: 316
+    row_number: 318
+    geography_id: 5001700US3701
+    geography_level: congressional_district
+    geography_name: North Carolina Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NC
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 37
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nc_02
+    label: North Carolina Congressional District 2
+    ordinal: 317
+    row_number: 319
+    geography_id: 5001700US3702
+    geography_level: congressional_district
+    geography_name: North Carolina Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NC
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 37
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nc_03
+    label: North Carolina Congressional District 3
+    ordinal: 318
+    row_number: 320
+    geography_id: 5001700US3703
+    geography_level: congressional_district
+    geography_name: North Carolina Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NC
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 37
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nc_04
+    label: North Carolina Congressional District 4
+    ordinal: 319
+    row_number: 321
+    geography_id: 5001700US3704
+    geography_level: congressional_district
+    geography_name: North Carolina Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NC
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 37
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nc_05
+    label: North Carolina Congressional District 5
+    ordinal: 320
+    row_number: 322
+    geography_id: 5001700US3705
+    geography_level: congressional_district
+    geography_name: North Carolina Congressional District 5
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NC
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 37
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 5
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nc_06
+    label: North Carolina Congressional District 6
+    ordinal: 321
+    row_number: 323
+    geography_id: 5001700US3706
+    geography_level: congressional_district
+    geography_name: North Carolina Congressional District 6
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NC
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 37
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 6
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nc_07
+    label: North Carolina Congressional District 7
+    ordinal: 322
+    row_number: 324
+    geography_id: 5001700US3707
+    geography_level: congressional_district
+    geography_name: North Carolina Congressional District 7
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NC
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 37
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 7
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nc_08
+    label: North Carolina Congressional District 8
+    ordinal: 323
+    row_number: 325
+    geography_id: 5001700US3708
+    geography_level: congressional_district
+    geography_name: North Carolina Congressional District 8
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NC
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 37
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 8
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nc_09
+    label: North Carolina Congressional District 9
+    ordinal: 324
+    row_number: 326
+    geography_id: 5001700US3709
+    geography_level: congressional_district
+    geography_name: North Carolina Congressional District 9
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NC
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 37
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 9
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nc_10
+    label: North Carolina Congressional District 10
+    ordinal: 325
+    row_number: 327
+    geography_id: 5001700US3710
+    geography_level: congressional_district
+    geography_name: North Carolina Congressional District 10
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NC
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 37
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 10
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nc_11
+    label: North Carolina Congressional District 11
+    ordinal: 326
+    row_number: 328
+    geography_id: 5001700US3711
+    geography_level: congressional_district
+    geography_name: North Carolina Congressional District 11
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NC
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 37
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 11
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nc_12
+    label: North Carolina Congressional District 12
+    ordinal: 327
+    row_number: 329
+    geography_id: 5001700US3712
+    geography_level: congressional_district
+    geography_name: North Carolina Congressional District 12
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NC
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 37
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 12
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nc_13
+    label: North Carolina Congressional District 13
+    ordinal: 328
+    row_number: 330
+    geography_id: 5001700US3713
+    geography_level: congressional_district
+    geography_name: North Carolina Congressional District 13
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: NC
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 37
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 13
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: nd_total
+    label: North Dakota all congressional districts
+    ordinal: 329
+    row_number: 331
+    geography_id: 0400000US38
+    geography_level: state
+    geography_name: North Dakota
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: ND
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 38
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: oh_total
+    label: Ohio all congressional districts
+    ordinal: 330
+    row_number: 332
+    geography_id: 0400000US39
+    geography_level: state
+    geography_name: Ohio
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: OH
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 39
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: oh_01
+    label: Ohio Congressional District 1
+    ordinal: 331
+    row_number: 333
+    geography_id: 5001700US3901
+    geography_level: congressional_district
+    geography_name: Ohio Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: OH
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 39
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: oh_02
+    label: Ohio Congressional District 2
+    ordinal: 332
+    row_number: 334
+    geography_id: 5001700US3902
+    geography_level: congressional_district
+    geography_name: Ohio Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: OH
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 39
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: oh_03
+    label: Ohio Congressional District 3
+    ordinal: 333
+    row_number: 335
+    geography_id: 5001700US3903
+    geography_level: congressional_district
+    geography_name: Ohio Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: OH
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 39
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: oh_04
+    label: Ohio Congressional District 4
+    ordinal: 334
+    row_number: 336
+    geography_id: 5001700US3904
+    geography_level: congressional_district
+    geography_name: Ohio Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: OH
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 39
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: oh_05
+    label: Ohio Congressional District 5
+    ordinal: 335
+    row_number: 337
+    geography_id: 5001700US3905
+    geography_level: congressional_district
+    geography_name: Ohio Congressional District 5
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: OH
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 39
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 5
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: oh_06
+    label: Ohio Congressional District 6
+    ordinal: 336
+    row_number: 338
+    geography_id: 5001700US3906
+    geography_level: congressional_district
+    geography_name: Ohio Congressional District 6
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: OH
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 39
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 6
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: oh_07
+    label: Ohio Congressional District 7
+    ordinal: 337
+    row_number: 339
+    geography_id: 5001700US3907
+    geography_level: congressional_district
+    geography_name: Ohio Congressional District 7
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: OH
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 39
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 7
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: oh_08
+    label: Ohio Congressional District 8
+    ordinal: 338
+    row_number: 340
+    geography_id: 5001700US3908
+    geography_level: congressional_district
+    geography_name: Ohio Congressional District 8
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: OH
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 39
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 8
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: oh_09
+    label: Ohio Congressional District 9
+    ordinal: 339
+    row_number: 341
+    geography_id: 5001700US3909
+    geography_level: congressional_district
+    geography_name: Ohio Congressional District 9
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: OH
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 39
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 9
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: oh_10
+    label: Ohio Congressional District 10
+    ordinal: 340
+    row_number: 342
+    geography_id: 5001700US3910
+    geography_level: congressional_district
+    geography_name: Ohio Congressional District 10
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: OH
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 39
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 10
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: oh_11
+    label: Ohio Congressional District 11
+    ordinal: 341
+    row_number: 343
+    geography_id: 5001700US3911
+    geography_level: congressional_district
+    geography_name: Ohio Congressional District 11
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: OH
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 39
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 11
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: oh_12
+    label: Ohio Congressional District 12
+    ordinal: 342
+    row_number: 344
+    geography_id: 5001700US3912
+    geography_level: congressional_district
+    geography_name: Ohio Congressional District 12
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: OH
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 39
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 12
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: oh_13
+    label: Ohio Congressional District 13
+    ordinal: 343
+    row_number: 345
+    geography_id: 5001700US3913
+    geography_level: congressional_district
+    geography_name: Ohio Congressional District 13
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: OH
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 39
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 13
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: oh_14
+    label: Ohio Congressional District 14
+    ordinal: 344
+    row_number: 346
+    geography_id: 5001700US3914
+    geography_level: congressional_district
+    geography_name: Ohio Congressional District 14
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: OH
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 39
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 14
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: oh_15
+    label: Ohio Congressional District 15
+    ordinal: 345
+    row_number: 347
+    geography_id: 5001700US3915
+    geography_level: congressional_district
+    geography_name: Ohio Congressional District 15
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: OH
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 39
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 15
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: oh_16
+    label: Ohio Congressional District 16
+    ordinal: 346
+    row_number: 348
+    geography_id: 5001700US3916
+    geography_level: congressional_district
+    geography_name: Ohio Congressional District 16
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: OH
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 39
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 16
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ok_total
+    label: Oklahoma all congressional districts
+    ordinal: 347
+    row_number: 349
+    geography_id: 0400000US40
+    geography_level: state
+    geography_name: Oklahoma
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: OK
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 40
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ok_01
+    label: Oklahoma Congressional District 1
+    ordinal: 348
+    row_number: 350
+    geography_id: 5001700US4001
+    geography_level: congressional_district
+    geography_name: Oklahoma Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: OK
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 40
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ok_02
+    label: Oklahoma Congressional District 2
+    ordinal: 349
+    row_number: 351
+    geography_id: 5001700US4002
+    geography_level: congressional_district
+    geography_name: Oklahoma Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: OK
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 40
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ok_03
+    label: Oklahoma Congressional District 3
+    ordinal: 350
+    row_number: 352
+    geography_id: 5001700US4003
+    geography_level: congressional_district
+    geography_name: Oklahoma Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: OK
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 40
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ok_04
+    label: Oklahoma Congressional District 4
+    ordinal: 351
+    row_number: 353
+    geography_id: 5001700US4004
+    geography_level: congressional_district
+    geography_name: Oklahoma Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: OK
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 40
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ok_05
+    label: Oklahoma Congressional District 5
+    ordinal: 352
+    row_number: 354
+    geography_id: 5001700US4005
+    geography_level: congressional_district
+    geography_name: Oklahoma Congressional District 5
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: OK
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 40
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 5
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: or_total
+    label: Oregon all congressional districts
+    ordinal: 353
+    row_number: 355
+    geography_id: 0400000US41
+    geography_level: state
+    geography_name: Oregon
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: OR
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 41
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: or_01
+    label: Oregon Congressional District 1
+    ordinal: 354
+    row_number: 356
+    geography_id: 5001700US4101
+    geography_level: congressional_district
+    geography_name: Oregon Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: OR
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 41
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: or_02
+    label: Oregon Congressional District 2
+    ordinal: 355
+    row_number: 357
+    geography_id: 5001700US4102
+    geography_level: congressional_district
+    geography_name: Oregon Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: OR
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 41
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: or_03
+    label: Oregon Congressional District 3
+    ordinal: 356
+    row_number: 358
+    geography_id: 5001700US4103
+    geography_level: congressional_district
+    geography_name: Oregon Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: OR
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 41
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: or_04
+    label: Oregon Congressional District 4
+    ordinal: 357
+    row_number: 359
+    geography_id: 5001700US4104
+    geography_level: congressional_district
+    geography_name: Oregon Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: OR
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 41
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: or_05
+    label: Oregon Congressional District 5
+    ordinal: 358
+    row_number: 360
+    geography_id: 5001700US4105
+    geography_level: congressional_district
+    geography_name: Oregon Congressional District 5
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: OR
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 41
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 5
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: pa_total
+    label: Pennsylvania all congressional districts
+    ordinal: 359
+    row_number: 361
+    geography_id: 0400000US42
+    geography_level: state
+    geography_name: Pennsylvania
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: PA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 42
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: pa_01
+    label: Pennsylvania Congressional District 1
+    ordinal: 360
+    row_number: 362
+    geography_id: 5001700US4201
+    geography_level: congressional_district
+    geography_name: Pennsylvania Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: PA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 42
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: pa_02
+    label: Pennsylvania Congressional District 2
+    ordinal: 361
+    row_number: 363
+    geography_id: 5001700US4202
+    geography_level: congressional_district
+    geography_name: Pennsylvania Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: PA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 42
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: pa_03
+    label: Pennsylvania Congressional District 3
+    ordinal: 362
+    row_number: 364
+    geography_id: 5001700US4203
+    geography_level: congressional_district
+    geography_name: Pennsylvania Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: PA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 42
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: pa_04
+    label: Pennsylvania Congressional District 4
+    ordinal: 363
+    row_number: 365
+    geography_id: 5001700US4204
+    geography_level: congressional_district
+    geography_name: Pennsylvania Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: PA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 42
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: pa_05
+    label: Pennsylvania Congressional District 5
+    ordinal: 364
+    row_number: 366
+    geography_id: 5001700US4205
+    geography_level: congressional_district
+    geography_name: Pennsylvania Congressional District 5
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: PA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 42
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 5
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: pa_06
+    label: Pennsylvania Congressional District 6
+    ordinal: 365
+    row_number: 367
+    geography_id: 5001700US4206
+    geography_level: congressional_district
+    geography_name: Pennsylvania Congressional District 6
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: PA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 42
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 6
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: pa_07
+    label: Pennsylvania Congressional District 7
+    ordinal: 366
+    row_number: 368
+    geography_id: 5001700US4207
+    geography_level: congressional_district
+    geography_name: Pennsylvania Congressional District 7
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: PA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 42
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 7
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: pa_08
+    label: Pennsylvania Congressional District 8
+    ordinal: 367
+    row_number: 369
+    geography_id: 5001700US4208
+    geography_level: congressional_district
+    geography_name: Pennsylvania Congressional District 8
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: PA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 42
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 8
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: pa_09
+    label: Pennsylvania Congressional District 9
+    ordinal: 368
+    row_number: 370
+    geography_id: 5001700US4209
+    geography_level: congressional_district
+    geography_name: Pennsylvania Congressional District 9
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: PA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 42
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 9
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: pa_10
+    label: Pennsylvania Congressional District 10
+    ordinal: 369
+    row_number: 371
+    geography_id: 5001700US4210
+    geography_level: congressional_district
+    geography_name: Pennsylvania Congressional District 10
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: PA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 42
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 10
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: pa_11
+    label: Pennsylvania Congressional District 11
+    ordinal: 370
+    row_number: 372
+    geography_id: 5001700US4211
+    geography_level: congressional_district
+    geography_name: Pennsylvania Congressional District 11
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: PA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 42
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 11
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: pa_12
+    label: Pennsylvania Congressional District 12
+    ordinal: 371
+    row_number: 373
+    geography_id: 5001700US4212
+    geography_level: congressional_district
+    geography_name: Pennsylvania Congressional District 12
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: PA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 42
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 12
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: pa_13
+    label: Pennsylvania Congressional District 13
+    ordinal: 372
+    row_number: 374
+    geography_id: 5001700US4213
+    geography_level: congressional_district
+    geography_name: Pennsylvania Congressional District 13
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: PA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 42
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 13
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: pa_14
+    label: Pennsylvania Congressional District 14
+    ordinal: 373
+    row_number: 375
+    geography_id: 5001700US4214
+    geography_level: congressional_district
+    geography_name: Pennsylvania Congressional District 14
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: PA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 42
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 14
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: pa_15
+    label: Pennsylvania Congressional District 15
+    ordinal: 374
+    row_number: 376
+    geography_id: 5001700US4215
+    geography_level: congressional_district
+    geography_name: Pennsylvania Congressional District 15
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: PA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 42
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 15
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: pa_16
+    label: Pennsylvania Congressional District 16
+    ordinal: 375
+    row_number: 377
+    geography_id: 5001700US4216
+    geography_level: congressional_district
+    geography_name: Pennsylvania Congressional District 16
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: PA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 42
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 16
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: pa_17
+    label: Pennsylvania Congressional District 17
+    ordinal: 376
+    row_number: 378
+    geography_id: 5001700US4217
+    geography_level: congressional_district
+    geography_name: Pennsylvania Congressional District 17
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: PA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 42
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 17
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: pa_18
+    label: Pennsylvania Congressional District 18
+    ordinal: 377
+    row_number: 379
+    geography_id: 5001700US4218
+    geography_level: congressional_district
+    geography_name: Pennsylvania Congressional District 18
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: PA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 42
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 18
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ri_total
+    label: Rhode Island all congressional districts
+    ordinal: 378
+    row_number: 380
+    geography_id: 0400000US44
+    geography_level: state
+    geography_name: Rhode Island
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: RI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 44
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ri_01
+    label: Rhode Island Congressional District 1
+    ordinal: 379
+    row_number: 381
+    geography_id: 5001700US4401
+    geography_level: congressional_district
+    geography_name: Rhode Island Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: RI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 44
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ri_02
+    label: Rhode Island Congressional District 2
+    ordinal: 380
+    row_number: 382
+    geography_id: 5001700US4402
+    geography_level: congressional_district
+    geography_name: Rhode Island Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: RI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 44
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: sc_total
+    label: South Carolina all congressional districts
+    ordinal: 381
+    row_number: 383
+    geography_id: 0400000US45
+    geography_level: state
+    geography_name: South Carolina
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: SC
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 45
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: sc_01
+    label: South Carolina Congressional District 1
+    ordinal: 382
+    row_number: 384
+    geography_id: 5001700US4501
+    geography_level: congressional_district
+    geography_name: South Carolina Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: SC
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 45
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: sc_02
+    label: South Carolina Congressional District 2
+    ordinal: 383
+    row_number: 385
+    geography_id: 5001700US4502
+    geography_level: congressional_district
+    geography_name: South Carolina Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: SC
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 45
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: sc_03
+    label: South Carolina Congressional District 3
+    ordinal: 384
+    row_number: 386
+    geography_id: 5001700US4503
+    geography_level: congressional_district
+    geography_name: South Carolina Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: SC
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 45
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: sc_04
+    label: South Carolina Congressional District 4
+    ordinal: 385
+    row_number: 387
+    geography_id: 5001700US4504
+    geography_level: congressional_district
+    geography_name: South Carolina Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: SC
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 45
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: sc_05
+    label: South Carolina Congressional District 5
+    ordinal: 386
+    row_number: 388
+    geography_id: 5001700US4505
+    geography_level: congressional_district
+    geography_name: South Carolina Congressional District 5
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: SC
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 45
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 5
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: sc_06
+    label: South Carolina Congressional District 6
+    ordinal: 387
+    row_number: 389
+    geography_id: 5001700US4506
+    geography_level: congressional_district
+    geography_name: South Carolina Congressional District 6
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: SC
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 45
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 6
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: sc_07
+    label: South Carolina Congressional District 7
+    ordinal: 388
+    row_number: 390
+    geography_id: 5001700US4507
+    geography_level: congressional_district
+    geography_name: South Carolina Congressional District 7
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: SC
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 45
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 7
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: sd_total
+    label: South Dakota all congressional districts
+    ordinal: 389
+    row_number: 391
+    geography_id: 0400000US46
+    geography_level: state
+    geography_name: South Dakota
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: SD
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 46
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tn_total
+    label: Tennessee all congressional districts
+    ordinal: 390
+    row_number: 392
+    geography_id: 0400000US47
+    geography_level: state
+    geography_name: Tennessee
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: TN
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 47
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tn_01
+    label: Tennessee Congressional District 1
+    ordinal: 391
+    row_number: 393
+    geography_id: 5001700US4701
+    geography_level: congressional_district
+    geography_name: Tennessee Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TN
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 47
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tn_02
+    label: Tennessee Congressional District 2
+    ordinal: 392
+    row_number: 394
+    geography_id: 5001700US4702
+    geography_level: congressional_district
+    geography_name: Tennessee Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TN
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 47
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tn_03
+    label: Tennessee Congressional District 3
+    ordinal: 393
+    row_number: 395
+    geography_id: 5001700US4703
+    geography_level: congressional_district
+    geography_name: Tennessee Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TN
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 47
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tn_04
+    label: Tennessee Congressional District 4
+    ordinal: 394
+    row_number: 396
+    geography_id: 5001700US4704
+    geography_level: congressional_district
+    geography_name: Tennessee Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TN
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 47
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tn_05
+    label: Tennessee Congressional District 5
+    ordinal: 395
+    row_number: 397
+    geography_id: 5001700US4705
+    geography_level: congressional_district
+    geography_name: Tennessee Congressional District 5
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TN
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 47
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 5
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tn_06
+    label: Tennessee Congressional District 6
+    ordinal: 396
+    row_number: 398
+    geography_id: 5001700US4706
+    geography_level: congressional_district
+    geography_name: Tennessee Congressional District 6
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TN
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 47
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 6
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tn_07
+    label: Tennessee Congressional District 7
+    ordinal: 397
+    row_number: 399
+    geography_id: 5001700US4707
+    geography_level: congressional_district
+    geography_name: Tennessee Congressional District 7
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TN
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 47
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 7
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tn_08
+    label: Tennessee Congressional District 8
+    ordinal: 398
+    row_number: 400
+    geography_id: 5001700US4708
+    geography_level: congressional_district
+    geography_name: Tennessee Congressional District 8
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TN
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 47
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 8
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tn_09
+    label: Tennessee Congressional District 9
+    ordinal: 399
+    row_number: 401
+    geography_id: 5001700US4709
+    geography_level: congressional_district
+    geography_name: Tennessee Congressional District 9
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TN
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 47
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 9
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_total
+    label: Texas all congressional districts
+    ordinal: 400
+    row_number: 402
+    geography_id: 0400000US48
+    geography_level: state
+    geography_name: Texas
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_01
+    label: Texas Congressional District 1
+    ordinal: 401
+    row_number: 403
+    geography_id: 5001700US4801
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_02
+    label: Texas Congressional District 2
+    ordinal: 402
+    row_number: 404
+    geography_id: 5001700US4802
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_03
+    label: Texas Congressional District 3
+    ordinal: 403
+    row_number: 405
+    geography_id: 5001700US4803
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_04
+    label: Texas Congressional District 4
+    ordinal: 404
+    row_number: 406
+    geography_id: 5001700US4804
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_05
+    label: Texas Congressional District 5
+    ordinal: 405
+    row_number: 407
+    geography_id: 5001700US4805
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 5
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 5
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_06
+    label: Texas Congressional District 6
+    ordinal: 406
+    row_number: 408
+    geography_id: 5001700US4806
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 6
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 6
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_07
+    label: Texas Congressional District 7
+    ordinal: 407
+    row_number: 409
+    geography_id: 5001700US4807
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 7
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 7
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_08
+    label: Texas Congressional District 8
+    ordinal: 408
+    row_number: 410
+    geography_id: 5001700US4808
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 8
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 8
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_09
+    label: Texas Congressional District 9
+    ordinal: 409
+    row_number: 411
+    geography_id: 5001700US4809
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 9
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 9
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_10
+    label: Texas Congressional District 10
+    ordinal: 410
+    row_number: 412
+    geography_id: 5001700US4810
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 10
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 10
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_11
+    label: Texas Congressional District 11
+    ordinal: 411
+    row_number: 413
+    geography_id: 5001700US4811
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 11
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 11
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_12
+    label: Texas Congressional District 12
+    ordinal: 412
+    row_number: 414
+    geography_id: 5001700US4812
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 12
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 12
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_13
+    label: Texas Congressional District 13
+    ordinal: 413
+    row_number: 415
+    geography_id: 5001700US4813
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 13
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 13
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_14
+    label: Texas Congressional District 14
+    ordinal: 414
+    row_number: 416
+    geography_id: 5001700US4814
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 14
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 14
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_15
+    label: Texas Congressional District 15
+    ordinal: 415
+    row_number: 417
+    geography_id: 5001700US4815
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 15
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 15
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_16
+    label: Texas Congressional District 16
+    ordinal: 416
+    row_number: 418
+    geography_id: 5001700US4816
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 16
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 16
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_17
+    label: Texas Congressional District 17
+    ordinal: 417
+    row_number: 419
+    geography_id: 5001700US4817
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 17
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 17
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_18
+    label: Texas Congressional District 18
+    ordinal: 418
+    row_number: 420
+    geography_id: 5001700US4818
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 18
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 18
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_19
+    label: Texas Congressional District 19
+    ordinal: 419
+    row_number: 421
+    geography_id: 5001700US4819
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 19
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 19
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_20
+    label: Texas Congressional District 20
+    ordinal: 420
+    row_number: 422
+    geography_id: 5001700US4820
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 20
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 20
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_21
+    label: Texas Congressional District 21
+    ordinal: 421
+    row_number: 423
+    geography_id: 5001700US4821
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 21
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 21
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_22
+    label: Texas Congressional District 22
+    ordinal: 422
+    row_number: 424
+    geography_id: 5001700US4822
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 22
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 22
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_23
+    label: Texas Congressional District 23
+    ordinal: 423
+    row_number: 425
+    geography_id: 5001700US4823
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 23
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 23
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_24
+    label: Texas Congressional District 24
+    ordinal: 424
+    row_number: 426
+    geography_id: 5001700US4824
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 24
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 24
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_25
+    label: Texas Congressional District 25
+    ordinal: 425
+    row_number: 427
+    geography_id: 5001700US4825
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 25
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 25
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_26
+    label: Texas Congressional District 26
+    ordinal: 426
+    row_number: 428
+    geography_id: 5001700US4826
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 26
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 26
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_27
+    label: Texas Congressional District 27
+    ordinal: 427
+    row_number: 429
+    geography_id: 5001700US4827
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 27
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 27
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_28
+    label: Texas Congressional District 28
+    ordinal: 428
+    row_number: 430
+    geography_id: 5001700US4828
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 28
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 28
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_29
+    label: Texas Congressional District 29
+    ordinal: 429
+    row_number: 431
+    geography_id: 5001700US4829
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 29
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 29
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_30
+    label: Texas Congressional District 30
+    ordinal: 430
+    row_number: 432
+    geography_id: 5001700US4830
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 30
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 30
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_31
+    label: Texas Congressional District 31
+    ordinal: 431
+    row_number: 433
+    geography_id: 5001700US4831
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 31
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 31
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_32
+    label: Texas Congressional District 32
+    ordinal: 432
+    row_number: 434
+    geography_id: 5001700US4832
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 32
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 32
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_33
+    label: Texas Congressional District 33
+    ordinal: 433
+    row_number: 435
+    geography_id: 5001700US4833
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 33
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 33
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_34
+    label: Texas Congressional District 34
+    ordinal: 434
+    row_number: 436
+    geography_id: 5001700US4834
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 34
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 34
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_35
+    label: Texas Congressional District 35
+    ordinal: 435
+    row_number: 437
+    geography_id: 5001700US4835
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 35
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 35
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: tx_36
+    label: Texas Congressional District 36
+    ordinal: 436
+    row_number: 438
+    geography_id: 5001700US4836
+    geography_level: congressional_district
+    geography_name: Texas Congressional District 36
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: TX
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 48
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 36
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ut_total
+    label: Utah all congressional districts
+    ordinal: 437
+    row_number: 439
+    geography_id: 0400000US49
+    geography_level: state
+    geography_name: Utah
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: UT
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 49
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ut_01
+    label: Utah Congressional District 1
+    ordinal: 438
+    row_number: 440
+    geography_id: 5001700US4901
+    geography_level: congressional_district
+    geography_name: Utah Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: UT
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 49
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ut_02
+    label: Utah Congressional District 2
+    ordinal: 439
+    row_number: 441
+    geography_id: 5001700US4902
+    geography_level: congressional_district
+    geography_name: Utah Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: UT
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 49
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ut_03
+    label: Utah Congressional District 3
+    ordinal: 440
+    row_number: 442
+    geography_id: 5001700US4903
+    geography_level: congressional_district
+    geography_name: Utah Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: UT
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 49
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: ut_04
+    label: Utah Congressional District 4
+    ordinal: 441
+    row_number: 443
+    geography_id: 5001700US4904
+    geography_level: congressional_district
+    geography_name: Utah Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: UT
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 49
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: vt_total
+    label: Vermont all congressional districts
+    ordinal: 442
+    row_number: 444
+    geography_id: 0400000US50
+    geography_level: state
+    geography_name: Vermont
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: VT
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 50
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: va_total
+    label: Virginia all congressional districts
+    ordinal: 443
+    row_number: 445
+    geography_id: 0400000US51
+    geography_level: state
+    geography_name: Virginia
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: VA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 51
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: va_01
+    label: Virginia Congressional District 1
+    ordinal: 444
+    row_number: 446
+    geography_id: 5001700US5101
+    geography_level: congressional_district
+    geography_name: Virginia Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: VA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 51
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: va_02
+    label: Virginia Congressional District 2
+    ordinal: 445
+    row_number: 447
+    geography_id: 5001700US5102
+    geography_level: congressional_district
+    geography_name: Virginia Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: VA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 51
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: va_03
+    label: Virginia Congressional District 3
+    ordinal: 446
+    row_number: 448
+    geography_id: 5001700US5103
+    geography_level: congressional_district
+    geography_name: Virginia Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: VA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 51
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: va_04
+    label: Virginia Congressional District 4
+    ordinal: 447
+    row_number: 449
+    geography_id: 5001700US5104
+    geography_level: congressional_district
+    geography_name: Virginia Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: VA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 51
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: va_05
+    label: Virginia Congressional District 5
+    ordinal: 448
+    row_number: 450
+    geography_id: 5001700US5105
+    geography_level: congressional_district
+    geography_name: Virginia Congressional District 5
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: VA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 51
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 5
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: va_06
+    label: Virginia Congressional District 6
+    ordinal: 449
+    row_number: 451
+    geography_id: 5001700US5106
+    geography_level: congressional_district
+    geography_name: Virginia Congressional District 6
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: VA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 51
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 6
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: va_07
+    label: Virginia Congressional District 7
+    ordinal: 450
+    row_number: 452
+    geography_id: 5001700US5107
+    geography_level: congressional_district
+    geography_name: Virginia Congressional District 7
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: VA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 51
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 7
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: va_08
+    label: Virginia Congressional District 8
+    ordinal: 451
+    row_number: 453
+    geography_id: 5001700US5108
+    geography_level: congressional_district
+    geography_name: Virginia Congressional District 8
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: VA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 51
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 8
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: va_09
+    label: Virginia Congressional District 9
+    ordinal: 452
+    row_number: 454
+    geography_id: 5001700US5109
+    geography_level: congressional_district
+    geography_name: Virginia Congressional District 9
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: VA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 51
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 9
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: va_10
+    label: Virginia Congressional District 10
+    ordinal: 453
+    row_number: 455
+    geography_id: 5001700US5110
+    geography_level: congressional_district
+    geography_name: Virginia Congressional District 10
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: VA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 51
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 10
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: va_11
+    label: Virginia Congressional District 11
+    ordinal: 454
+    row_number: 456
+    geography_id: 5001700US5111
+    geography_level: congressional_district
+    geography_name: Virginia Congressional District 11
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: VA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 51
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 11
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: wa_total
+    label: Washington all congressional districts
+    ordinal: 455
+    row_number: 457
+    geography_id: 0400000US53
+    geography_level: state
+    geography_name: Washington
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: WA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 53
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: wa_01
+    label: Washington Congressional District 1
+    ordinal: 456
+    row_number: 458
+    geography_id: 5001700US5301
+    geography_level: congressional_district
+    geography_name: Washington Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: WA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 53
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: wa_02
+    label: Washington Congressional District 2
+    ordinal: 457
+    row_number: 459
+    geography_id: 5001700US5302
+    geography_level: congressional_district
+    geography_name: Washington Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: WA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 53
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: wa_03
+    label: Washington Congressional District 3
+    ordinal: 458
+    row_number: 460
+    geography_id: 5001700US5303
+    geography_level: congressional_district
+    geography_name: Washington Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: WA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 53
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: wa_04
+    label: Washington Congressional District 4
+    ordinal: 459
+    row_number: 461
+    geography_id: 5001700US5304
+    geography_level: congressional_district
+    geography_name: Washington Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: WA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 53
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: wa_05
+    label: Washington Congressional District 5
+    ordinal: 460
+    row_number: 462
+    geography_id: 5001700US5305
+    geography_level: congressional_district
+    geography_name: Washington Congressional District 5
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: WA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 53
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 5
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: wa_06
+    label: Washington Congressional District 6
+    ordinal: 461
+    row_number: 463
+    geography_id: 5001700US5306
+    geography_level: congressional_district
+    geography_name: Washington Congressional District 6
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: WA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 53
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 6
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: wa_07
+    label: Washington Congressional District 7
+    ordinal: 462
+    row_number: 464
+    geography_id: 5001700US5307
+    geography_level: congressional_district
+    geography_name: Washington Congressional District 7
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: WA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 53
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 7
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: wa_08
+    label: Washington Congressional District 8
+    ordinal: 463
+    row_number: 465
+    geography_id: 5001700US5308
+    geography_level: congressional_district
+    geography_name: Washington Congressional District 8
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: WA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 53
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 8
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: wa_09
+    label: Washington Congressional District 9
+    ordinal: 464
+    row_number: 466
+    geography_id: 5001700US5309
+    geography_level: congressional_district
+    geography_name: Washington Congressional District 9
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: WA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 53
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 9
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: wa_10
+    label: Washington Congressional District 10
+    ordinal: 465
+    row_number: 467
+    geography_id: 5001700US5310
+    geography_level: congressional_district
+    geography_name: Washington Congressional District 10
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: WA
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 53
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 10
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: wv_total
+    label: West Virginia all congressional districts
+    ordinal: 466
+    row_number: 468
+    geography_id: 0400000US54
+    geography_level: state
+    geography_name: West Virginia
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: WV
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 54
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: wv_01
+    label: West Virginia Congressional District 1
+    ordinal: 467
+    row_number: 469
+    geography_id: 5001700US5401
+    geography_level: congressional_district
+    geography_name: West Virginia Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: WV
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 54
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: wv_02
+    label: West Virginia Congressional District 2
+    ordinal: 468
+    row_number: 470
+    geography_id: 5001700US5402
+    geography_level: congressional_district
+    geography_name: West Virginia Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: WV
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 54
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: wv_03
+    label: West Virginia Congressional District 3
+    ordinal: 469
+    row_number: 471
+    geography_id: 5001700US5403
+    geography_level: congressional_district
+    geography_name: West Virginia Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: WV
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 54
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: wi_total
+    label: Wisconsin all congressional districts
+    ordinal: 470
+    row_number: 472
+    geography_id: 0400000US55
+    geography_level: state
+    geography_name: Wisconsin
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: WI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 55
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: wi_01
+    label: Wisconsin Congressional District 1
+    ordinal: 471
+    row_number: 473
+    geography_id: 5001700US5501
+    geography_level: congressional_district
+    geography_name: Wisconsin Congressional District 1
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: WI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 55
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 1
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: wi_02
+    label: Wisconsin Congressional District 2
+    ordinal: 472
+    row_number: 474
+    geography_id: 5001700US5502
+    geography_level: congressional_district
+    geography_name: Wisconsin Congressional District 2
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: WI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 55
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 2
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: wi_03
+    label: Wisconsin Congressional District 3
+    ordinal: 473
+    row_number: 475
+    geography_id: 5001700US5503
+    geography_level: congressional_district
+    geography_name: Wisconsin Congressional District 3
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: WI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 55
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 3
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: wi_04
+    label: Wisconsin Congressional District 4
+    ordinal: 474
+    row_number: 476
+    geography_id: 5001700US5504
+    geography_level: congressional_district
+    geography_name: Wisconsin Congressional District 4
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: WI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 55
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 4
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: wi_05
+    label: Wisconsin Congressional District 5
+    ordinal: 475
+    row_number: 477
+    geography_id: 5001700US5505
+    geography_level: congressional_district
+    geography_name: Wisconsin Congressional District 5
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: WI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 55
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 5
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: wi_06
+    label: Wisconsin Congressional District 6
+    ordinal: 476
+    row_number: 478
+    geography_id: 5001700US5506
+    geography_level: congressional_district
+    geography_name: Wisconsin Congressional District 6
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: WI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 55
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 6
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: wi_07
+    label: Wisconsin Congressional District 7
+    ordinal: 477
+    row_number: 479
+    geography_id: 5001700US5507
+    geography_level: congressional_district
+    geography_name: Wisconsin Congressional District 7
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: WI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 55
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 7
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: wi_08
+    label: Wisconsin Congressional District 8
+    ordinal: 478
+    row_number: 480
+    geography_id: 5001700US5508
+    geography_level: congressional_district
+    geography_name: Wisconsin Congressional District 8
+    geography_vintage: 117th_congress
+    expected_row_header_column: B
+    expected_row_header: WI
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 55
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 8
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  - value_id: wy_total
+    label: Wyoming all congressional districts
+    ordinal: 479
+    row_number: 481
+    geography_id: 0400000US56
+    geography_level: state
+    geography_name: Wyoming
+    geography_vintage: 2020_census
+    expected_row_header_column: B
+    expected_row_header: WY
+    filters:
+      income_range: all
+    guard_cells:
+    - column: A
+      row: start
+      expected_value: 56
+      label: state FIPS
+    - column: C
+      row: start
+      expected_value: 0
+      label: congressional district code
+    - column: D
+      row: start
+      expected_value: 0
+      label: AGI stub
+    table_record_kind: total
+  measures:
+  - measure_id: return_count
+    label: Number of returns
+    ordinal: 0
+    column: E
+    source_column_id: N1
+    expected_column_header_row: 1
+    expected_column_header: N1
+    concept: irs_soi.individual_income_tax_returns
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+  - measure_id: tax_filer_individual_count
+    label: Number of individuals
+    ordinal: 1
+    column: N
+    source_column_id: N2
+    expected_column_header_row: 1
+    expected_column_header: N2
+    concept: irs_soi.tax_filer_individuals
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+  - measure_id: adjusted_gross_income
+    label: Adjusted gross income
+    ordinal: 2
+    column: U
+    source_column_id: A00100
+    expected_column_header_row: 1
+    expected_column_header: A00100
+    concept: us:statutes/26/62#adjusted_gross_income
+    source_concept: irs_soi.adjusted_gross_income
+    concept_relation: exact
+    concept_authority: arch-us
+    concept_evidence_url: https://uscode.house.gov/view.xhtml?req=(title:26%20section:62%20edition:prelim)
+    concept_evidence_notes: IRS SOI congressional district files report adjusted gross income for individual
+      income tax returns; IRC section 62 defines adjusted gross income. This Arch assertion treats the
+      SOI AGI column as exactly adopting that legal concept for the tax-year source record.
+    legal_vintage: tax_year_{year}
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number

--- a/tests/test_arch_source_package.py
+++ b/tests/test_arch_source_package.py
@@ -1684,6 +1684,58 @@ def test_soi_state_2022_source_package_alias_builds_us_totals():
     }
 
 
+def test_soi_congressional_district_2022_builds_all_return_facts():
+    package = load_source_package("soi-congressional-district-2022")
+    rows = package.build_source_rows(2022)
+    cells = package.build_source_cells(2022, source_rows=rows)
+    facts = package.build_facts(2022, cells=cells, source_rows=rows)
+    values_by_record = {fact.source_record_id: fact for fact in facts}
+
+    assert package.package_id == "soi-congressional-district-2022"
+    assert len(rows) == 4_791
+    assert len(cells) == 79_365
+    assert len(facts) == 1_440
+    assert validate_source_rows(rows).valid
+    assert validate_source_cells(cells).valid
+    assert validate_facts(facts).valid
+    assert {fact.geography.level for fact in facts} == {
+        "country",
+        "state",
+        "congressional_district",
+    }
+    assert all(fact.source_row_keys for fact in facts)
+    assert all(fact.source.raw_r2_uri for fact in facts)
+
+    assert (
+        values_by_record[
+            "irs_soi.ty2022.congressional_district_2022.all_returns."
+            "us.adjusted_gross_income"
+        ].value
+        == 14_424_810_411_000
+    )
+    assert (
+        values_by_record[
+            "irs_soi.ty2022.congressional_district_2022.all_returns."
+            "al_total.return_count"
+        ].value
+        == 2_104_760
+    )
+    al_01_agi = values_by_record[
+        "irs_soi.ty2022.congressional_district_2022.all_returns."
+        "al_01.adjusted_gross_income"
+    ]
+    ca_53_returns = values_by_record[
+        "irs_soi.ty2022.congressional_district_2022.all_returns."
+        "ca_53.return_count"
+    ]
+
+    assert al_01_agi.value == 22_915_824_000
+    assert al_01_agi.geography.id == "5001700US0101"
+    assert al_01_agi.geography.name == "Alabama Congressional District 1"
+    assert ca_53_returns.value == 383_160
+    assert ca_53_returns.geography.id == "5001700US0653"
+
+
 def test_soi_historic_table_2_package_builds_2022_national_facts():
     package = load_source_package("soi-historic-table-2")
     rows = package.build_source_rows(2023)


### PR DESCRIPTION
## Summary\n- add the IRS SOI 2022 congressional district CSV artifact and manifest\n- build all-return US, state, and 117th-congressional-district return count, filer-individual count, and AGI facts\n- preserve full source-row lineage while selecting 480 all-return rows for 1,440 consumer facts\n\n## Validation\n- uv run --python 3.13 ruff check arch/source_package.py tests/test_arch_source_package.py\n- uv run --python 3.13 pytest -q tests/test_arch_source_package.py -k 'congressional_district_2022 or source_package_alias_builds_census_acs_s0101_district_age_facts or source_package_alias_builds_census_acs_s2201_district_snap_facts'\n- uv run --python 3.13 arch validate-package soi-congressional-district-2022 --year 2022\n- uv run --python 3.13 arch build-suite soi-congressional-district-2022 --year 2022 --out /tmp/arch-soi-congressional-district-2022 --replace