### PR TITLE
Add BEA pension contribution source package

### DIFF
--- a/packages/bea/nipa_pension_contributions/source_package.yaml
+++ b/packages/bea/nipa_pension_contributions/source_package.yaml
@@ -1,0 +1,105 @@
+schema_version: arch.source_package.v1
+package_id: bea-nipa-pension-contributions
+label: BEA NIPA defined contribution pension contributions
+artifact:
+  source_name: bea
+  source_table: BEA NIPA annual data flat file
+  resource_package: db
+  resource_directory: data/bea/nipa_total_wages_salaries
+  manifest: manifest.yaml
+  vintage: bea_nipa_annual_release_2026_04_30
+  extracted_at: "2026-05-11"
+  extraction_method: delimited text full-row parse with selected-cell facts
+  parser: delimited_text_full_rows
+  sheet_name: NipaDataA
+  artifact_year: 2024
+  selected_rows:
+    - SeriesCode: W351RC
+      Period: "{year}"
+    - SeriesCode: Y351RC
+      Period: "{year}"
+record_sets:
+  - record_set_id: bea_nipa.cy{year}.defined_contribution_employer_contributions
+    record_set_spec_id: bea_nipa.defined_contribution_employer_contributions.v1
+    source_record_id_prefix: bea_nipa.cy{year}.defined_contribution_employer_contributions
+    sheet_name: NipaDataA
+    period_type: calendar_year
+    period: "{year}"
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    entity: pension_plan
+    entity_role: defined_contribution
+    domain: defined_contribution_pension_plans
+    groupby_dimension: bea_nipa.series_code
+    rows:
+      - value_id: w351rc
+        label: W351RC
+        ordinal: 0
+        row_number: 2
+        filters:
+          bea_nipa.series_code: W351RC
+        constraints:
+          - variable: bea_nipa.series_code
+            operator: "=="
+            value: W351RC
+            label: BEA NIPA series code
+        guard_cells:
+          - column: B
+            row: start
+            expected_value: "{year}"
+            label: calendar year
+    measures:
+      - measure_id: employer_contributions
+        label: Defined contribution employer contributions
+        ordinal: 0
+        column: C
+        source_column_id: value
+        concept: bea_nipa.defined_contribution_employer_contributions
+        unit: usd
+        aggregation: sum
+        value_scale: 1000000
+        expected_cell_type: number
+  - record_set_id: bea_nipa.cy{year}.defined_contribution_actual_contributions
+    record_set_spec_id: bea_nipa.defined_contribution_actual_contributions.v1
+    source_record_id_prefix: bea_nipa.cy{year}.defined_contribution_actual_contributions
+    sheet_name: NipaDataA
+    period_type: calendar_year
+    period: "{year}"
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    entity: pension_plan
+    entity_role: defined_contribution
+    domain: defined_contribution_pension_plans
+    groupby_dimension: bea_nipa.series_code
+    rows:
+      - value_id: y351rc
+        label: Y351RC
+        ordinal: 0
+        row_number: 3
+        filters:
+          bea_nipa.series_code: Y351RC
+        constraints:
+          - variable: bea_nipa.series_code
+            operator: "=="
+            value: Y351RC
+            label: BEA NIPA series code
+        guard_cells:
+          - column: B
+            row: start
+            expected_value: "{year}"
+            label: calendar year
+    measures:
+      - measure_id: actual_employer_and_household_contributions
+        label: Actual employer and household contributions
+        ordinal: 0
+        column: C
+        source_column_id: value
+        concept: bea_nipa.defined_contribution_actual_employer_and_household_contributions
+        unit: usd
+        aggregation: sum
+        value_scale: 1000000
+        expected_cell_type: number


### PR DESCRIPTION
## Summary
- Adds a focused BEA NIPA source package for defined contribution pension contribution aggregates.
- Reuses the existing BEA NIPA annual raw artifact directory instead of adding duplicate raw data.
- Splits this narrowly from the broader draft source-package PR so Microplex can ingest new Arch packages incrementally.

## Validation
- uv run arch validate-package packages/bea/nipa_pension_contributions --year 2024
- uv run arch build-suite packages/bea/nipa_pension_contributions --year 2024 --out /tmp/arch-bea-pension-2024-suite-20260529 --replace

Build-suite output emitted 2 consumer facts, 2 aggregate facts, 2 source records, 9 source cells, lineage_coverage=1.0, and valid agent acceptance. The only warning is no_concept_alignments, because these BEA pension concepts are source-native and not yet mapped into a downstream Microplex target.
