### PR TITLE
Add SSA SSI Table 7.B1 source package

### DIFF
--- a/arch/source_package.py
+++ b/arch/source_package.py
@@ -152,6 +152,7 @@ SOURCE_PACKAGE_ALIASES = {
     "ssa-annual-statistical-supplement-2025": Path(
         "ssa/annual_statistical_supplement_2025"
     ),
+    "ssa-ssi-table-7b1-2024": Path("ssa/ssi_table_7b1_2024"),
     "hhs-acf-tanf-caseload-2024": Path("hhs_acf/tanf_caseload_2024"),
     "hhs-acf-tanf-financial-2024": Path("hhs_acf/tanf_financial_2024"),
     "kff-marketplace-effectuated-enrollment": Path(

--- a/db/data/ssa/ssi_table_7b1_2024/manifest.yaml
+++ b/db/data/ssa/ssi_table_7b1_2024/manifest.yaml
@@ -1,0 +1,26 @@
+source_id: ssa-ssi-table-7b1-2024
+source_name: SSA Annual Statistical Supplement, 2025
+publisher: Social Security Administration
+source_page: https://www.ssa.gov/policy/docs/statcomps/supplement/2025/7b.html
+files:
+  2024:
+    filename: ssi_table_7b1_2024.csv
+    source_url: https://www.ssa.gov/policy/docs/statcomps/supplement/2025/7b.html
+    sha256: 4935f2b90d5abedc869e660f8a68df33b6f935630ebab2b159c09de7e4bf2401
+    size_bytes: 13990
+    storage:
+      r2:
+        provider: r2
+        bucket: arch-raw
+        key: raw/ssa/ssa-annual-statistical-supplement-2025/2024/4935f2b90d5abedc869e660f8a68df33b6f935630ebab2b159c09de7e4bf2401/ssi_table_7b1_2024.csv
+        uri: r2://arch-raw/raw/ssa/ssa-annual-statistical-supplement-2025/2024/4935f2b90d5abedc869e660f8a68df33b6f935630ebab2b159c09de7e4bf2401/ssi_table_7b1_2024.csv
+    source_urls:
+    - https://www.ssa.gov/policy/docs/statcomps/supplement/2025/7b.html
+    notes: Extracted selected 2024 All areas, state, and DC rows from SSA Annual Statistical
+      Supplement 2025 Table 7.B1. Payment rows retain source table thousands of dollars.
+  extracted_targets:
+    filename: ssi_table_7b1_2024.csv
+    source_urls:
+    - https://www.ssa.gov/policy/docs/statcomps/supplement/2025/7b.html
+    notes: Extracted selected 2024 SSI recipient and payment rows from SSA Annual
+      Statistical Supplement 2025 Table 7.B1.

--- a/db/data/ssa/ssi_table_7b1_2024/ssi_table_7b1_2024.csv
+++ b/db/data/ssa/ssi_table_7b1_2024/ssi_table_7b1_2024.csv
@@ -1,0 +1,209 @@
+area_id,area_name,geography_id,geography_level,geography_name,ssi_category,recipient_count,payment_thousands
+all_areas,All areas,0100000US,country,United States,total,7404820,63079493
+all_areas,All areas,0100000US,country,United States,aged,1161623,7677974
+all_areas,All areas,0100000US,country,United States,blind,63312,550051
+all_areas,All areas,0100000US,country,United States,disabled,6179885,54851468
+alabama,Alabama,0400000US01,state,Alabama,total,129972,954623
+alabama,Alabama,0400000US01,state,Alabama,aged,11270,57672
+alabama,Alabama,0400000US01,state,Alabama,blind,888,6237
+alabama,Alabama,0400000US01,state,Alabama,disabled,117814,890714
+alaska,Alaska,0400000US02,state,Alaska,total,10269,83990
+alaska,Alaska,0400000US02,state,Alaska,aged,994,5832
+alaska,Alaska,0400000US02,state,Alaska,blind,86,674
+alaska,Alaska,0400000US02,state,Alaska,disabled,9189,77484
+arizona,Arizona,0400000US04,state,Arizona,total,126988,1065208
+arizona,Arizona,0400000US04,state,Arizona,aged,20758,130728
+arizona,Arizona,0400000US04,state,Arizona,blind,1284,10420
+arizona,Arizona,0400000US04,state,Arizona,disabled,104946,924060
+arkansas,Arkansas,0400000US05,state,Arkansas,total,74009,543005
+arkansas,Arkansas,0400000US05,state,Arkansas,aged,6189,32303
+arkansas,Arkansas,0400000US05,state,Arkansas,blind,568,3868
+arkansas,Arkansas,0400000US05,state,Arkansas,disabled,67252,506833
+california,California,0400000US06,state,California,total,1177135,12927048
+california,California,0400000US06,state,California,aged,311336,2923742
+california,California,0400000US06,state,California,blind,15965,168545
+california,California,0400000US06,state,California,disabled,849834,9834761
+colorado,Colorado,0400000US08,state,Colorado,total,69338,584806
+colorado,Colorado,0400000US08,state,Colorado,aged,12324,83345
+colorado,Colorado,0400000US08,state,Colorado,blind,659,5457
+colorado,Colorado,0400000US08,state,Colorado,disabled,56355,496004
+connecticut,Connecticut,0400000US09,state,Connecticut,total,48033,434835
+connecticut,Connecticut,0400000US09,state,Connecticut,aged,7285,53998
+connecticut,Connecticut,0400000US09,state,Connecticut,blind,333,3247
+connecticut,Connecticut,0400000US09,state,Connecticut,disabled,40415,377590
+delaware,Delaware,0400000US10,state,Delaware,total,13023,106517
+delaware,Delaware,0400000US10,state,Delaware,aged,1391,7903
+delaware,Delaware,0400000US10,state,Delaware,blind,69,517
+delaware,Delaware,0400000US10,state,Delaware,disabled,11563,98096
+district_of_columbia,District of Columbia,0400000US11,state,District of Columbia,total,20624,170290
+district_of_columbia,District of Columbia,0400000US11,state,District of Columbia,aged,4357,26942
+district_of_columbia,District of Columbia,0400000US11,state,District of Columbia,blind,93,835
+district_of_columbia,District of Columbia,0400000US11,state,District of Columbia,disabled,16174,142513
+florida,Florida,0400000US12,state,Florida,total,552713,4440405
+florida,Florida,0400000US12,state,Florida,aged,160193,1025920
+florida,Florida,0400000US12,state,Florida,blind,5169,40889
+florida,Florida,0400000US12,state,Florida,disabled,387351,3373596
+georgia,Georgia,0400000US13,state,Georgia,total,238086,1818395
+georgia,Georgia,0400000US13,state,Georgia,aged,39924,224560
+georgia,Georgia,0400000US13,state,Georgia,blind,2320,16050
+georgia,Georgia,0400000US13,state,Georgia,disabled,195842,1577785
+hawaii,Hawaii,0400000US15,state,Hawaii,total,21907,200491
+hawaii,Hawaii,0400000US15,state,Hawaii,aged,5722,47702
+hawaii,Hawaii,0400000US15,state,Hawaii,blind,106,877
+hawaii,Hawaii,0400000US15,state,Hawaii,disabled,16079,151912
+idaho,Idaho,0400000US16,state,Idaho,total,17796,144925
+idaho,Idaho,0400000US16,state,Idaho,aged,1260,6741
+idaho,Idaho,0400000US16,state,Idaho,blind,118,908
+idaho,Idaho,0400000US16,state,Idaho,disabled,16418,137276
+illinois,Illinois,0400000US17,state,Illinois,total,241436,2120837
+illinois,Illinois,0400000US17,state,Illinois,aged,42142,296226
+illinois,Illinois,0400000US17,state,Illinois,blind,2631,23099
+illinois,Illinois,0400000US17,state,Illinois,disabled,196663,1801511
+indiana,Indiana,0400000US18,state,Indiana,total,117861,923695
+indiana,Indiana,0400000US18,state,Indiana,aged,9652,52191
+indiana,Indiana,0400000US18,state,Indiana,blind,839,6435
+indiana,Indiana,0400000US18,state,Indiana,disabled,107370,865069
+iowa,Iowa,0400000US19,state,Iowa,total,45192,356309
+iowa,Iowa,0400000US19,state,Iowa,aged,4202,22387
+iowa,Iowa,0400000US19,state,Iowa,blind,346,2539
+iowa,Iowa,0400000US19,state,Iowa,disabled,40644,331383
+kansas,Kansas,0400000US20,state,Kansas,total,41468,325251
+kansas,Kansas,0400000US20,state,Kansas,aged,3328,17098
+kansas,Kansas,0400000US20,state,Kansas,blind,252,1838
+kansas,Kansas,0400000US20,state,Kansas,disabled,37888,306315
+kentucky,Kentucky,0400000US21,state,Kentucky,total,152572,1163408
+kentucky,Kentucky,0400000US21,state,Kentucky,aged,10740,58700
+kentucky,Kentucky,0400000US21,state,Kentucky,blind,1066,7704
+kentucky,Kentucky,0400000US21,state,Kentucky,disabled,140766,1097004
+louisiana,Louisiana,0400000US22,state,Louisiana,total,157722,1148229
+louisiana,Louisiana,0400000US22,state,Louisiana,aged,12052,60554
+louisiana,Louisiana,0400000US22,state,Louisiana,blind,947,6153
+louisiana,Louisiana,0400000US22,state,Louisiana,disabled,144723,1081522
+maine,Maine,0400000US23,state,Maine,total,36925,314877
+maine,Maine,0400000US23,state,Maine,aged,2779,16280
+maine,Maine,0400000US23,state,Maine,blind,255,1903
+maine,Maine,0400000US23,state,Maine,disabled,33891,296694
+maryland,Maryland,0400000US24,state,Maryland,total,105543,849014
+maryland,Maryland,0400000US24,state,Maryland,aged,16907,104317
+maryland,Maryland,0400000US24,state,Maryland,blind,1008,7621
+maryland,Maryland,0400000US24,state,Maryland,disabled,87628,737075
+massachusetts,Massachusetts,0400000US25,state,Massachusetts,total,167726,1728731
+massachusetts,Massachusetts,0400000US25,state,Massachusetts,aged,34193,302320
+massachusetts,Massachusetts,0400000US25,state,Massachusetts,blind,1559,17331
+massachusetts,Massachusetts,0400000US25,state,Massachusetts,disabled,131974,1409080
+michigan,Michigan,0400000US26,state,Michigan,total,231797,1949424
+michigan,Michigan,0400000US26,state,Michigan,aged,30264,217866
+michigan,Michigan,0400000US26,state,Michigan,blind,1773,15602
+michigan,Michigan,0400000US26,state,Michigan,disabled,199760,1715956
+minnesota,Minnesota,0400000US27,state,Minnesota,total,91256,773985
+minnesota,Minnesota,0400000US27,state,Minnesota,aged,12683,78345
+minnesota,Minnesota,0400000US27,state,Minnesota,blind,1072,9616
+minnesota,Minnesota,0400000US27,state,Minnesota,disabled,77501,686024
+mississippi,Mississippi,0400000US28,state,Mississippi,total,95679,683466
+mississippi,Mississippi,0400000US28,state,Mississippi,aged,8659,41636
+mississippi,Mississippi,0400000US28,state,Mississippi,blind,531,3646
+mississippi,Mississippi,0400000US28,state,Mississippi,disabled,86489,638184
+missouri,Missouri,0400000US29,state,Missouri,total,138883,1079049
+missouri,Missouri,0400000US29,state,Missouri,aged,12548,71656
+missouri,Missouri,0400000US29,state,Missouri,blind,1178,8964
+missouri,Missouri,0400000US29,state,Missouri,disabled,125157,998429
+montana,Montana,0400000US30,state,Montana,total,14649,113789
+montana,Montana,0400000US30,state,Montana,aged,1188,6597
+montana,Montana,0400000US30,state,Montana,blind,119,874
+montana,Montana,0400000US30,state,Montana,disabled,13342,106319
+nebraska,Nebraska,0400000US31,state,Nebraska,total,31660,254325
+nebraska,Nebraska,0400000US31,state,Nebraska,aged,3547,20809
+nebraska,Nebraska,0400000US31,state,Nebraska,blind,212,1602
+nebraska,Nebraska,0400000US31,state,Nebraska,disabled,27901,231914
+nevada,Nevada,0400000US32,state,Nevada,total,47831,407995
+nevada,Nevada,0400000US32,state,Nevada,aged,9467,61815
+nevada,Nevada,0400000US32,state,Nevada,blind,383,3220
+nevada,Nevada,0400000US32,state,Nevada,disabled,37981,342961
+new_hampshire,New Hampshire,0400000US33,state,New Hampshire,total,14197,117867
+new_hampshire,New Hampshire,0400000US33,state,New Hampshire,aged,1363,8431
+new_hampshire,New Hampshire,0400000US33,state,New Hampshire,blind,112,839
+new_hampshire,New Hampshire,0400000US33,state,New Hampshire,disabled,12722,108596
+new_jersey,New Jersey,0400000US34,state,New Jersey,total,150737,1432005
+new_jersey,New Jersey,0400000US34,state,New Jersey,aged,30727,256147
+new_jersey,New Jersey,0400000US34,state,New Jersey,blind,1105,11029
+new_jersey,New Jersey,0400000US34,state,New Jersey,disabled,118905,1164830
+new_mexico,New Mexico,0400000US35,state,New Mexico,total,48088,349411
+new_mexico,New Mexico,0400000US35,state,New Mexico,aged,6837,30573
+new_mexico,New Mexico,0400000US35,state,New Mexico,blind,414,2546
+new_mexico,New Mexico,0400000US35,state,New Mexico,disabled,40837,316292
+new_york,New York,0400000US36,state,New York,total,554242,5330965
+new_york,New York,0400000US36,state,New York,aged,115090,926448
+new_york,New York,0400000US36,state,New York,blind,4485,42892
+new_york,New York,0400000US36,state,New York,disabled,434667,4361626
+north_carolina,North Carolina,0400000US37,state,North Carolina,total,220637,1702702
+north_carolina,North Carolina,0400000US37,state,North Carolina,aged,34366,193973
+north_carolina,North Carolina,0400000US37,state,North Carolina,blind,2114,13977
+north_carolina,North Carolina,0400000US37,state,North Carolina,disabled,184157,1494753
+north_dakota,North Dakota,0400000US38,state,North Dakota,total,7490,57766
+north_dakota,North Dakota,0400000US38,state,North Dakota,aged,557,3008
+north_dakota,North Dakota,0400000US38,state,North Dakota,blind,43,291
+north_dakota,North Dakota,0400000US38,state,North Dakota,disabled,6890,54467
+ohio,Ohio,0400000US39,state,Ohio,total,283350,2315757
+ohio,Ohio,0400000US39,state,Ohio,aged,33988,220343
+ohio,Ohio,0400000US39,state,Ohio,blind,2143,19766
+ohio,Ohio,0400000US39,state,Ohio,disabled,247219,2075648
+oklahoma,Oklahoma,0400000US40,state,Oklahoma,total,76894,570937
+oklahoma,Oklahoma,0400000US40,state,Oklahoma,aged,7069,34644
+oklahoma,Oklahoma,0400000US40,state,Oklahoma,blind,626,4557
+oklahoma,Oklahoma,0400000US40,state,Oklahoma,disabled,69199,531736
+oregon,Oregon,0400000US41,state,Oregon,total,72965,650922
+oregon,Oregon,0400000US41,state,Oregon,aged,7611,45184
+oregon,Oregon,0400000US41,state,Oregon,blind,446,4238
+oregon,Oregon,0400000US41,state,Oregon,disabled,64908,601500
+pennsylvania,Pennsylvania,0400000US42,state,Pennsylvania,total,327789,2987186
+pennsylvania,Pennsylvania,0400000US42,state,Pennsylvania,aged,51024,437241
+pennsylvania,Pennsylvania,0400000US42,state,Pennsylvania,blind,2457,25353
+pennsylvania,Pennsylvania,0400000US42,state,Pennsylvania,disabled,274308,2524591
+rhode_island,Rhode Island,0400000US44,state,Rhode Island,total,31786,295756
+rhode_island,Rhode Island,0400000US44,state,Rhode Island,aged,3411,24653
+rhode_island,Rhode Island,0400000US44,state,Rhode Island,blind,137,1470
+rhode_island,Rhode Island,0400000US44,state,Rhode Island,disabled,28238,269633
+south_carolina,South Carolina,0400000US45,state,South Carolina,total,103771,776090
+south_carolina,South Carolina,0400000US45,state,South Carolina,aged,12184,60493
+south_carolina,South Carolina,0400000US45,state,South Carolina,blind,705,4690
+south_carolina,South Carolina,0400000US45,state,South Carolina,disabled,90882,710907
+south_dakota,South Dakota,0400000US46,state,South Dakota,total,12834,91842
+south_dakota,South Dakota,0400000US46,state,South Dakota,aged,1155,5287
+south_dakota,South Dakota,0400000US46,state,South Dakota,blind,93,617
+south_dakota,South Dakota,0400000US46,state,South Dakota,disabled,11586,85938
+tennessee,Tennessee,0400000US47,state,Tennessee,total,161998,1208821
+tennessee,Tennessee,0400000US47,state,Tennessee,aged,17486,79370
+tennessee,Tennessee,0400000US47,state,Tennessee,blind,1375,9173
+tennessee,Tennessee,0400000US47,state,Tennessee,disabled,143137,1120278
+texas,Texas,0400000US48,state,Texas,total,585233,4478056
+texas,Texas,0400000US48,state,Texas,aged,107234,597208
+texas,Texas,0400000US48,state,Texas,blind,6890,46634
+texas,Texas,0400000US48,state,Texas,disabled,471109,3834214
+utah,Utah,0400000US49,state,Utah,total,30827,260783
+utah,Utah,0400000US49,state,Utah,aged,3948,24309
+utah,Utah,0400000US49,state,Utah,blind,229,1733
+utah,Utah,0400000US49,state,Utah,disabled,26650,234741
+vermont,Vermont,0400000US50,state,Vermont,total,11332,93892
+vermont,Vermont,0400000US50,state,Vermont,aged,904,6157
+vermont,Vermont,0400000US50,state,Vermont,blind,65,517
+vermont,Vermont,0400000US50,state,Vermont,disabled,10363,87219
+virginia,Virginia,0400000US51,state,Virginia,total,127972,1006446
+virginia,Virginia,0400000US51,state,Virginia,aged,19240,116471
+virginia,Virginia,0400000US51,state,Virginia,blind,1219,9821
+virginia,Virginia,0400000US51,state,Virginia,disabled,107513,880154
+washington,Washington,0400000US53,state,Washington,total,113414,1034724
+washington,Washington,0400000US53,state,Washington,aged,18483,140753
+washington,Washington,0400000US53,state,Washington,blind,1148,11156
+washington,Washington,0400000US53,state,Washington,disabled,93783,882815
+west_virginia,West Virginia,0400000US54,state,West Virginia,total,67503,532777
+west_virginia,West Virginia,0400000US54,state,West Virginia,aged,4156,23644
+west_virginia,West Virginia,0400000US54,state,West Virginia,blind,457,3266
+west_virginia,West Virginia,0400000US54,state,West Virginia,disabled,62890,505867
+wisconsin,Wisconsin,0400000US55,state,Wisconsin,total,105642,910657
+wisconsin,Wisconsin,0400000US55,state,Wisconsin,aged,8997,59211
+wisconsin,Wisconsin,0400000US55,state,Wisconsin,blind,793,6574
+wisconsin,Wisconsin,0400000US55,state,Wisconsin,disabled,95852,844871
+wyoming,Wyoming,0400000US56,state,Wyoming,total,5606,43539
+wyoming,Wyoming,0400000US56,state,Wyoming,aged,381,2126
+wyoming,Wyoming,0400000US56,state,Wyoming,blind,38,286
+wyoming,Wyoming,0400000US56,state,Wyoming,disabled,5187,41127

--- a/packages/ssa/ssi_table_7b1_2024/source_package.yaml
+++ b/packages/ssa/ssi_table_7b1_2024/source_package.yaml
@@ -1,0 +1,9129 @@
+schema_version: arch.source_package.v1
+package_id: ssa-ssi-table-7b1-2024
+label: SSA Annual Statistical Supplement 2025 Table 7.B1 SSI recipients and payments
+artifact:
+  source_name: ssa
+  source_table: SSA Annual Statistical Supplement 2025 Table 7.B1
+  resource_package: db
+  resource_directory: data/ssa/ssi_table_7b1_2024
+  manifest: manifest.yaml
+  vintage: annual_statistical_supplement_2025
+  extracted_at: '2026-05-29'
+  extraction_method: manual table extraction from SSA Annual Statistical Supplement 2025 Table 7.B1 HTML; payment rows retained in source thousands of dollars and scaled in Arch measures
+  parser: delimited_text_full_rows
+  artifact_year: 2024
+  sheet_name: ssi_table_7b1_2024
+record_sets:
+- sheet_name: ssi_table_7b1_2024
+  period_type: calendar_year
+  period: 2024
+  geography_id: 0100000US
+  geography_level: country
+  geography_name: United States
+  geography_vintage: current
+  entity: person
+  entity_role: ssi_recipient
+  domain: social_security_and_ssi_payments
+  rows:
+  - value_id: all_areas_total
+    label: All areas total SSI
+    ordinal: 0
+    row_number: 2
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: All areas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: all_areas_aged
+    label: All areas aged SSI
+    ordinal: 1
+    row_number: 3
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: All areas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: all_areas_blind
+    label: All areas blind SSI
+    ordinal: 2
+    row_number: 4
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: All areas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: all_areas_disabled
+    label: All areas disabled SSI
+    ordinal: 3
+    row_number: 5
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: All areas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: alabama_total
+    label: Alabama total SSI
+    ordinal: 4
+    row_number: 6
+    geography_id: 0400000US01
+    geography_level: state
+    geography_name: Alabama
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Alabama
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: alabama_aged
+    label: Alabama aged SSI
+    ordinal: 5
+    row_number: 7
+    geography_id: 0400000US01
+    geography_level: state
+    geography_name: Alabama
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Alabama
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: alabama_blind
+    label: Alabama blind SSI
+    ordinal: 6
+    row_number: 8
+    geography_id: 0400000US01
+    geography_level: state
+    geography_name: Alabama
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Alabama
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: alabama_disabled
+    label: Alabama disabled SSI
+    ordinal: 7
+    row_number: 9
+    geography_id: 0400000US01
+    geography_level: state
+    geography_name: Alabama
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Alabama
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: alaska_total
+    label: Alaska total SSI
+    ordinal: 8
+    row_number: 10
+    geography_id: 0400000US02
+    geography_level: state
+    geography_name: Alaska
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Alaska
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: alaska_aged
+    label: Alaska aged SSI
+    ordinal: 9
+    row_number: 11
+    geography_id: 0400000US02
+    geography_level: state
+    geography_name: Alaska
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Alaska
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: alaska_blind
+    label: Alaska blind SSI
+    ordinal: 10
+    row_number: 12
+    geography_id: 0400000US02
+    geography_level: state
+    geography_name: Alaska
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Alaska
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: alaska_disabled
+    label: Alaska disabled SSI
+    ordinal: 11
+    row_number: 13
+    geography_id: 0400000US02
+    geography_level: state
+    geography_name: Alaska
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Alaska
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: arizona_total
+    label: Arizona total SSI
+    ordinal: 12
+    row_number: 14
+    geography_id: 0400000US04
+    geography_level: state
+    geography_name: Arizona
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Arizona
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: arizona_aged
+    label: Arizona aged SSI
+    ordinal: 13
+    row_number: 15
+    geography_id: 0400000US04
+    geography_level: state
+    geography_name: Arizona
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Arizona
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: arizona_blind
+    label: Arizona blind SSI
+    ordinal: 14
+    row_number: 16
+    geography_id: 0400000US04
+    geography_level: state
+    geography_name: Arizona
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Arizona
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: arizona_disabled
+    label: Arizona disabled SSI
+    ordinal: 15
+    row_number: 17
+    geography_id: 0400000US04
+    geography_level: state
+    geography_name: Arizona
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Arizona
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: arkansas_total
+    label: Arkansas total SSI
+    ordinal: 16
+    row_number: 18
+    geography_id: 0400000US05
+    geography_level: state
+    geography_name: Arkansas
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Arkansas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: arkansas_aged
+    label: Arkansas aged SSI
+    ordinal: 17
+    row_number: 19
+    geography_id: 0400000US05
+    geography_level: state
+    geography_name: Arkansas
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Arkansas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: arkansas_blind
+    label: Arkansas blind SSI
+    ordinal: 18
+    row_number: 20
+    geography_id: 0400000US05
+    geography_level: state
+    geography_name: Arkansas
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Arkansas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: arkansas_disabled
+    label: Arkansas disabled SSI
+    ordinal: 19
+    row_number: 21
+    geography_id: 0400000US05
+    geography_level: state
+    geography_name: Arkansas
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Arkansas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: california_total
+    label: California total SSI
+    ordinal: 20
+    row_number: 22
+    geography_id: 0400000US06
+    geography_level: state
+    geography_name: California
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: California
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: california_aged
+    label: California aged SSI
+    ordinal: 21
+    row_number: 23
+    geography_id: 0400000US06
+    geography_level: state
+    geography_name: California
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: California
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: california_blind
+    label: California blind SSI
+    ordinal: 22
+    row_number: 24
+    geography_id: 0400000US06
+    geography_level: state
+    geography_name: California
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: California
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: california_disabled
+    label: California disabled SSI
+    ordinal: 23
+    row_number: 25
+    geography_id: 0400000US06
+    geography_level: state
+    geography_name: California
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: California
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: colorado_total
+    label: Colorado total SSI
+    ordinal: 24
+    row_number: 26
+    geography_id: 0400000US08
+    geography_level: state
+    geography_name: Colorado
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Colorado
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: colorado_aged
+    label: Colorado aged SSI
+    ordinal: 25
+    row_number: 27
+    geography_id: 0400000US08
+    geography_level: state
+    geography_name: Colorado
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Colorado
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: colorado_blind
+    label: Colorado blind SSI
+    ordinal: 26
+    row_number: 28
+    geography_id: 0400000US08
+    geography_level: state
+    geography_name: Colorado
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Colorado
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: colorado_disabled
+    label: Colorado disabled SSI
+    ordinal: 27
+    row_number: 29
+    geography_id: 0400000US08
+    geography_level: state
+    geography_name: Colorado
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Colorado
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: connecticut_total
+    label: Connecticut total SSI
+    ordinal: 28
+    row_number: 30
+    geography_id: 0400000US09
+    geography_level: state
+    geography_name: Connecticut
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Connecticut
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: connecticut_aged
+    label: Connecticut aged SSI
+    ordinal: 29
+    row_number: 31
+    geography_id: 0400000US09
+    geography_level: state
+    geography_name: Connecticut
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Connecticut
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: connecticut_blind
+    label: Connecticut blind SSI
+    ordinal: 30
+    row_number: 32
+    geography_id: 0400000US09
+    geography_level: state
+    geography_name: Connecticut
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Connecticut
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: connecticut_disabled
+    label: Connecticut disabled SSI
+    ordinal: 31
+    row_number: 33
+    geography_id: 0400000US09
+    geography_level: state
+    geography_name: Connecticut
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Connecticut
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: delaware_total
+    label: Delaware total SSI
+    ordinal: 32
+    row_number: 34
+    geography_id: 0400000US10
+    geography_level: state
+    geography_name: Delaware
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Delaware
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: delaware_aged
+    label: Delaware aged SSI
+    ordinal: 33
+    row_number: 35
+    geography_id: 0400000US10
+    geography_level: state
+    geography_name: Delaware
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Delaware
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: delaware_blind
+    label: Delaware blind SSI
+    ordinal: 34
+    row_number: 36
+    geography_id: 0400000US10
+    geography_level: state
+    geography_name: Delaware
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Delaware
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: delaware_disabled
+    label: Delaware disabled SSI
+    ordinal: 35
+    row_number: 37
+    geography_id: 0400000US10
+    geography_level: state
+    geography_name: Delaware
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Delaware
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: district_of_columbia_total
+    label: District of Columbia total SSI
+    ordinal: 36
+    row_number: 38
+    geography_id: 0400000US11
+    geography_level: state
+    geography_name: District of Columbia
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: District of Columbia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: district_of_columbia_aged
+    label: District of Columbia aged SSI
+    ordinal: 37
+    row_number: 39
+    geography_id: 0400000US11
+    geography_level: state
+    geography_name: District of Columbia
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: District of Columbia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: district_of_columbia_blind
+    label: District of Columbia blind SSI
+    ordinal: 38
+    row_number: 40
+    geography_id: 0400000US11
+    geography_level: state
+    geography_name: District of Columbia
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: District of Columbia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: district_of_columbia_disabled
+    label: District of Columbia disabled SSI
+    ordinal: 39
+    row_number: 41
+    geography_id: 0400000US11
+    geography_level: state
+    geography_name: District of Columbia
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: District of Columbia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: florida_total
+    label: Florida total SSI
+    ordinal: 40
+    row_number: 42
+    geography_id: 0400000US12
+    geography_level: state
+    geography_name: Florida
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Florida
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: florida_aged
+    label: Florida aged SSI
+    ordinal: 41
+    row_number: 43
+    geography_id: 0400000US12
+    geography_level: state
+    geography_name: Florida
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Florida
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: florida_blind
+    label: Florida blind SSI
+    ordinal: 42
+    row_number: 44
+    geography_id: 0400000US12
+    geography_level: state
+    geography_name: Florida
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Florida
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: florida_disabled
+    label: Florida disabled SSI
+    ordinal: 43
+    row_number: 45
+    geography_id: 0400000US12
+    geography_level: state
+    geography_name: Florida
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Florida
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: georgia_total
+    label: Georgia total SSI
+    ordinal: 44
+    row_number: 46
+    geography_id: 0400000US13
+    geography_level: state
+    geography_name: Georgia
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Georgia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: georgia_aged
+    label: Georgia aged SSI
+    ordinal: 45
+    row_number: 47
+    geography_id: 0400000US13
+    geography_level: state
+    geography_name: Georgia
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Georgia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: georgia_blind
+    label: Georgia blind SSI
+    ordinal: 46
+    row_number: 48
+    geography_id: 0400000US13
+    geography_level: state
+    geography_name: Georgia
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Georgia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: georgia_disabled
+    label: Georgia disabled SSI
+    ordinal: 47
+    row_number: 49
+    geography_id: 0400000US13
+    geography_level: state
+    geography_name: Georgia
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Georgia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: hawaii_total
+    label: Hawaii total SSI
+    ordinal: 48
+    row_number: 50
+    geography_id: 0400000US15
+    geography_level: state
+    geography_name: Hawaii
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Hawaii
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: hawaii_aged
+    label: Hawaii aged SSI
+    ordinal: 49
+    row_number: 51
+    geography_id: 0400000US15
+    geography_level: state
+    geography_name: Hawaii
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Hawaii
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: hawaii_blind
+    label: Hawaii blind SSI
+    ordinal: 50
+    row_number: 52
+    geography_id: 0400000US15
+    geography_level: state
+    geography_name: Hawaii
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Hawaii
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: hawaii_disabled
+    label: Hawaii disabled SSI
+    ordinal: 51
+    row_number: 53
+    geography_id: 0400000US15
+    geography_level: state
+    geography_name: Hawaii
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Hawaii
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: idaho_total
+    label: Idaho total SSI
+    ordinal: 52
+    row_number: 54
+    geography_id: 0400000US16
+    geography_level: state
+    geography_name: Idaho
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Idaho
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: idaho_aged
+    label: Idaho aged SSI
+    ordinal: 53
+    row_number: 55
+    geography_id: 0400000US16
+    geography_level: state
+    geography_name: Idaho
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Idaho
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: idaho_blind
+    label: Idaho blind SSI
+    ordinal: 54
+    row_number: 56
+    geography_id: 0400000US16
+    geography_level: state
+    geography_name: Idaho
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Idaho
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: idaho_disabled
+    label: Idaho disabled SSI
+    ordinal: 55
+    row_number: 57
+    geography_id: 0400000US16
+    geography_level: state
+    geography_name: Idaho
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Idaho
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: illinois_total
+    label: Illinois total SSI
+    ordinal: 56
+    row_number: 58
+    geography_id: 0400000US17
+    geography_level: state
+    geography_name: Illinois
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Illinois
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: illinois_aged
+    label: Illinois aged SSI
+    ordinal: 57
+    row_number: 59
+    geography_id: 0400000US17
+    geography_level: state
+    geography_name: Illinois
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Illinois
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: illinois_blind
+    label: Illinois blind SSI
+    ordinal: 58
+    row_number: 60
+    geography_id: 0400000US17
+    geography_level: state
+    geography_name: Illinois
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Illinois
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: illinois_disabled
+    label: Illinois disabled SSI
+    ordinal: 59
+    row_number: 61
+    geography_id: 0400000US17
+    geography_level: state
+    geography_name: Illinois
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Illinois
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: indiana_total
+    label: Indiana total SSI
+    ordinal: 60
+    row_number: 62
+    geography_id: 0400000US18
+    geography_level: state
+    geography_name: Indiana
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Indiana
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: indiana_aged
+    label: Indiana aged SSI
+    ordinal: 61
+    row_number: 63
+    geography_id: 0400000US18
+    geography_level: state
+    geography_name: Indiana
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Indiana
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: indiana_blind
+    label: Indiana blind SSI
+    ordinal: 62
+    row_number: 64
+    geography_id: 0400000US18
+    geography_level: state
+    geography_name: Indiana
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Indiana
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: indiana_disabled
+    label: Indiana disabled SSI
+    ordinal: 63
+    row_number: 65
+    geography_id: 0400000US18
+    geography_level: state
+    geography_name: Indiana
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Indiana
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: iowa_total
+    label: Iowa total SSI
+    ordinal: 64
+    row_number: 66
+    geography_id: 0400000US19
+    geography_level: state
+    geography_name: Iowa
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Iowa
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: iowa_aged
+    label: Iowa aged SSI
+    ordinal: 65
+    row_number: 67
+    geography_id: 0400000US19
+    geography_level: state
+    geography_name: Iowa
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Iowa
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: iowa_blind
+    label: Iowa blind SSI
+    ordinal: 66
+    row_number: 68
+    geography_id: 0400000US19
+    geography_level: state
+    geography_name: Iowa
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Iowa
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: iowa_disabled
+    label: Iowa disabled SSI
+    ordinal: 67
+    row_number: 69
+    geography_id: 0400000US19
+    geography_level: state
+    geography_name: Iowa
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Iowa
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: kansas_total
+    label: Kansas total SSI
+    ordinal: 68
+    row_number: 70
+    geography_id: 0400000US20
+    geography_level: state
+    geography_name: Kansas
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Kansas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: kansas_aged
+    label: Kansas aged SSI
+    ordinal: 69
+    row_number: 71
+    geography_id: 0400000US20
+    geography_level: state
+    geography_name: Kansas
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Kansas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: kansas_blind
+    label: Kansas blind SSI
+    ordinal: 70
+    row_number: 72
+    geography_id: 0400000US20
+    geography_level: state
+    geography_name: Kansas
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Kansas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: kansas_disabled
+    label: Kansas disabled SSI
+    ordinal: 71
+    row_number: 73
+    geography_id: 0400000US20
+    geography_level: state
+    geography_name: Kansas
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Kansas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: kentucky_total
+    label: Kentucky total SSI
+    ordinal: 72
+    row_number: 74
+    geography_id: 0400000US21
+    geography_level: state
+    geography_name: Kentucky
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Kentucky
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: kentucky_aged
+    label: Kentucky aged SSI
+    ordinal: 73
+    row_number: 75
+    geography_id: 0400000US21
+    geography_level: state
+    geography_name: Kentucky
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Kentucky
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: kentucky_blind
+    label: Kentucky blind SSI
+    ordinal: 74
+    row_number: 76
+    geography_id: 0400000US21
+    geography_level: state
+    geography_name: Kentucky
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Kentucky
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: kentucky_disabled
+    label: Kentucky disabled SSI
+    ordinal: 75
+    row_number: 77
+    geography_id: 0400000US21
+    geography_level: state
+    geography_name: Kentucky
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Kentucky
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: louisiana_total
+    label: Louisiana total SSI
+    ordinal: 76
+    row_number: 78
+    geography_id: 0400000US22
+    geography_level: state
+    geography_name: Louisiana
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Louisiana
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: louisiana_aged
+    label: Louisiana aged SSI
+    ordinal: 77
+    row_number: 79
+    geography_id: 0400000US22
+    geography_level: state
+    geography_name: Louisiana
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Louisiana
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: louisiana_blind
+    label: Louisiana blind SSI
+    ordinal: 78
+    row_number: 80
+    geography_id: 0400000US22
+    geography_level: state
+    geography_name: Louisiana
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Louisiana
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: louisiana_disabled
+    label: Louisiana disabled SSI
+    ordinal: 79
+    row_number: 81
+    geography_id: 0400000US22
+    geography_level: state
+    geography_name: Louisiana
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Louisiana
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: maine_total
+    label: Maine total SSI
+    ordinal: 80
+    row_number: 82
+    geography_id: 0400000US23
+    geography_level: state
+    geography_name: Maine
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Maine
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: maine_aged
+    label: Maine aged SSI
+    ordinal: 81
+    row_number: 83
+    geography_id: 0400000US23
+    geography_level: state
+    geography_name: Maine
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Maine
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: maine_blind
+    label: Maine blind SSI
+    ordinal: 82
+    row_number: 84
+    geography_id: 0400000US23
+    geography_level: state
+    geography_name: Maine
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Maine
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: maine_disabled
+    label: Maine disabled SSI
+    ordinal: 83
+    row_number: 85
+    geography_id: 0400000US23
+    geography_level: state
+    geography_name: Maine
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Maine
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: maryland_total
+    label: Maryland total SSI
+    ordinal: 84
+    row_number: 86
+    geography_id: 0400000US24
+    geography_level: state
+    geography_name: Maryland
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Maryland
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: maryland_aged
+    label: Maryland aged SSI
+    ordinal: 85
+    row_number: 87
+    geography_id: 0400000US24
+    geography_level: state
+    geography_name: Maryland
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Maryland
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: maryland_blind
+    label: Maryland blind SSI
+    ordinal: 86
+    row_number: 88
+    geography_id: 0400000US24
+    geography_level: state
+    geography_name: Maryland
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Maryland
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: maryland_disabled
+    label: Maryland disabled SSI
+    ordinal: 87
+    row_number: 89
+    geography_id: 0400000US24
+    geography_level: state
+    geography_name: Maryland
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Maryland
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: massachusetts_total
+    label: Massachusetts total SSI
+    ordinal: 88
+    row_number: 90
+    geography_id: 0400000US25
+    geography_level: state
+    geography_name: Massachusetts
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Massachusetts
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: massachusetts_aged
+    label: Massachusetts aged SSI
+    ordinal: 89
+    row_number: 91
+    geography_id: 0400000US25
+    geography_level: state
+    geography_name: Massachusetts
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Massachusetts
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: massachusetts_blind
+    label: Massachusetts blind SSI
+    ordinal: 90
+    row_number: 92
+    geography_id: 0400000US25
+    geography_level: state
+    geography_name: Massachusetts
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Massachusetts
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: massachusetts_disabled
+    label: Massachusetts disabled SSI
+    ordinal: 91
+    row_number: 93
+    geography_id: 0400000US25
+    geography_level: state
+    geography_name: Massachusetts
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Massachusetts
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: michigan_total
+    label: Michigan total SSI
+    ordinal: 92
+    row_number: 94
+    geography_id: 0400000US26
+    geography_level: state
+    geography_name: Michigan
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Michigan
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: michigan_aged
+    label: Michigan aged SSI
+    ordinal: 93
+    row_number: 95
+    geography_id: 0400000US26
+    geography_level: state
+    geography_name: Michigan
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Michigan
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: michigan_blind
+    label: Michigan blind SSI
+    ordinal: 94
+    row_number: 96
+    geography_id: 0400000US26
+    geography_level: state
+    geography_name: Michigan
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Michigan
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: michigan_disabled
+    label: Michigan disabled SSI
+    ordinal: 95
+    row_number: 97
+    geography_id: 0400000US26
+    geography_level: state
+    geography_name: Michigan
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Michigan
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: minnesota_total
+    label: Minnesota total SSI
+    ordinal: 96
+    row_number: 98
+    geography_id: 0400000US27
+    geography_level: state
+    geography_name: Minnesota
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Minnesota
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: minnesota_aged
+    label: Minnesota aged SSI
+    ordinal: 97
+    row_number: 99
+    geography_id: 0400000US27
+    geography_level: state
+    geography_name: Minnesota
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Minnesota
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: minnesota_blind
+    label: Minnesota blind SSI
+    ordinal: 98
+    row_number: 100
+    geography_id: 0400000US27
+    geography_level: state
+    geography_name: Minnesota
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Minnesota
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: minnesota_disabled
+    label: Minnesota disabled SSI
+    ordinal: 99
+    row_number: 101
+    geography_id: 0400000US27
+    geography_level: state
+    geography_name: Minnesota
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Minnesota
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: mississippi_total
+    label: Mississippi total SSI
+    ordinal: 100
+    row_number: 102
+    geography_id: 0400000US28
+    geography_level: state
+    geography_name: Mississippi
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Mississippi
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: mississippi_aged
+    label: Mississippi aged SSI
+    ordinal: 101
+    row_number: 103
+    geography_id: 0400000US28
+    geography_level: state
+    geography_name: Mississippi
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Mississippi
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: mississippi_blind
+    label: Mississippi blind SSI
+    ordinal: 102
+    row_number: 104
+    geography_id: 0400000US28
+    geography_level: state
+    geography_name: Mississippi
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Mississippi
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: mississippi_disabled
+    label: Mississippi disabled SSI
+    ordinal: 103
+    row_number: 105
+    geography_id: 0400000US28
+    geography_level: state
+    geography_name: Mississippi
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Mississippi
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: missouri_total
+    label: Missouri total SSI
+    ordinal: 104
+    row_number: 106
+    geography_id: 0400000US29
+    geography_level: state
+    geography_name: Missouri
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Missouri
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: missouri_aged
+    label: Missouri aged SSI
+    ordinal: 105
+    row_number: 107
+    geography_id: 0400000US29
+    geography_level: state
+    geography_name: Missouri
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Missouri
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: missouri_blind
+    label: Missouri blind SSI
+    ordinal: 106
+    row_number: 108
+    geography_id: 0400000US29
+    geography_level: state
+    geography_name: Missouri
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Missouri
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: missouri_disabled
+    label: Missouri disabled SSI
+    ordinal: 107
+    row_number: 109
+    geography_id: 0400000US29
+    geography_level: state
+    geography_name: Missouri
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Missouri
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: montana_total
+    label: Montana total SSI
+    ordinal: 108
+    row_number: 110
+    geography_id: 0400000US30
+    geography_level: state
+    geography_name: Montana
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Montana
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: montana_aged
+    label: Montana aged SSI
+    ordinal: 109
+    row_number: 111
+    geography_id: 0400000US30
+    geography_level: state
+    geography_name: Montana
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Montana
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: montana_blind
+    label: Montana blind SSI
+    ordinal: 110
+    row_number: 112
+    geography_id: 0400000US30
+    geography_level: state
+    geography_name: Montana
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Montana
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: montana_disabled
+    label: Montana disabled SSI
+    ordinal: 111
+    row_number: 113
+    geography_id: 0400000US30
+    geography_level: state
+    geography_name: Montana
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Montana
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: nebraska_total
+    label: Nebraska total SSI
+    ordinal: 112
+    row_number: 114
+    geography_id: 0400000US31
+    geography_level: state
+    geography_name: Nebraska
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Nebraska
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: nebraska_aged
+    label: Nebraska aged SSI
+    ordinal: 113
+    row_number: 115
+    geography_id: 0400000US31
+    geography_level: state
+    geography_name: Nebraska
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Nebraska
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: nebraska_blind
+    label: Nebraska blind SSI
+    ordinal: 114
+    row_number: 116
+    geography_id: 0400000US31
+    geography_level: state
+    geography_name: Nebraska
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Nebraska
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: nebraska_disabled
+    label: Nebraska disabled SSI
+    ordinal: 115
+    row_number: 117
+    geography_id: 0400000US31
+    geography_level: state
+    geography_name: Nebraska
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Nebraska
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: nevada_total
+    label: Nevada total SSI
+    ordinal: 116
+    row_number: 118
+    geography_id: 0400000US32
+    geography_level: state
+    geography_name: Nevada
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Nevada
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: nevada_aged
+    label: Nevada aged SSI
+    ordinal: 117
+    row_number: 119
+    geography_id: 0400000US32
+    geography_level: state
+    geography_name: Nevada
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Nevada
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: nevada_blind
+    label: Nevada blind SSI
+    ordinal: 118
+    row_number: 120
+    geography_id: 0400000US32
+    geography_level: state
+    geography_name: Nevada
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Nevada
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: nevada_disabled
+    label: Nevada disabled SSI
+    ordinal: 119
+    row_number: 121
+    geography_id: 0400000US32
+    geography_level: state
+    geography_name: Nevada
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Nevada
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: new_hampshire_total
+    label: New Hampshire total SSI
+    ordinal: 120
+    row_number: 122
+    geography_id: 0400000US33
+    geography_level: state
+    geography_name: New Hampshire
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: New Hampshire
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: new_hampshire_aged
+    label: New Hampshire aged SSI
+    ordinal: 121
+    row_number: 123
+    geography_id: 0400000US33
+    geography_level: state
+    geography_name: New Hampshire
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: New Hampshire
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: new_hampshire_blind
+    label: New Hampshire blind SSI
+    ordinal: 122
+    row_number: 124
+    geography_id: 0400000US33
+    geography_level: state
+    geography_name: New Hampshire
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: New Hampshire
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: new_hampshire_disabled
+    label: New Hampshire disabled SSI
+    ordinal: 123
+    row_number: 125
+    geography_id: 0400000US33
+    geography_level: state
+    geography_name: New Hampshire
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: New Hampshire
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: new_jersey_total
+    label: New Jersey total SSI
+    ordinal: 124
+    row_number: 126
+    geography_id: 0400000US34
+    geography_level: state
+    geography_name: New Jersey
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: New Jersey
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: new_jersey_aged
+    label: New Jersey aged SSI
+    ordinal: 125
+    row_number: 127
+    geography_id: 0400000US34
+    geography_level: state
+    geography_name: New Jersey
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: New Jersey
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: new_jersey_blind
+    label: New Jersey blind SSI
+    ordinal: 126
+    row_number: 128
+    geography_id: 0400000US34
+    geography_level: state
+    geography_name: New Jersey
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: New Jersey
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: new_jersey_disabled
+    label: New Jersey disabled SSI
+    ordinal: 127
+    row_number: 129
+    geography_id: 0400000US34
+    geography_level: state
+    geography_name: New Jersey
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: New Jersey
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: new_mexico_total
+    label: New Mexico total SSI
+    ordinal: 128
+    row_number: 130
+    geography_id: 0400000US35
+    geography_level: state
+    geography_name: New Mexico
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: New Mexico
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: new_mexico_aged
+    label: New Mexico aged SSI
+    ordinal: 129
+    row_number: 131
+    geography_id: 0400000US35
+    geography_level: state
+    geography_name: New Mexico
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: New Mexico
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: new_mexico_blind
+    label: New Mexico blind SSI
+    ordinal: 130
+    row_number: 132
+    geography_id: 0400000US35
+    geography_level: state
+    geography_name: New Mexico
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: New Mexico
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: new_mexico_disabled
+    label: New Mexico disabled SSI
+    ordinal: 131
+    row_number: 133
+    geography_id: 0400000US35
+    geography_level: state
+    geography_name: New Mexico
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: New Mexico
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: new_york_total
+    label: New York total SSI
+    ordinal: 132
+    row_number: 134
+    geography_id: 0400000US36
+    geography_level: state
+    geography_name: New York
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: New York
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: new_york_aged
+    label: New York aged SSI
+    ordinal: 133
+    row_number: 135
+    geography_id: 0400000US36
+    geography_level: state
+    geography_name: New York
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: New York
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: new_york_blind
+    label: New York blind SSI
+    ordinal: 134
+    row_number: 136
+    geography_id: 0400000US36
+    geography_level: state
+    geography_name: New York
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: New York
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: new_york_disabled
+    label: New York disabled SSI
+    ordinal: 135
+    row_number: 137
+    geography_id: 0400000US36
+    geography_level: state
+    geography_name: New York
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: New York
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: north_carolina_total
+    label: North Carolina total SSI
+    ordinal: 136
+    row_number: 138
+    geography_id: 0400000US37
+    geography_level: state
+    geography_name: North Carolina
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: North Carolina
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: north_carolina_aged
+    label: North Carolina aged SSI
+    ordinal: 137
+    row_number: 139
+    geography_id: 0400000US37
+    geography_level: state
+    geography_name: North Carolina
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: North Carolina
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: north_carolina_blind
+    label: North Carolina blind SSI
+    ordinal: 138
+    row_number: 140
+    geography_id: 0400000US37
+    geography_level: state
+    geography_name: North Carolina
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: North Carolina
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: north_carolina_disabled
+    label: North Carolina disabled SSI
+    ordinal: 139
+    row_number: 141
+    geography_id: 0400000US37
+    geography_level: state
+    geography_name: North Carolina
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: North Carolina
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: north_dakota_total
+    label: North Dakota total SSI
+    ordinal: 140
+    row_number: 142
+    geography_id: 0400000US38
+    geography_level: state
+    geography_name: North Dakota
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: North Dakota
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: north_dakota_aged
+    label: North Dakota aged SSI
+    ordinal: 141
+    row_number: 143
+    geography_id: 0400000US38
+    geography_level: state
+    geography_name: North Dakota
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: North Dakota
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: north_dakota_blind
+    label: North Dakota blind SSI
+    ordinal: 142
+    row_number: 144
+    geography_id: 0400000US38
+    geography_level: state
+    geography_name: North Dakota
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: North Dakota
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: north_dakota_disabled
+    label: North Dakota disabled SSI
+    ordinal: 143
+    row_number: 145
+    geography_id: 0400000US38
+    geography_level: state
+    geography_name: North Dakota
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: North Dakota
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: ohio_total
+    label: Ohio total SSI
+    ordinal: 144
+    row_number: 146
+    geography_id: 0400000US39
+    geography_level: state
+    geography_name: Ohio
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Ohio
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: ohio_aged
+    label: Ohio aged SSI
+    ordinal: 145
+    row_number: 147
+    geography_id: 0400000US39
+    geography_level: state
+    geography_name: Ohio
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Ohio
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: ohio_blind
+    label: Ohio blind SSI
+    ordinal: 146
+    row_number: 148
+    geography_id: 0400000US39
+    geography_level: state
+    geography_name: Ohio
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Ohio
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: ohio_disabled
+    label: Ohio disabled SSI
+    ordinal: 147
+    row_number: 149
+    geography_id: 0400000US39
+    geography_level: state
+    geography_name: Ohio
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Ohio
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: oklahoma_total
+    label: Oklahoma total SSI
+    ordinal: 148
+    row_number: 150
+    geography_id: 0400000US40
+    geography_level: state
+    geography_name: Oklahoma
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Oklahoma
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: oklahoma_aged
+    label: Oklahoma aged SSI
+    ordinal: 149
+    row_number: 151
+    geography_id: 0400000US40
+    geography_level: state
+    geography_name: Oklahoma
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Oklahoma
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: oklahoma_blind
+    label: Oklahoma blind SSI
+    ordinal: 150
+    row_number: 152
+    geography_id: 0400000US40
+    geography_level: state
+    geography_name: Oklahoma
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Oklahoma
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: oklahoma_disabled
+    label: Oklahoma disabled SSI
+    ordinal: 151
+    row_number: 153
+    geography_id: 0400000US40
+    geography_level: state
+    geography_name: Oklahoma
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Oklahoma
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: oregon_total
+    label: Oregon total SSI
+    ordinal: 152
+    row_number: 154
+    geography_id: 0400000US41
+    geography_level: state
+    geography_name: Oregon
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Oregon
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: oregon_aged
+    label: Oregon aged SSI
+    ordinal: 153
+    row_number: 155
+    geography_id: 0400000US41
+    geography_level: state
+    geography_name: Oregon
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Oregon
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: oregon_blind
+    label: Oregon blind SSI
+    ordinal: 154
+    row_number: 156
+    geography_id: 0400000US41
+    geography_level: state
+    geography_name: Oregon
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Oregon
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: oregon_disabled
+    label: Oregon disabled SSI
+    ordinal: 155
+    row_number: 157
+    geography_id: 0400000US41
+    geography_level: state
+    geography_name: Oregon
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Oregon
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: pennsylvania_total
+    label: Pennsylvania total SSI
+    ordinal: 156
+    row_number: 158
+    geography_id: 0400000US42
+    geography_level: state
+    geography_name: Pennsylvania
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Pennsylvania
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: pennsylvania_aged
+    label: Pennsylvania aged SSI
+    ordinal: 157
+    row_number: 159
+    geography_id: 0400000US42
+    geography_level: state
+    geography_name: Pennsylvania
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Pennsylvania
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: pennsylvania_blind
+    label: Pennsylvania blind SSI
+    ordinal: 158
+    row_number: 160
+    geography_id: 0400000US42
+    geography_level: state
+    geography_name: Pennsylvania
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Pennsylvania
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: pennsylvania_disabled
+    label: Pennsylvania disabled SSI
+    ordinal: 159
+    row_number: 161
+    geography_id: 0400000US42
+    geography_level: state
+    geography_name: Pennsylvania
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Pennsylvania
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: rhode_island_total
+    label: Rhode Island total SSI
+    ordinal: 160
+    row_number: 162
+    geography_id: 0400000US44
+    geography_level: state
+    geography_name: Rhode Island
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Rhode Island
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: rhode_island_aged
+    label: Rhode Island aged SSI
+    ordinal: 161
+    row_number: 163
+    geography_id: 0400000US44
+    geography_level: state
+    geography_name: Rhode Island
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Rhode Island
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: rhode_island_blind
+    label: Rhode Island blind SSI
+    ordinal: 162
+    row_number: 164
+    geography_id: 0400000US44
+    geography_level: state
+    geography_name: Rhode Island
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Rhode Island
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: rhode_island_disabled
+    label: Rhode Island disabled SSI
+    ordinal: 163
+    row_number: 165
+    geography_id: 0400000US44
+    geography_level: state
+    geography_name: Rhode Island
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Rhode Island
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: south_carolina_total
+    label: South Carolina total SSI
+    ordinal: 164
+    row_number: 166
+    geography_id: 0400000US45
+    geography_level: state
+    geography_name: South Carolina
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: South Carolina
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: south_carolina_aged
+    label: South Carolina aged SSI
+    ordinal: 165
+    row_number: 167
+    geography_id: 0400000US45
+    geography_level: state
+    geography_name: South Carolina
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: South Carolina
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: south_carolina_blind
+    label: South Carolina blind SSI
+    ordinal: 166
+    row_number: 168
+    geography_id: 0400000US45
+    geography_level: state
+    geography_name: South Carolina
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: South Carolina
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: south_carolina_disabled
+    label: South Carolina disabled SSI
+    ordinal: 167
+    row_number: 169
+    geography_id: 0400000US45
+    geography_level: state
+    geography_name: South Carolina
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: South Carolina
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: south_dakota_total
+    label: South Dakota total SSI
+    ordinal: 168
+    row_number: 170
+    geography_id: 0400000US46
+    geography_level: state
+    geography_name: South Dakota
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: South Dakota
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: south_dakota_aged
+    label: South Dakota aged SSI
+    ordinal: 169
+    row_number: 171
+    geography_id: 0400000US46
+    geography_level: state
+    geography_name: South Dakota
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: South Dakota
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: south_dakota_blind
+    label: South Dakota blind SSI
+    ordinal: 170
+    row_number: 172
+    geography_id: 0400000US46
+    geography_level: state
+    geography_name: South Dakota
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: South Dakota
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: south_dakota_disabled
+    label: South Dakota disabled SSI
+    ordinal: 171
+    row_number: 173
+    geography_id: 0400000US46
+    geography_level: state
+    geography_name: South Dakota
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: South Dakota
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: tennessee_total
+    label: Tennessee total SSI
+    ordinal: 172
+    row_number: 174
+    geography_id: 0400000US47
+    geography_level: state
+    geography_name: Tennessee
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Tennessee
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: tennessee_aged
+    label: Tennessee aged SSI
+    ordinal: 173
+    row_number: 175
+    geography_id: 0400000US47
+    geography_level: state
+    geography_name: Tennessee
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Tennessee
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: tennessee_blind
+    label: Tennessee blind SSI
+    ordinal: 174
+    row_number: 176
+    geography_id: 0400000US47
+    geography_level: state
+    geography_name: Tennessee
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Tennessee
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: tennessee_disabled
+    label: Tennessee disabled SSI
+    ordinal: 175
+    row_number: 177
+    geography_id: 0400000US47
+    geography_level: state
+    geography_name: Tennessee
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Tennessee
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: texas_total
+    label: Texas total SSI
+    ordinal: 176
+    row_number: 178
+    geography_id: 0400000US48
+    geography_level: state
+    geography_name: Texas
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Texas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: texas_aged
+    label: Texas aged SSI
+    ordinal: 177
+    row_number: 179
+    geography_id: 0400000US48
+    geography_level: state
+    geography_name: Texas
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Texas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: texas_blind
+    label: Texas blind SSI
+    ordinal: 178
+    row_number: 180
+    geography_id: 0400000US48
+    geography_level: state
+    geography_name: Texas
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Texas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: texas_disabled
+    label: Texas disabled SSI
+    ordinal: 179
+    row_number: 181
+    geography_id: 0400000US48
+    geography_level: state
+    geography_name: Texas
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Texas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: utah_total
+    label: Utah total SSI
+    ordinal: 180
+    row_number: 182
+    geography_id: 0400000US49
+    geography_level: state
+    geography_name: Utah
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Utah
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: utah_aged
+    label: Utah aged SSI
+    ordinal: 181
+    row_number: 183
+    geography_id: 0400000US49
+    geography_level: state
+    geography_name: Utah
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Utah
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: utah_blind
+    label: Utah blind SSI
+    ordinal: 182
+    row_number: 184
+    geography_id: 0400000US49
+    geography_level: state
+    geography_name: Utah
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Utah
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: utah_disabled
+    label: Utah disabled SSI
+    ordinal: 183
+    row_number: 185
+    geography_id: 0400000US49
+    geography_level: state
+    geography_name: Utah
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Utah
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: vermont_total
+    label: Vermont total SSI
+    ordinal: 184
+    row_number: 186
+    geography_id: 0400000US50
+    geography_level: state
+    geography_name: Vermont
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Vermont
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: vermont_aged
+    label: Vermont aged SSI
+    ordinal: 185
+    row_number: 187
+    geography_id: 0400000US50
+    geography_level: state
+    geography_name: Vermont
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Vermont
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: vermont_blind
+    label: Vermont blind SSI
+    ordinal: 186
+    row_number: 188
+    geography_id: 0400000US50
+    geography_level: state
+    geography_name: Vermont
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Vermont
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: vermont_disabled
+    label: Vermont disabled SSI
+    ordinal: 187
+    row_number: 189
+    geography_id: 0400000US50
+    geography_level: state
+    geography_name: Vermont
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Vermont
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: virginia_total
+    label: Virginia total SSI
+    ordinal: 188
+    row_number: 190
+    geography_id: 0400000US51
+    geography_level: state
+    geography_name: Virginia
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Virginia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: virginia_aged
+    label: Virginia aged SSI
+    ordinal: 189
+    row_number: 191
+    geography_id: 0400000US51
+    geography_level: state
+    geography_name: Virginia
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Virginia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: virginia_blind
+    label: Virginia blind SSI
+    ordinal: 190
+    row_number: 192
+    geography_id: 0400000US51
+    geography_level: state
+    geography_name: Virginia
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Virginia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: virginia_disabled
+    label: Virginia disabled SSI
+    ordinal: 191
+    row_number: 193
+    geography_id: 0400000US51
+    geography_level: state
+    geography_name: Virginia
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Virginia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: washington_total
+    label: Washington total SSI
+    ordinal: 192
+    row_number: 194
+    geography_id: 0400000US53
+    geography_level: state
+    geography_name: Washington
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Washington
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: washington_aged
+    label: Washington aged SSI
+    ordinal: 193
+    row_number: 195
+    geography_id: 0400000US53
+    geography_level: state
+    geography_name: Washington
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Washington
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: washington_blind
+    label: Washington blind SSI
+    ordinal: 194
+    row_number: 196
+    geography_id: 0400000US53
+    geography_level: state
+    geography_name: Washington
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Washington
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: washington_disabled
+    label: Washington disabled SSI
+    ordinal: 195
+    row_number: 197
+    geography_id: 0400000US53
+    geography_level: state
+    geography_name: Washington
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Washington
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: west_virginia_total
+    label: West Virginia total SSI
+    ordinal: 196
+    row_number: 198
+    geography_id: 0400000US54
+    geography_level: state
+    geography_name: West Virginia
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: West Virginia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: west_virginia_aged
+    label: West Virginia aged SSI
+    ordinal: 197
+    row_number: 199
+    geography_id: 0400000US54
+    geography_level: state
+    geography_name: West Virginia
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: West Virginia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: west_virginia_blind
+    label: West Virginia blind SSI
+    ordinal: 198
+    row_number: 200
+    geography_id: 0400000US54
+    geography_level: state
+    geography_name: West Virginia
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: West Virginia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: west_virginia_disabled
+    label: West Virginia disabled SSI
+    ordinal: 199
+    row_number: 201
+    geography_id: 0400000US54
+    geography_level: state
+    geography_name: West Virginia
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: West Virginia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: wisconsin_total
+    label: Wisconsin total SSI
+    ordinal: 200
+    row_number: 202
+    geography_id: 0400000US55
+    geography_level: state
+    geography_name: Wisconsin
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Wisconsin
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: wisconsin_aged
+    label: Wisconsin aged SSI
+    ordinal: 201
+    row_number: 203
+    geography_id: 0400000US55
+    geography_level: state
+    geography_name: Wisconsin
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Wisconsin
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: wisconsin_blind
+    label: Wisconsin blind SSI
+    ordinal: 202
+    row_number: 204
+    geography_id: 0400000US55
+    geography_level: state
+    geography_name: Wisconsin
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Wisconsin
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: wisconsin_disabled
+    label: Wisconsin disabled SSI
+    ordinal: 203
+    row_number: 205
+    geography_id: 0400000US55
+    geography_level: state
+    geography_name: Wisconsin
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Wisconsin
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: wyoming_total
+    label: Wyoming total SSI
+    ordinal: 204
+    row_number: 206
+    geography_id: 0400000US56
+    geography_level: state
+    geography_name: Wyoming
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Wyoming
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: wyoming_aged
+    label: Wyoming aged SSI
+    ordinal: 205
+    row_number: 207
+    geography_id: 0400000US56
+    geography_level: state
+    geography_name: Wyoming
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Wyoming
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: wyoming_blind
+    label: Wyoming blind SSI
+    ordinal: 206
+    row_number: 208
+    geography_id: 0400000US56
+    geography_level: state
+    geography_name: Wyoming
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Wyoming
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: wyoming_disabled
+    label: Wyoming disabled SSI
+    ordinal: 207
+    row_number: 209
+    geography_id: 0400000US56
+    geography_level: state
+    geography_name: Wyoming
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Wyoming
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  record_set_id: ssa_supplement.cy2024.ssi_recipients.by_area_category
+  record_set_spec_id: ssa_supplement.ssi_recipients.by_area_category.v1
+  source_record_id_prefix: ssa_supplement.cy2024.ssi_recipients.by_area_category
+  measures:
+  - measure_id: recipient_count
+    label: SSI recipients
+    ordinal: 0
+    column: G
+    source_column_id: recipient_count
+    concept: ssa.ssi_recipient_count
+    source_concept: ssa_supplement.table_7b1.recipient_count
+    concept_relation: exact
+    concept_authority: arch-us
+    concept_evidence_url: https://www.ssa.gov/policy/docs/statcomps/supplement/2025/7b.html
+    concept_evidence_notes: SSA Annual Statistical Supplement 2025 Table 7.B1 reports federally administered SSI recipients for December 2024 by area and eligibility category.
+    unit: count
+    aggregation: count
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: recipient_count
+  groupby_dimension: ssi_category
+- sheet_name: ssi_table_7b1_2024
+  period_type: calendar_year
+  period: 2024
+  geography_id: 0100000US
+  geography_level: country
+  geography_name: United States
+  geography_vintage: current
+  entity: person
+  entity_role: ssi_recipient
+  domain: social_security_and_ssi_payments
+  rows:
+  - value_id: all_areas_total
+    label: All areas total SSI
+    ordinal: 0
+    row_number: 2
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: All areas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: all_areas_aged
+    label: All areas aged SSI
+    ordinal: 1
+    row_number: 3
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: All areas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: all_areas_blind
+    label: All areas blind SSI
+    ordinal: 2
+    row_number: 4
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: All areas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: all_areas_disabled
+    label: All areas disabled SSI
+    ordinal: 3
+    row_number: 5
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: All areas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: alabama_total
+    label: Alabama total SSI
+    ordinal: 4
+    row_number: 6
+    geography_id: 0400000US01
+    geography_level: state
+    geography_name: Alabama
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Alabama
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: alabama_aged
+    label: Alabama aged SSI
+    ordinal: 5
+    row_number: 7
+    geography_id: 0400000US01
+    geography_level: state
+    geography_name: Alabama
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Alabama
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: alabama_blind
+    label: Alabama blind SSI
+    ordinal: 6
+    row_number: 8
+    geography_id: 0400000US01
+    geography_level: state
+    geography_name: Alabama
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Alabama
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: alabama_disabled
+    label: Alabama disabled SSI
+    ordinal: 7
+    row_number: 9
+    geography_id: 0400000US01
+    geography_level: state
+    geography_name: Alabama
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Alabama
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: alaska_total
+    label: Alaska total SSI
+    ordinal: 8
+    row_number: 10
+    geography_id: 0400000US02
+    geography_level: state
+    geography_name: Alaska
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Alaska
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: alaska_aged
+    label: Alaska aged SSI
+    ordinal: 9
+    row_number: 11
+    geography_id: 0400000US02
+    geography_level: state
+    geography_name: Alaska
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Alaska
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: alaska_blind
+    label: Alaska blind SSI
+    ordinal: 10
+    row_number: 12
+    geography_id: 0400000US02
+    geography_level: state
+    geography_name: Alaska
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Alaska
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: alaska_disabled
+    label: Alaska disabled SSI
+    ordinal: 11
+    row_number: 13
+    geography_id: 0400000US02
+    geography_level: state
+    geography_name: Alaska
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Alaska
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: arizona_total
+    label: Arizona total SSI
+    ordinal: 12
+    row_number: 14
+    geography_id: 0400000US04
+    geography_level: state
+    geography_name: Arizona
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Arizona
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: arizona_aged
+    label: Arizona aged SSI
+    ordinal: 13
+    row_number: 15
+    geography_id: 0400000US04
+    geography_level: state
+    geography_name: Arizona
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Arizona
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: arizona_blind
+    label: Arizona blind SSI
+    ordinal: 14
+    row_number: 16
+    geography_id: 0400000US04
+    geography_level: state
+    geography_name: Arizona
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Arizona
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: arizona_disabled
+    label: Arizona disabled SSI
+    ordinal: 15
+    row_number: 17
+    geography_id: 0400000US04
+    geography_level: state
+    geography_name: Arizona
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Arizona
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: arkansas_total
+    label: Arkansas total SSI
+    ordinal: 16
+    row_number: 18
+    geography_id: 0400000US05
+    geography_level: state
+    geography_name: Arkansas
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Arkansas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: arkansas_aged
+    label: Arkansas aged SSI
+    ordinal: 17
+    row_number: 19
+    geography_id: 0400000US05
+    geography_level: state
+    geography_name: Arkansas
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Arkansas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: arkansas_blind
+    label: Arkansas blind SSI
+    ordinal: 18
+    row_number: 20
+    geography_id: 0400000US05
+    geography_level: state
+    geography_name: Arkansas
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Arkansas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: arkansas_disabled
+    label: Arkansas disabled SSI
+    ordinal: 19
+    row_number: 21
+    geography_id: 0400000US05
+    geography_level: state
+    geography_name: Arkansas
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Arkansas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: california_total
+    label: California total SSI
+    ordinal: 20
+    row_number: 22
+    geography_id: 0400000US06
+    geography_level: state
+    geography_name: California
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: California
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: california_aged
+    label: California aged SSI
+    ordinal: 21
+    row_number: 23
+    geography_id: 0400000US06
+    geography_level: state
+    geography_name: California
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: California
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: california_blind
+    label: California blind SSI
+    ordinal: 22
+    row_number: 24
+    geography_id: 0400000US06
+    geography_level: state
+    geography_name: California
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: California
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: california_disabled
+    label: California disabled SSI
+    ordinal: 23
+    row_number: 25
+    geography_id: 0400000US06
+    geography_level: state
+    geography_name: California
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: California
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: colorado_total
+    label: Colorado total SSI
+    ordinal: 24
+    row_number: 26
+    geography_id: 0400000US08
+    geography_level: state
+    geography_name: Colorado
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Colorado
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: colorado_aged
+    label: Colorado aged SSI
+    ordinal: 25
+    row_number: 27
+    geography_id: 0400000US08
+    geography_level: state
+    geography_name: Colorado
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Colorado
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: colorado_blind
+    label: Colorado blind SSI
+    ordinal: 26
+    row_number: 28
+    geography_id: 0400000US08
+    geography_level: state
+    geography_name: Colorado
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Colorado
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: colorado_disabled
+    label: Colorado disabled SSI
+    ordinal: 27
+    row_number: 29
+    geography_id: 0400000US08
+    geography_level: state
+    geography_name: Colorado
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Colorado
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: connecticut_total
+    label: Connecticut total SSI
+    ordinal: 28
+    row_number: 30
+    geography_id: 0400000US09
+    geography_level: state
+    geography_name: Connecticut
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Connecticut
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: connecticut_aged
+    label: Connecticut aged SSI
+    ordinal: 29
+    row_number: 31
+    geography_id: 0400000US09
+    geography_level: state
+    geography_name: Connecticut
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Connecticut
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: connecticut_blind
+    label: Connecticut blind SSI
+    ordinal: 30
+    row_number: 32
+    geography_id: 0400000US09
+    geography_level: state
+    geography_name: Connecticut
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Connecticut
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: connecticut_disabled
+    label: Connecticut disabled SSI
+    ordinal: 31
+    row_number: 33
+    geography_id: 0400000US09
+    geography_level: state
+    geography_name: Connecticut
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Connecticut
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: delaware_total
+    label: Delaware total SSI
+    ordinal: 32
+    row_number: 34
+    geography_id: 0400000US10
+    geography_level: state
+    geography_name: Delaware
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Delaware
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: delaware_aged
+    label: Delaware aged SSI
+    ordinal: 33
+    row_number: 35
+    geography_id: 0400000US10
+    geography_level: state
+    geography_name: Delaware
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Delaware
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: delaware_blind
+    label: Delaware blind SSI
+    ordinal: 34
+    row_number: 36
+    geography_id: 0400000US10
+    geography_level: state
+    geography_name: Delaware
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Delaware
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: delaware_disabled
+    label: Delaware disabled SSI
+    ordinal: 35
+    row_number: 37
+    geography_id: 0400000US10
+    geography_level: state
+    geography_name: Delaware
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Delaware
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: district_of_columbia_total
+    label: District of Columbia total SSI
+    ordinal: 36
+    row_number: 38
+    geography_id: 0400000US11
+    geography_level: state
+    geography_name: District of Columbia
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: District of Columbia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: district_of_columbia_aged
+    label: District of Columbia aged SSI
+    ordinal: 37
+    row_number: 39
+    geography_id: 0400000US11
+    geography_level: state
+    geography_name: District of Columbia
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: District of Columbia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: district_of_columbia_blind
+    label: District of Columbia blind SSI
+    ordinal: 38
+    row_number: 40
+    geography_id: 0400000US11
+    geography_level: state
+    geography_name: District of Columbia
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: District of Columbia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: district_of_columbia_disabled
+    label: District of Columbia disabled SSI
+    ordinal: 39
+    row_number: 41
+    geography_id: 0400000US11
+    geography_level: state
+    geography_name: District of Columbia
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: District of Columbia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: florida_total
+    label: Florida total SSI
+    ordinal: 40
+    row_number: 42
+    geography_id: 0400000US12
+    geography_level: state
+    geography_name: Florida
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Florida
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: florida_aged
+    label: Florida aged SSI
+    ordinal: 41
+    row_number: 43
+    geography_id: 0400000US12
+    geography_level: state
+    geography_name: Florida
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Florida
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: florida_blind
+    label: Florida blind SSI
+    ordinal: 42
+    row_number: 44
+    geography_id: 0400000US12
+    geography_level: state
+    geography_name: Florida
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Florida
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: florida_disabled
+    label: Florida disabled SSI
+    ordinal: 43
+    row_number: 45
+    geography_id: 0400000US12
+    geography_level: state
+    geography_name: Florida
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Florida
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: georgia_total
+    label: Georgia total SSI
+    ordinal: 44
+    row_number: 46
+    geography_id: 0400000US13
+    geography_level: state
+    geography_name: Georgia
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Georgia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: georgia_aged
+    label: Georgia aged SSI
+    ordinal: 45
+    row_number: 47
+    geography_id: 0400000US13
+    geography_level: state
+    geography_name: Georgia
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Georgia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: georgia_blind
+    label: Georgia blind SSI
+    ordinal: 46
+    row_number: 48
+    geography_id: 0400000US13
+    geography_level: state
+    geography_name: Georgia
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Georgia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: georgia_disabled
+    label: Georgia disabled SSI
+    ordinal: 47
+    row_number: 49
+    geography_id: 0400000US13
+    geography_level: state
+    geography_name: Georgia
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Georgia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: hawaii_total
+    label: Hawaii total SSI
+    ordinal: 48
+    row_number: 50
+    geography_id: 0400000US15
+    geography_level: state
+    geography_name: Hawaii
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Hawaii
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: hawaii_aged
+    label: Hawaii aged SSI
+    ordinal: 49
+    row_number: 51
+    geography_id: 0400000US15
+    geography_level: state
+    geography_name: Hawaii
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Hawaii
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: hawaii_blind
+    label: Hawaii blind SSI
+    ordinal: 50
+    row_number: 52
+    geography_id: 0400000US15
+    geography_level: state
+    geography_name: Hawaii
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Hawaii
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: hawaii_disabled
+    label: Hawaii disabled SSI
+    ordinal: 51
+    row_number: 53
+    geography_id: 0400000US15
+    geography_level: state
+    geography_name: Hawaii
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Hawaii
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: idaho_total
+    label: Idaho total SSI
+    ordinal: 52
+    row_number: 54
+    geography_id: 0400000US16
+    geography_level: state
+    geography_name: Idaho
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Idaho
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: idaho_aged
+    label: Idaho aged SSI
+    ordinal: 53
+    row_number: 55
+    geography_id: 0400000US16
+    geography_level: state
+    geography_name: Idaho
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Idaho
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: idaho_blind
+    label: Idaho blind SSI
+    ordinal: 54
+    row_number: 56
+    geography_id: 0400000US16
+    geography_level: state
+    geography_name: Idaho
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Idaho
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: idaho_disabled
+    label: Idaho disabled SSI
+    ordinal: 55
+    row_number: 57
+    geography_id: 0400000US16
+    geography_level: state
+    geography_name: Idaho
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Idaho
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: illinois_total
+    label: Illinois total SSI
+    ordinal: 56
+    row_number: 58
+    geography_id: 0400000US17
+    geography_level: state
+    geography_name: Illinois
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Illinois
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: illinois_aged
+    label: Illinois aged SSI
+    ordinal: 57
+    row_number: 59
+    geography_id: 0400000US17
+    geography_level: state
+    geography_name: Illinois
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Illinois
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: illinois_blind
+    label: Illinois blind SSI
+    ordinal: 58
+    row_number: 60
+    geography_id: 0400000US17
+    geography_level: state
+    geography_name: Illinois
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Illinois
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: illinois_disabled
+    label: Illinois disabled SSI
+    ordinal: 59
+    row_number: 61
+    geography_id: 0400000US17
+    geography_level: state
+    geography_name: Illinois
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Illinois
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: indiana_total
+    label: Indiana total SSI
+    ordinal: 60
+    row_number: 62
+    geography_id: 0400000US18
+    geography_level: state
+    geography_name: Indiana
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Indiana
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: indiana_aged
+    label: Indiana aged SSI
+    ordinal: 61
+    row_number: 63
+    geography_id: 0400000US18
+    geography_level: state
+    geography_name: Indiana
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Indiana
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: indiana_blind
+    label: Indiana blind SSI
+    ordinal: 62
+    row_number: 64
+    geography_id: 0400000US18
+    geography_level: state
+    geography_name: Indiana
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Indiana
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: indiana_disabled
+    label: Indiana disabled SSI
+    ordinal: 63
+    row_number: 65
+    geography_id: 0400000US18
+    geography_level: state
+    geography_name: Indiana
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Indiana
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: iowa_total
+    label: Iowa total SSI
+    ordinal: 64
+    row_number: 66
+    geography_id: 0400000US19
+    geography_level: state
+    geography_name: Iowa
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Iowa
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: iowa_aged
+    label: Iowa aged SSI
+    ordinal: 65
+    row_number: 67
+    geography_id: 0400000US19
+    geography_level: state
+    geography_name: Iowa
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Iowa
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: iowa_blind
+    label: Iowa blind SSI
+    ordinal: 66
+    row_number: 68
+    geography_id: 0400000US19
+    geography_level: state
+    geography_name: Iowa
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Iowa
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: iowa_disabled
+    label: Iowa disabled SSI
+    ordinal: 67
+    row_number: 69
+    geography_id: 0400000US19
+    geography_level: state
+    geography_name: Iowa
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Iowa
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: kansas_total
+    label: Kansas total SSI
+    ordinal: 68
+    row_number: 70
+    geography_id: 0400000US20
+    geography_level: state
+    geography_name: Kansas
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Kansas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: kansas_aged
+    label: Kansas aged SSI
+    ordinal: 69
+    row_number: 71
+    geography_id: 0400000US20
+    geography_level: state
+    geography_name: Kansas
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Kansas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: kansas_blind
+    label: Kansas blind SSI
+    ordinal: 70
+    row_number: 72
+    geography_id: 0400000US20
+    geography_level: state
+    geography_name: Kansas
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Kansas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: kansas_disabled
+    label: Kansas disabled SSI
+    ordinal: 71
+    row_number: 73
+    geography_id: 0400000US20
+    geography_level: state
+    geography_name: Kansas
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Kansas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: kentucky_total
+    label: Kentucky total SSI
+    ordinal: 72
+    row_number: 74
+    geography_id: 0400000US21
+    geography_level: state
+    geography_name: Kentucky
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Kentucky
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: kentucky_aged
+    label: Kentucky aged SSI
+    ordinal: 73
+    row_number: 75
+    geography_id: 0400000US21
+    geography_level: state
+    geography_name: Kentucky
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Kentucky
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: kentucky_blind
+    label: Kentucky blind SSI
+    ordinal: 74
+    row_number: 76
+    geography_id: 0400000US21
+    geography_level: state
+    geography_name: Kentucky
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Kentucky
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: kentucky_disabled
+    label: Kentucky disabled SSI
+    ordinal: 75
+    row_number: 77
+    geography_id: 0400000US21
+    geography_level: state
+    geography_name: Kentucky
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Kentucky
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: louisiana_total
+    label: Louisiana total SSI
+    ordinal: 76
+    row_number: 78
+    geography_id: 0400000US22
+    geography_level: state
+    geography_name: Louisiana
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Louisiana
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: louisiana_aged
+    label: Louisiana aged SSI
+    ordinal: 77
+    row_number: 79
+    geography_id: 0400000US22
+    geography_level: state
+    geography_name: Louisiana
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Louisiana
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: louisiana_blind
+    label: Louisiana blind SSI
+    ordinal: 78
+    row_number: 80
+    geography_id: 0400000US22
+    geography_level: state
+    geography_name: Louisiana
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Louisiana
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: louisiana_disabled
+    label: Louisiana disabled SSI
+    ordinal: 79
+    row_number: 81
+    geography_id: 0400000US22
+    geography_level: state
+    geography_name: Louisiana
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Louisiana
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: maine_total
+    label: Maine total SSI
+    ordinal: 80
+    row_number: 82
+    geography_id: 0400000US23
+    geography_level: state
+    geography_name: Maine
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Maine
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: maine_aged
+    label: Maine aged SSI
+    ordinal: 81
+    row_number: 83
+    geography_id: 0400000US23
+    geography_level: state
+    geography_name: Maine
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Maine
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: maine_blind
+    label: Maine blind SSI
+    ordinal: 82
+    row_number: 84
+    geography_id: 0400000US23
+    geography_level: state
+    geography_name: Maine
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Maine
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: maine_disabled
+    label: Maine disabled SSI
+    ordinal: 83
+    row_number: 85
+    geography_id: 0400000US23
+    geography_level: state
+    geography_name: Maine
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Maine
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: maryland_total
+    label: Maryland total SSI
+    ordinal: 84
+    row_number: 86
+    geography_id: 0400000US24
+    geography_level: state
+    geography_name: Maryland
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Maryland
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: maryland_aged
+    label: Maryland aged SSI
+    ordinal: 85
+    row_number: 87
+    geography_id: 0400000US24
+    geography_level: state
+    geography_name: Maryland
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Maryland
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: maryland_blind
+    label: Maryland blind SSI
+    ordinal: 86
+    row_number: 88
+    geography_id: 0400000US24
+    geography_level: state
+    geography_name: Maryland
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Maryland
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: maryland_disabled
+    label: Maryland disabled SSI
+    ordinal: 87
+    row_number: 89
+    geography_id: 0400000US24
+    geography_level: state
+    geography_name: Maryland
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Maryland
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: massachusetts_total
+    label: Massachusetts total SSI
+    ordinal: 88
+    row_number: 90
+    geography_id: 0400000US25
+    geography_level: state
+    geography_name: Massachusetts
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Massachusetts
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: massachusetts_aged
+    label: Massachusetts aged SSI
+    ordinal: 89
+    row_number: 91
+    geography_id: 0400000US25
+    geography_level: state
+    geography_name: Massachusetts
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Massachusetts
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: massachusetts_blind
+    label: Massachusetts blind SSI
+    ordinal: 90
+    row_number: 92
+    geography_id: 0400000US25
+    geography_level: state
+    geography_name: Massachusetts
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Massachusetts
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: massachusetts_disabled
+    label: Massachusetts disabled SSI
+    ordinal: 91
+    row_number: 93
+    geography_id: 0400000US25
+    geography_level: state
+    geography_name: Massachusetts
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Massachusetts
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: michigan_total
+    label: Michigan total SSI
+    ordinal: 92
+    row_number: 94
+    geography_id: 0400000US26
+    geography_level: state
+    geography_name: Michigan
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Michigan
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: michigan_aged
+    label: Michigan aged SSI
+    ordinal: 93
+    row_number: 95
+    geography_id: 0400000US26
+    geography_level: state
+    geography_name: Michigan
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Michigan
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: michigan_blind
+    label: Michigan blind SSI
+    ordinal: 94
+    row_number: 96
+    geography_id: 0400000US26
+    geography_level: state
+    geography_name: Michigan
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Michigan
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: michigan_disabled
+    label: Michigan disabled SSI
+    ordinal: 95
+    row_number: 97
+    geography_id: 0400000US26
+    geography_level: state
+    geography_name: Michigan
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Michigan
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: minnesota_total
+    label: Minnesota total SSI
+    ordinal: 96
+    row_number: 98
+    geography_id: 0400000US27
+    geography_level: state
+    geography_name: Minnesota
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Minnesota
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: minnesota_aged
+    label: Minnesota aged SSI
+    ordinal: 97
+    row_number: 99
+    geography_id: 0400000US27
+    geography_level: state
+    geography_name: Minnesota
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Minnesota
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: minnesota_blind
+    label: Minnesota blind SSI
+    ordinal: 98
+    row_number: 100
+    geography_id: 0400000US27
+    geography_level: state
+    geography_name: Minnesota
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Minnesota
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: minnesota_disabled
+    label: Minnesota disabled SSI
+    ordinal: 99
+    row_number: 101
+    geography_id: 0400000US27
+    geography_level: state
+    geography_name: Minnesota
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Minnesota
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: mississippi_total
+    label: Mississippi total SSI
+    ordinal: 100
+    row_number: 102
+    geography_id: 0400000US28
+    geography_level: state
+    geography_name: Mississippi
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Mississippi
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: mississippi_aged
+    label: Mississippi aged SSI
+    ordinal: 101
+    row_number: 103
+    geography_id: 0400000US28
+    geography_level: state
+    geography_name: Mississippi
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Mississippi
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: mississippi_blind
+    label: Mississippi blind SSI
+    ordinal: 102
+    row_number: 104
+    geography_id: 0400000US28
+    geography_level: state
+    geography_name: Mississippi
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Mississippi
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: mississippi_disabled
+    label: Mississippi disabled SSI
+    ordinal: 103
+    row_number: 105
+    geography_id: 0400000US28
+    geography_level: state
+    geography_name: Mississippi
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Mississippi
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: missouri_total
+    label: Missouri total SSI
+    ordinal: 104
+    row_number: 106
+    geography_id: 0400000US29
+    geography_level: state
+    geography_name: Missouri
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Missouri
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: missouri_aged
+    label: Missouri aged SSI
+    ordinal: 105
+    row_number: 107
+    geography_id: 0400000US29
+    geography_level: state
+    geography_name: Missouri
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Missouri
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: missouri_blind
+    label: Missouri blind SSI
+    ordinal: 106
+    row_number: 108
+    geography_id: 0400000US29
+    geography_level: state
+    geography_name: Missouri
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Missouri
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: missouri_disabled
+    label: Missouri disabled SSI
+    ordinal: 107
+    row_number: 109
+    geography_id: 0400000US29
+    geography_level: state
+    geography_name: Missouri
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Missouri
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: montana_total
+    label: Montana total SSI
+    ordinal: 108
+    row_number: 110
+    geography_id: 0400000US30
+    geography_level: state
+    geography_name: Montana
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Montana
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: montana_aged
+    label: Montana aged SSI
+    ordinal: 109
+    row_number: 111
+    geography_id: 0400000US30
+    geography_level: state
+    geography_name: Montana
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Montana
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: montana_blind
+    label: Montana blind SSI
+    ordinal: 110
+    row_number: 112
+    geography_id: 0400000US30
+    geography_level: state
+    geography_name: Montana
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Montana
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: montana_disabled
+    label: Montana disabled SSI
+    ordinal: 111
+    row_number: 113
+    geography_id: 0400000US30
+    geography_level: state
+    geography_name: Montana
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Montana
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: nebraska_total
+    label: Nebraska total SSI
+    ordinal: 112
+    row_number: 114
+    geography_id: 0400000US31
+    geography_level: state
+    geography_name: Nebraska
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Nebraska
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: nebraska_aged
+    label: Nebraska aged SSI
+    ordinal: 113
+    row_number: 115
+    geography_id: 0400000US31
+    geography_level: state
+    geography_name: Nebraska
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Nebraska
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: nebraska_blind
+    label: Nebraska blind SSI
+    ordinal: 114
+    row_number: 116
+    geography_id: 0400000US31
+    geography_level: state
+    geography_name: Nebraska
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Nebraska
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: nebraska_disabled
+    label: Nebraska disabled SSI
+    ordinal: 115
+    row_number: 117
+    geography_id: 0400000US31
+    geography_level: state
+    geography_name: Nebraska
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Nebraska
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: nevada_total
+    label: Nevada total SSI
+    ordinal: 116
+    row_number: 118
+    geography_id: 0400000US32
+    geography_level: state
+    geography_name: Nevada
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Nevada
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: nevada_aged
+    label: Nevada aged SSI
+    ordinal: 117
+    row_number: 119
+    geography_id: 0400000US32
+    geography_level: state
+    geography_name: Nevada
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Nevada
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: nevada_blind
+    label: Nevada blind SSI
+    ordinal: 118
+    row_number: 120
+    geography_id: 0400000US32
+    geography_level: state
+    geography_name: Nevada
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Nevada
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: nevada_disabled
+    label: Nevada disabled SSI
+    ordinal: 119
+    row_number: 121
+    geography_id: 0400000US32
+    geography_level: state
+    geography_name: Nevada
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Nevada
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: new_hampshire_total
+    label: New Hampshire total SSI
+    ordinal: 120
+    row_number: 122
+    geography_id: 0400000US33
+    geography_level: state
+    geography_name: New Hampshire
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: New Hampshire
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: new_hampshire_aged
+    label: New Hampshire aged SSI
+    ordinal: 121
+    row_number: 123
+    geography_id: 0400000US33
+    geography_level: state
+    geography_name: New Hampshire
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: New Hampshire
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: new_hampshire_blind
+    label: New Hampshire blind SSI
+    ordinal: 122
+    row_number: 124
+    geography_id: 0400000US33
+    geography_level: state
+    geography_name: New Hampshire
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: New Hampshire
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: new_hampshire_disabled
+    label: New Hampshire disabled SSI
+    ordinal: 123
+    row_number: 125
+    geography_id: 0400000US33
+    geography_level: state
+    geography_name: New Hampshire
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: New Hampshire
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: new_jersey_total
+    label: New Jersey total SSI
+    ordinal: 124
+    row_number: 126
+    geography_id: 0400000US34
+    geography_level: state
+    geography_name: New Jersey
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: New Jersey
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: new_jersey_aged
+    label: New Jersey aged SSI
+    ordinal: 125
+    row_number: 127
+    geography_id: 0400000US34
+    geography_level: state
+    geography_name: New Jersey
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: New Jersey
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: new_jersey_blind
+    label: New Jersey blind SSI
+    ordinal: 126
+    row_number: 128
+    geography_id: 0400000US34
+    geography_level: state
+    geography_name: New Jersey
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: New Jersey
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: new_jersey_disabled
+    label: New Jersey disabled SSI
+    ordinal: 127
+    row_number: 129
+    geography_id: 0400000US34
+    geography_level: state
+    geography_name: New Jersey
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: New Jersey
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: new_mexico_total
+    label: New Mexico total SSI
+    ordinal: 128
+    row_number: 130
+    geography_id: 0400000US35
+    geography_level: state
+    geography_name: New Mexico
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: New Mexico
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: new_mexico_aged
+    label: New Mexico aged SSI
+    ordinal: 129
+    row_number: 131
+    geography_id: 0400000US35
+    geography_level: state
+    geography_name: New Mexico
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: New Mexico
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: new_mexico_blind
+    label: New Mexico blind SSI
+    ordinal: 130
+    row_number: 132
+    geography_id: 0400000US35
+    geography_level: state
+    geography_name: New Mexico
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: New Mexico
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: new_mexico_disabled
+    label: New Mexico disabled SSI
+    ordinal: 131
+    row_number: 133
+    geography_id: 0400000US35
+    geography_level: state
+    geography_name: New Mexico
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: New Mexico
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: new_york_total
+    label: New York total SSI
+    ordinal: 132
+    row_number: 134
+    geography_id: 0400000US36
+    geography_level: state
+    geography_name: New York
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: New York
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: new_york_aged
+    label: New York aged SSI
+    ordinal: 133
+    row_number: 135
+    geography_id: 0400000US36
+    geography_level: state
+    geography_name: New York
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: New York
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: new_york_blind
+    label: New York blind SSI
+    ordinal: 134
+    row_number: 136
+    geography_id: 0400000US36
+    geography_level: state
+    geography_name: New York
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: New York
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: new_york_disabled
+    label: New York disabled SSI
+    ordinal: 135
+    row_number: 137
+    geography_id: 0400000US36
+    geography_level: state
+    geography_name: New York
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: New York
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: north_carolina_total
+    label: North Carolina total SSI
+    ordinal: 136
+    row_number: 138
+    geography_id: 0400000US37
+    geography_level: state
+    geography_name: North Carolina
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: North Carolina
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: north_carolina_aged
+    label: North Carolina aged SSI
+    ordinal: 137
+    row_number: 139
+    geography_id: 0400000US37
+    geography_level: state
+    geography_name: North Carolina
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: North Carolina
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: north_carolina_blind
+    label: North Carolina blind SSI
+    ordinal: 138
+    row_number: 140
+    geography_id: 0400000US37
+    geography_level: state
+    geography_name: North Carolina
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: North Carolina
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: north_carolina_disabled
+    label: North Carolina disabled SSI
+    ordinal: 139
+    row_number: 141
+    geography_id: 0400000US37
+    geography_level: state
+    geography_name: North Carolina
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: North Carolina
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: north_dakota_total
+    label: North Dakota total SSI
+    ordinal: 140
+    row_number: 142
+    geography_id: 0400000US38
+    geography_level: state
+    geography_name: North Dakota
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: North Dakota
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: north_dakota_aged
+    label: North Dakota aged SSI
+    ordinal: 141
+    row_number: 143
+    geography_id: 0400000US38
+    geography_level: state
+    geography_name: North Dakota
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: North Dakota
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: north_dakota_blind
+    label: North Dakota blind SSI
+    ordinal: 142
+    row_number: 144
+    geography_id: 0400000US38
+    geography_level: state
+    geography_name: North Dakota
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: North Dakota
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: north_dakota_disabled
+    label: North Dakota disabled SSI
+    ordinal: 143
+    row_number: 145
+    geography_id: 0400000US38
+    geography_level: state
+    geography_name: North Dakota
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: North Dakota
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: ohio_total
+    label: Ohio total SSI
+    ordinal: 144
+    row_number: 146
+    geography_id: 0400000US39
+    geography_level: state
+    geography_name: Ohio
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Ohio
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: ohio_aged
+    label: Ohio aged SSI
+    ordinal: 145
+    row_number: 147
+    geography_id: 0400000US39
+    geography_level: state
+    geography_name: Ohio
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Ohio
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: ohio_blind
+    label: Ohio blind SSI
+    ordinal: 146
+    row_number: 148
+    geography_id: 0400000US39
+    geography_level: state
+    geography_name: Ohio
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Ohio
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: ohio_disabled
+    label: Ohio disabled SSI
+    ordinal: 147
+    row_number: 149
+    geography_id: 0400000US39
+    geography_level: state
+    geography_name: Ohio
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Ohio
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: oklahoma_total
+    label: Oklahoma total SSI
+    ordinal: 148
+    row_number: 150
+    geography_id: 0400000US40
+    geography_level: state
+    geography_name: Oklahoma
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Oklahoma
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: oklahoma_aged
+    label: Oklahoma aged SSI
+    ordinal: 149
+    row_number: 151
+    geography_id: 0400000US40
+    geography_level: state
+    geography_name: Oklahoma
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Oklahoma
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: oklahoma_blind
+    label: Oklahoma blind SSI
+    ordinal: 150
+    row_number: 152
+    geography_id: 0400000US40
+    geography_level: state
+    geography_name: Oklahoma
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Oklahoma
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: oklahoma_disabled
+    label: Oklahoma disabled SSI
+    ordinal: 151
+    row_number: 153
+    geography_id: 0400000US40
+    geography_level: state
+    geography_name: Oklahoma
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Oklahoma
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: oregon_total
+    label: Oregon total SSI
+    ordinal: 152
+    row_number: 154
+    geography_id: 0400000US41
+    geography_level: state
+    geography_name: Oregon
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Oregon
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: oregon_aged
+    label: Oregon aged SSI
+    ordinal: 153
+    row_number: 155
+    geography_id: 0400000US41
+    geography_level: state
+    geography_name: Oregon
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Oregon
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: oregon_blind
+    label: Oregon blind SSI
+    ordinal: 154
+    row_number: 156
+    geography_id: 0400000US41
+    geography_level: state
+    geography_name: Oregon
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Oregon
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: oregon_disabled
+    label: Oregon disabled SSI
+    ordinal: 155
+    row_number: 157
+    geography_id: 0400000US41
+    geography_level: state
+    geography_name: Oregon
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Oregon
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: pennsylvania_total
+    label: Pennsylvania total SSI
+    ordinal: 156
+    row_number: 158
+    geography_id: 0400000US42
+    geography_level: state
+    geography_name: Pennsylvania
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Pennsylvania
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: pennsylvania_aged
+    label: Pennsylvania aged SSI
+    ordinal: 157
+    row_number: 159
+    geography_id: 0400000US42
+    geography_level: state
+    geography_name: Pennsylvania
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Pennsylvania
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: pennsylvania_blind
+    label: Pennsylvania blind SSI
+    ordinal: 158
+    row_number: 160
+    geography_id: 0400000US42
+    geography_level: state
+    geography_name: Pennsylvania
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Pennsylvania
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: pennsylvania_disabled
+    label: Pennsylvania disabled SSI
+    ordinal: 159
+    row_number: 161
+    geography_id: 0400000US42
+    geography_level: state
+    geography_name: Pennsylvania
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Pennsylvania
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: rhode_island_total
+    label: Rhode Island total SSI
+    ordinal: 160
+    row_number: 162
+    geography_id: 0400000US44
+    geography_level: state
+    geography_name: Rhode Island
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Rhode Island
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: rhode_island_aged
+    label: Rhode Island aged SSI
+    ordinal: 161
+    row_number: 163
+    geography_id: 0400000US44
+    geography_level: state
+    geography_name: Rhode Island
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Rhode Island
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: rhode_island_blind
+    label: Rhode Island blind SSI
+    ordinal: 162
+    row_number: 164
+    geography_id: 0400000US44
+    geography_level: state
+    geography_name: Rhode Island
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Rhode Island
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: rhode_island_disabled
+    label: Rhode Island disabled SSI
+    ordinal: 163
+    row_number: 165
+    geography_id: 0400000US44
+    geography_level: state
+    geography_name: Rhode Island
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Rhode Island
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: south_carolina_total
+    label: South Carolina total SSI
+    ordinal: 164
+    row_number: 166
+    geography_id: 0400000US45
+    geography_level: state
+    geography_name: South Carolina
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: South Carolina
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: south_carolina_aged
+    label: South Carolina aged SSI
+    ordinal: 165
+    row_number: 167
+    geography_id: 0400000US45
+    geography_level: state
+    geography_name: South Carolina
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: South Carolina
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: south_carolina_blind
+    label: South Carolina blind SSI
+    ordinal: 166
+    row_number: 168
+    geography_id: 0400000US45
+    geography_level: state
+    geography_name: South Carolina
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: South Carolina
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: south_carolina_disabled
+    label: South Carolina disabled SSI
+    ordinal: 167
+    row_number: 169
+    geography_id: 0400000US45
+    geography_level: state
+    geography_name: South Carolina
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: South Carolina
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: south_dakota_total
+    label: South Dakota total SSI
+    ordinal: 168
+    row_number: 170
+    geography_id: 0400000US46
+    geography_level: state
+    geography_name: South Dakota
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: South Dakota
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: south_dakota_aged
+    label: South Dakota aged SSI
+    ordinal: 169
+    row_number: 171
+    geography_id: 0400000US46
+    geography_level: state
+    geography_name: South Dakota
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: South Dakota
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: south_dakota_blind
+    label: South Dakota blind SSI
+    ordinal: 170
+    row_number: 172
+    geography_id: 0400000US46
+    geography_level: state
+    geography_name: South Dakota
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: South Dakota
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: south_dakota_disabled
+    label: South Dakota disabled SSI
+    ordinal: 171
+    row_number: 173
+    geography_id: 0400000US46
+    geography_level: state
+    geography_name: South Dakota
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: South Dakota
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: tennessee_total
+    label: Tennessee total SSI
+    ordinal: 172
+    row_number: 174
+    geography_id: 0400000US47
+    geography_level: state
+    geography_name: Tennessee
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Tennessee
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: tennessee_aged
+    label: Tennessee aged SSI
+    ordinal: 173
+    row_number: 175
+    geography_id: 0400000US47
+    geography_level: state
+    geography_name: Tennessee
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Tennessee
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: tennessee_blind
+    label: Tennessee blind SSI
+    ordinal: 174
+    row_number: 176
+    geography_id: 0400000US47
+    geography_level: state
+    geography_name: Tennessee
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Tennessee
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: tennessee_disabled
+    label: Tennessee disabled SSI
+    ordinal: 175
+    row_number: 177
+    geography_id: 0400000US47
+    geography_level: state
+    geography_name: Tennessee
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Tennessee
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: texas_total
+    label: Texas total SSI
+    ordinal: 176
+    row_number: 178
+    geography_id: 0400000US48
+    geography_level: state
+    geography_name: Texas
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Texas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: texas_aged
+    label: Texas aged SSI
+    ordinal: 177
+    row_number: 179
+    geography_id: 0400000US48
+    geography_level: state
+    geography_name: Texas
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Texas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: texas_blind
+    label: Texas blind SSI
+    ordinal: 178
+    row_number: 180
+    geography_id: 0400000US48
+    geography_level: state
+    geography_name: Texas
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Texas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: texas_disabled
+    label: Texas disabled SSI
+    ordinal: 179
+    row_number: 181
+    geography_id: 0400000US48
+    geography_level: state
+    geography_name: Texas
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Texas
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: utah_total
+    label: Utah total SSI
+    ordinal: 180
+    row_number: 182
+    geography_id: 0400000US49
+    geography_level: state
+    geography_name: Utah
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Utah
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: utah_aged
+    label: Utah aged SSI
+    ordinal: 181
+    row_number: 183
+    geography_id: 0400000US49
+    geography_level: state
+    geography_name: Utah
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Utah
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: utah_blind
+    label: Utah blind SSI
+    ordinal: 182
+    row_number: 184
+    geography_id: 0400000US49
+    geography_level: state
+    geography_name: Utah
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Utah
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: utah_disabled
+    label: Utah disabled SSI
+    ordinal: 183
+    row_number: 185
+    geography_id: 0400000US49
+    geography_level: state
+    geography_name: Utah
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Utah
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: vermont_total
+    label: Vermont total SSI
+    ordinal: 184
+    row_number: 186
+    geography_id: 0400000US50
+    geography_level: state
+    geography_name: Vermont
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Vermont
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: vermont_aged
+    label: Vermont aged SSI
+    ordinal: 185
+    row_number: 187
+    geography_id: 0400000US50
+    geography_level: state
+    geography_name: Vermont
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Vermont
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: vermont_blind
+    label: Vermont blind SSI
+    ordinal: 186
+    row_number: 188
+    geography_id: 0400000US50
+    geography_level: state
+    geography_name: Vermont
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Vermont
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: vermont_disabled
+    label: Vermont disabled SSI
+    ordinal: 187
+    row_number: 189
+    geography_id: 0400000US50
+    geography_level: state
+    geography_name: Vermont
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Vermont
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: virginia_total
+    label: Virginia total SSI
+    ordinal: 188
+    row_number: 190
+    geography_id: 0400000US51
+    geography_level: state
+    geography_name: Virginia
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Virginia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: virginia_aged
+    label: Virginia aged SSI
+    ordinal: 189
+    row_number: 191
+    geography_id: 0400000US51
+    geography_level: state
+    geography_name: Virginia
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Virginia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: virginia_blind
+    label: Virginia blind SSI
+    ordinal: 190
+    row_number: 192
+    geography_id: 0400000US51
+    geography_level: state
+    geography_name: Virginia
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Virginia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: virginia_disabled
+    label: Virginia disabled SSI
+    ordinal: 191
+    row_number: 193
+    geography_id: 0400000US51
+    geography_level: state
+    geography_name: Virginia
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Virginia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: washington_total
+    label: Washington total SSI
+    ordinal: 192
+    row_number: 194
+    geography_id: 0400000US53
+    geography_level: state
+    geography_name: Washington
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Washington
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: washington_aged
+    label: Washington aged SSI
+    ordinal: 193
+    row_number: 195
+    geography_id: 0400000US53
+    geography_level: state
+    geography_name: Washington
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Washington
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: washington_blind
+    label: Washington blind SSI
+    ordinal: 194
+    row_number: 196
+    geography_id: 0400000US53
+    geography_level: state
+    geography_name: Washington
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Washington
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: washington_disabled
+    label: Washington disabled SSI
+    ordinal: 195
+    row_number: 197
+    geography_id: 0400000US53
+    geography_level: state
+    geography_name: Washington
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Washington
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: west_virginia_total
+    label: West Virginia total SSI
+    ordinal: 196
+    row_number: 198
+    geography_id: 0400000US54
+    geography_level: state
+    geography_name: West Virginia
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: West Virginia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: west_virginia_aged
+    label: West Virginia aged SSI
+    ordinal: 197
+    row_number: 199
+    geography_id: 0400000US54
+    geography_level: state
+    geography_name: West Virginia
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: West Virginia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: west_virginia_blind
+    label: West Virginia blind SSI
+    ordinal: 198
+    row_number: 200
+    geography_id: 0400000US54
+    geography_level: state
+    geography_name: West Virginia
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: West Virginia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: west_virginia_disabled
+    label: West Virginia disabled SSI
+    ordinal: 199
+    row_number: 201
+    geography_id: 0400000US54
+    geography_level: state
+    geography_name: West Virginia
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: West Virginia
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: wisconsin_total
+    label: Wisconsin total SSI
+    ordinal: 200
+    row_number: 202
+    geography_id: 0400000US55
+    geography_level: state
+    geography_name: Wisconsin
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Wisconsin
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: wisconsin_aged
+    label: Wisconsin aged SSI
+    ordinal: 201
+    row_number: 203
+    geography_id: 0400000US55
+    geography_level: state
+    geography_name: Wisconsin
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Wisconsin
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: wisconsin_blind
+    label: Wisconsin blind SSI
+    ordinal: 202
+    row_number: 204
+    geography_id: 0400000US55
+    geography_level: state
+    geography_name: Wisconsin
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Wisconsin
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: wisconsin_disabled
+    label: Wisconsin disabled SSI
+    ordinal: 203
+    row_number: 205
+    geography_id: 0400000US55
+    geography_level: state
+    geography_name: Wisconsin
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Wisconsin
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  - value_id: wyoming_total
+    label: Wyoming total SSI
+    ordinal: 204
+    row_number: 206
+    geography_id: 0400000US56
+    geography_level: state
+    geography_name: Wyoming
+    geography_vintage: current
+    filters: {}
+    constraints: []
+    expected_row_header_column: B
+    expected_row_header: Wyoming
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: total
+      label: SSI category
+    table_record_kind: total
+  - value_id: wyoming_aged
+    label: Wyoming aged SSI
+    ordinal: 205
+    row_number: 207
+    geography_id: 0400000US56
+    geography_level: state
+    geography_name: Wyoming
+    geography_vintage: current
+    filters:
+      ssi_category: aged
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: aged
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Wyoming
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: aged
+      label: SSI category
+    table_record_kind: detail
+  - value_id: wyoming_blind
+    label: Wyoming blind SSI
+    ordinal: 206
+    row_number: 208
+    geography_id: 0400000US56
+    geography_level: state
+    geography_name: Wyoming
+    geography_vintage: current
+    filters:
+      ssi_category: blind
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: blind
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Wyoming
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: blind
+      label: SSI category
+    table_record_kind: detail
+  - value_id: wyoming_disabled
+    label: Wyoming disabled SSI
+    ordinal: 207
+    row_number: 209
+    geography_id: 0400000US56
+    geography_level: state
+    geography_name: Wyoming
+    geography_vintage: current
+    filters:
+      ssi_category: disabled
+    constraints:
+    - variable: ssi_category
+      operator: ==
+      value: disabled
+      label: SSI eligibility category
+    expected_row_header_column: B
+    expected_row_header: Wyoming
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: disabled
+      label: SSI category
+    table_record_kind: detail
+  record_set_id: ssa_supplement.cy2024.ssi_payments.by_area_category
+  record_set_spec_id: ssa_supplement.ssi_payments.by_area_category.v1
+  source_record_id_prefix: ssa_supplement.cy2024.ssi_payments.by_area_category
+  measures:
+  - measure_id: payment_amount
+    label: SSI payments
+    ordinal: 0
+    column: H
+    source_column_id: payment_thousands
+    concept: ssa.ssi_payment_amount
+    source_concept: ssa_supplement.table_7b1.payment_amount
+    concept_relation: exact
+    concept_authority: arch-us
+    concept_evidence_url: https://www.ssa.gov/policy/docs/statcomps/supplement/2025/7b.html
+    concept_evidence_notes: SSA Annual Statistical Supplement 2025 Table 7.B1 reports calendar-year 2024 federally administered SSI payments by area and eligibility category in thousands of dollars.
+    unit: usd
+    aggregation: sum
+    value_scale: 1000
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: payment_thousands
+  groupby_dimension: ssi_category

--- a/tests/test_arch_source_package.py
+++ b/tests/test_arch_source_package.py
@@ -1118,6 +1118,61 @@ def test_ssa_supplement_source_package_alias_validates_fixture_counts():
     }
 
 
+def test_ssa_ssi_table_7b1_source_package_alias_validates_fixture_counts():
+    report = validate_source_package("ssa-ssi-table-7b1-2024", year=2024)
+
+    assert report.valid
+    assert report.counts == {
+        "record_set_count": 2,
+        "row_count": 416,
+        "measure_count": 2,
+        "source_record_count": 416,
+        "source_region_count": 2,
+    }
+
+
+def test_ssa_ssi_table_7b1_source_package_builds_area_category_facts():
+    package = load_source_package("ssa-ssi-table-7b1-2024")
+    cells = package.build_source_cells(2024)
+    facts = package.build_facts(2024, cells=cells)
+    values_by_record = {fact.source_record_id: fact for fact in facts}
+
+    assert package.package_id == "ssa-ssi-table-7b1-2024"
+    assert validate_source_cells(cells).valid
+    assert validate_facts(facts).valid
+    assert len(cells) == 1_672
+    assert len(facts) == 416
+    assert all(fact.source.raw_r2_uri for fact in facts)
+
+    us_payments = values_by_record[
+        "ssa_supplement.cy2024.ssi_payments.by_area_category."
+        "all_areas_total.payment_amount"
+    ]
+    ca_disabled_recipients = values_by_record[
+        "ssa_supplement.cy2024.ssi_recipients.by_area_category."
+        "california_disabled.recipient_count"
+    ]
+    ca_disabled_payments = values_by_record[
+        "ssa_supplement.cy2024.ssi_payments.by_area_category."
+        "california_disabled.payment_amount"
+    ]
+
+    assert us_payments.value == 63_079_493_000
+    assert us_payments.measure.concept == "ssa.ssi_payment_amount"
+    assert us_payments.constraints == ()
+
+    assert ca_disabled_recipients.value == 849_834
+    assert ca_disabled_recipients.geography.id == "0400000US06"
+    assert ca_disabled_recipients.measure.concept == "ssa.ssi_recipient_count"
+    assert {
+        (constraint.variable, constraint.operator, constraint.value)
+        for constraint in ca_disabled_recipients.constraints
+    } == {("ssi_category", "==", "disabled")}
+
+    assert ca_disabled_payments.value == 9_834_761_000
+    assert ca_disabled_payments.geography.id == "0400000US06"
+
+
 def test_census_pep_source_package_alias_validates_fixture_counts():
     report = validate_source_package("census-pep-2024-national-age-sex", year=2023)
 


### PR DESCRIPTION
## Summary
- add a validated SSA Annual Statistical Supplement 2025 Table 7.B1 source package for 2024 SSI recipients and payments
- emit All areas plus state/DC recipient-count and payment-amount facts by total, aged, blind, and disabled SSI category
- add the source-package alias and tests pinning package counts plus California disabled SSI values and U.S. total SSI payments

## Validation
- uv run --extra dev ruff check arch/source_package.py tests/test_arch_source_package.py
- uv run --extra dev pytest -q tests/test_arch_source_package.py -k "ssa_ssi_table_7b1 or ssa_supplement"
- uv run --extra dev pytest -q tests/test_arch_source_package.py
- uv run --extra dev pytest -q tests/test_arch_bundle.py -k "source_package_count or ssa"
- uv run --extra dev arch validate-package packages/ssa/ssi_table_7b1_2024 --year 2024
- uv run --extra dev arch build-suite ssa-ssi-table-7b1-2024 --year 2024 --out /tmp/arch-ssa-ssi-7b1-2024-alias --replace

## Microplex smoke check
The generated consumer_facts.jsonl loads through PolicyEngine/microplex-us#52 into 416 SSI targets, including California disabled recipients = 849,834 and U.S. total SSI payments = $63,079,493,000.

Source: https://www.ssa.gov/policy/docs/statcomps/supplement/2025/7b.html