### PR TITLE
Add US poverty target coverage contract

### DIFF
--- a/arch/source_package.py
+++ b/arch/source_package.py
@@ -70,6 +70,7 @@ SOURCE_PACKAGE_ALIASES = {
     "bea-nipa-personal-income-disposition": Path(
         "bea/nipa_personal_income_disposition"
     ),
+    "bea-nipa-pension-contributions": Path("bea/nipa_pension_contributions"),
     "bea-nipa-total-wages-salaries": Path("bea/nipa_total_wages_salaries"),
     "bea-regional-state-personal-income-components-2024": Path(
         "bea/regional_personal_income_state"

--- a/arch/targets/__init__.py
+++ b/arch/targets/__init__.py
@@ -15,6 +15,15 @@ from db.schema import (
 )
 from db.supabase_client import insert_targets_batch, query_strata, query_targets
 from calibration.targets import TargetSpec, get_targets
+from .us_poverty import (
+    US_POVERTY_NONFILER_TARGET_COVERAGE,
+    TargetSourceCoverage,
+    coverage_entries,
+    hard_target_package_aliases,
+    source_gap_family_ids,
+    validate_us_poverty_nonfiler_source_coverage,
+    validation_only_family_ids,
+)
 
 __all__ = [
     "DEFAULT_DB_PATH",
@@ -25,12 +34,19 @@ __all__ = [
     "StratumConstraint",
     "Target",
     "TargetSpec",
+    "TargetSourceCoverage",
     "TargetType",
+    "US_POVERTY_NONFILER_TARGET_COVERAGE",
+    "coverage_entries",
     "get_engine",
     "get_targets",
     "get_session",
+    "hard_target_package_aliases",
     "init_db",
     "insert_targets_batch",
     "query_strata",
     "query_targets",
+    "source_gap_family_ids",
+    "validate_us_poverty_nonfiler_source_coverage",
+    "validation_only_family_ids",
 ]

--- a/arch/targets/us_poverty.py
+++ b/arch/targets/us_poverty.py
@@ -1,0 +1,365 @@
+"""US poverty and nonfiler source-target coverage.
+
+Arch only records source-backed inputs. Populace owns the active calibration
+profile, source reconciliation, aging, and model variable mapping.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from arch.source_package import SOURCE_PACKAGE_ALIASES, SOURCE_PACKAGE_FILENAME
+
+
+CoverageRole = Literal["hard_target", "validation_only", "source_gap"]
+
+
+@dataclass(frozen=True)
+class TargetSourceCoverage:
+    """Coverage status for one source family relevant to poverty calibration."""
+
+    family_id: str
+    label: str
+    role: CoverageRole
+    source_scope: str
+    package_aliases: tuple[str, ...] = ()
+    missing_source_packages: tuple[str, ...] = ()
+    notes: str = ""
+
+    @property
+    def has_arch_package(self) -> bool:
+        """Return whether this family has at least one Arch package alias."""
+        return bool(self.package_aliases)
+
+
+US_POVERTY_NONFILER_TARGET_COVERAGE: tuple[TargetSourceCoverage, ...] = (
+    TargetSourceCoverage(
+        family_id="population_age_sex",
+        label="Population by age, sex, state, and congressional district",
+        role="hard_target",
+        source_scope="Census population estimates and ACS demographics",
+        package_aliases=(
+            "census-pep-2024-national-age-sex",
+            "census-pep-2024-state-age-sex",
+            "census-acs-s0101-national-age-2024",
+            "census-acs-s0101-state-age-2024",
+            "census-acs-s0101-congressional-district-age-2024",
+        ),
+        notes=(
+            "Use PEP for population controls. ACS geography/detail can support "
+            "local allocation and validation."
+        ),
+    ),
+    TargetSourceCoverage(
+        family_id="nipa_personal_income",
+        label="NIPA personal income, transfers, taxes, and pensions",
+        role="hard_target",
+        source_scope="BEA NIPA full-population aggregates",
+        package_aliases=(
+            "bea-nipa-total-wages-salaries",
+            "bea-nipa-personal-income-components",
+            "bea-nipa-personal-income-disposition",
+            "bea-nipa-pension-contributions",
+        ),
+        notes=(
+            "This is the main non-SOI full-population backstop for wages, "
+            "proprietors' income, rental income, interest, dividends, UI, "
+            "Social Security, SSI, SNAP, Medicare, Medicaid, TANF, personal "
+            "taxes, and disposable personal income."
+        ),
+    ),
+    TargetSourceCoverage(
+        family_id="irs_soi_filer_income_tax_credits",
+        label="SOI filer income, taxes, deductions, and credits",
+        role="hard_target",
+        source_scope="IRS SOI filer administrative totals",
+        package_aliases=(
+            "soi-table-1-1",
+            "soi-table-1-2",
+            "soi-table-1-4",
+            "soi-table-2-1",
+            "soi-table-2-5",
+            "soi-table-2-5-eitc-agi-children-2022",
+            "soi-table-4-3",
+            "soi-state-2022",
+            "soi-historic-table-2",
+            "soi-historic-table-2-state-agi-2022",
+            "soi-historic-table-2-state-broad-2022",
+            "soi-historic-table-2-state-eitc-2022",
+            "soi-w2-statistics-2020",
+        ),
+        notes=(
+            "Use for filer and tax-form aggregates. Pair with NIPA/program "
+            "administrative controls to avoid making nonfilers inherit SOI-only "
+            "coverage."
+        ),
+    ),
+    TargetSourceCoverage(
+        family_id="social_security_ssi",
+        label="Social Security and SSI payments",
+        role="hard_target",
+        source_scope="SSA administrative program totals",
+        package_aliases=(
+            "ssa-annual-statistical-supplement-2025",
+            "ssa-ssi-table-7b1-2024",
+        ),
+        notes=("SSA gives program-specific checks on the broader NIPA transfer lines."),
+    ),
+    TargetSourceCoverage(
+        family_id="snap_admin",
+        label="SNAP participation and benefit cost",
+        role="hard_target",
+        source_scope="USDA FNS administrative totals",
+        package_aliases=("usda-snap-fy69-to-current",),
+    ),
+    TargetSourceCoverage(
+        family_id="tanf_admin",
+        label="TANF caseload and financial data",
+        role="hard_target",
+        source_scope="HHS ACF administrative totals",
+        package_aliases=(
+            "hhs-acf-tanf-caseload-2024",
+            "hhs-acf-tanf-financial-2024",
+        ),
+    ),
+    TargetSourceCoverage(
+        family_id="liheap_admin",
+        label="LIHEAP households and benefits",
+        role="hard_target",
+        source_scope="HHS ACF LIHEAP administrative profile",
+        package_aliases=(
+            "hhs-acf-liheap-fy2023-national-profile",
+            "hhs-acf-liheap-fy2024-national-profile",
+        ),
+    ),
+    TargetSourceCoverage(
+        family_id="health_programs",
+        label="Medicaid, CHIP, ACA, Medicare, and NHE controls",
+        role="hard_target",
+        source_scope="CMS administrative enrollment and expenditure totals",
+        package_aliases=(
+            "cms-medicaid-chip-monthly-enrollment-dataset",
+            "cms-medicaid-chip-monthly-enrollment-december-2024",
+            "cms-nhe-historical-service-source",
+            "cms-aca-oep-state-level",
+            "cms-aca-oep-state-level-2022",
+            "cms-aca-oep-state-level-2025",
+            "cms-aca-effectuated-enrollment-2022",
+            "cms-medicare-trustees-report-2025-part-b-premium-income",
+        ),
+        notes=(
+            "Health coverage and public health spending affect SPM resources "
+            "mostly through premiums, subsidies, and out-of-pocket costs."
+        ),
+    ),
+    TargetSourceCoverage(
+        family_id="state_income_tax_collections",
+        label="State individual income tax collections",
+        role="hard_target",
+        source_scope="Census Annual Survey of State Government Tax Collections",
+        package_aliases=("census-stc-individual-income-tax",),
+    ),
+    TargetSourceCoverage(
+        family_id="snap_local_proxy",
+        label="SNAP congressional district household estimates",
+        role="validation_only",
+        source_scope="ACS S2201 survey estimates",
+        package_aliases=("census-acs-s2201-congressional-district-snap-2024",),
+        notes=(
+            "ACS is not CPS, but it is still a survey estimate. Use for local "
+            "validation or allocation, not as a national hard target."
+        ),
+    ),
+    TargetSourceCoverage(
+        family_id="cbo_income_revenue_projection",
+        label="CBO income and revenue projections",
+        role="validation_only",
+        source_scope="CBO projection tables",
+        package_aliases=("cbo-revenue-projections-income-by-source-2026-02",),
+        notes="Use for forecast/aging checks, not contemporaneous calibration.",
+    ),
+    TargetSourceCoverage(
+        family_id="wealth_balance_sheet",
+        label="Household net worth balance-sheet checks",
+        role="validation_only",
+        source_scope="Federal Reserve Financial Accounts",
+        package_aliases=("federal-reserve-z1-household-net-worth",),
+    ),
+    TargetSourceCoverage(
+        family_id="census_cps_spm",
+        label="Census CPS ASEC SPM poverty, resources, and thresholds",
+        role="validation_only",
+        source_scope="CPS-derived official poverty measurement",
+        notes=(
+            "Use to diagnose the SPM result. Do not hard-target it while fixing "
+            "CPS/Populace poverty-resource construction."
+        ),
+    ),
+    TargetSourceCoverage(
+        family_id="dina_distributional_accounts",
+        label="Distributional national accounts",
+        role="validation_only",
+        source_scope="Distributional estimates partly informed by CPS/SCF/SOI",
+        notes=(
+            "Useful for reasonableness checks, but not an independent poverty "
+            "target because it can reintroduce CPS distributional assumptions."
+        ),
+    ),
+    TargetSourceCoverage(
+        family_id="acs_poverty_income_distribution",
+        label="ACS poverty and income distributions",
+        role="validation_only",
+        source_scope="ACS survey estimates",
+        notes=(
+            "Independent of CPS sampling, but still survey-based and not SPM "
+            "resources. Use as validation."
+        ),
+    ),
+    TargetSourceCoverage(
+        family_id="hud_assisted_housing",
+        label="Housing assistance and subsidy controls",
+        role="source_gap",
+        source_scope="HUD administrative program data",
+        missing_source_packages=(
+            "HUD Picture of Subsidized Households",
+            "HUD assisted-housing expenditure or unit-count tables",
+        ),
+        notes=(
+            "Needed for SPM capped housing subsidy resources. Current Arch has "
+            "no HUD source package for this family."
+        ),
+    ),
+    TargetSourceCoverage(
+        family_id="usda_wic",
+        label="WIC participation and benefits",
+        role="source_gap",
+        source_scope="USDA FNS administrative totals",
+        missing_source_packages=("USDA FNS WIC program data",),
+        notes="Needed for SPM WIC resources.",
+    ),
+    TargetSourceCoverage(
+        family_id="usda_school_meals",
+        label="School lunch and breakfast benefits",
+        role="source_gap",
+        source_scope="USDA FNS administrative totals",
+        missing_source_packages=(
+            "USDA FNS National School Lunch Program data",
+            "USDA FNS School Breakfast Program data",
+        ),
+        notes="Needed for SPM school meal resources.",
+    ),
+    TargetSourceCoverage(
+        family_id="ocse_child_support",
+        label="Child support received and paid",
+        role="source_gap",
+        source_scope="HHS OCSE administrative collections/disbursements",
+        missing_source_packages=("HHS OCSE child support annual report tables",),
+        notes=(
+            "Small in the SPM-rate decomposition, but should be modeled and "
+            "ledgered for completeness."
+        ),
+    ),
+    TargetSourceCoverage(
+        family_id="dol_workers_compensation",
+        label="Workers' compensation benefits",
+        role="source_gap",
+        source_scope="Program-specific workers' compensation administrative data",
+        missing_source_packages=(
+            "DOL or NASI workers' compensation benefit totals",
+            "State workers' compensation benefit totals",
+        ),
+        notes=(
+            "BEA has broad transfer aggregates, but not the program-specific "
+            "source package needed for a clean model target."
+        ),
+    ),
+    TargetSourceCoverage(
+        family_id="moop_work_childcare_costs",
+        label="MOOP, work expenses, and childcare expense validation",
+        role="source_gap",
+        source_scope="MEPS, BLS CE, AHS, or other non-CPS validation sources",
+        missing_source_packages=(
+            "MEPS out-of-pocket medical spending tables",
+            "BLS Consumer Expenditure work-related expense tables",
+            "Childcare expense validation source",
+        ),
+        notes=(
+            "These are SPM deductions rather than resources. They should be "
+            "validation or imputation benchmarks, not blind hard targets."
+        ),
+    ),
+)
+
+
+def coverage_entries(
+    *,
+    role: CoverageRole | None = None,
+) -> tuple[TargetSourceCoverage, ...]:
+    """Return poverty/nonfiler source coverage entries, optionally by role."""
+    if role is None:
+        return US_POVERTY_NONFILER_TARGET_COVERAGE
+    return tuple(
+        entry for entry in US_POVERTY_NONFILER_TARGET_COVERAGE if entry.role == role
+    )
+
+
+def hard_target_package_aliases() -> tuple[str, ...]:
+    """Return package aliases required for source-backed hard target coverage."""
+    aliases = {
+        alias
+        for entry in coverage_entries(role="hard_target")
+        for alias in entry.package_aliases
+    }
+    return tuple(sorted(aliases))
+
+
+def validation_only_family_ids() -> tuple[str, ...]:
+    """Return validation-only source family IDs."""
+    return tuple(entry.family_id for entry in coverage_entries(role="validation_only"))
+
+
+def source_gap_family_ids() -> tuple[str, ...]:
+    """Return source-gap family IDs."""
+    return tuple(entry.family_id for entry in coverage_entries(role="source_gap"))
+
+
+def validate_us_poverty_nonfiler_source_coverage(
+    *,
+    package_root: str | Path | None = None,
+) -> tuple[str, ...]:
+    """Validate that hard-target package aliases are registered and present.
+
+    Args:
+        package_root: Optional packages directory to check for package YAMLs.
+
+    Returns:
+        A tuple of validation error messages.
+    """
+    errors: list[str] = []
+    root = Path(package_root) if package_root is not None else None
+    for alias in hard_target_package_aliases():
+        package_path = SOURCE_PACKAGE_ALIASES.get(alias)
+        if package_path is None:
+            errors.append(f"Missing source package alias: {alias}")
+            continue
+        if root is not None:
+            source_package = root / package_path / SOURCE_PACKAGE_FILENAME
+            if not source_package.exists():
+                errors.append(
+                    f"Missing source package file for {alias}: {source_package}"
+                )
+    return tuple(errors)
+
+
+__all__ = [
+    "CoverageRole",
+    "TargetSourceCoverage",
+    "US_POVERTY_NONFILER_TARGET_COVERAGE",
+    "coverage_entries",
+    "hard_target_package_aliases",
+    "source_gap_family_ids",
+    "validate_us_poverty_nonfiler_source_coverage",
+    "validation_only_family_ids",
+]

--- a/docs/pe-calibration-targets.md
+++ b/docs/pe-calibration-targets.md
@@ -1,276 +1,93 @@
-# PolicyEngine-US-Data Calibration Targets
+# US Poverty and Nonfiler Source-Target Coverage
 
-This document catalogs the calibration targets used in PolicyEngine-US-Data and compares them to Arch.
+This document records the Arch-side source coverage contract for US poverty and
+nonfiler calibration work. Arch stores source-backed facts and target inputs.
+Populace owns the active calibration profile, source reconciliation, aging, and
+model variable mapping.
 
-## Overview
+The related machine-readable contract lives in
+`arch.targets.us_poverty.US_POVERTY_NONFILER_TARGET_COVERAGE`.
 
-PolicyEngine-US-Data calibrates the Enhanced CPS dataset to **2,813 targets** from multiple authoritative sources. The calibration uses a dropout-regularized gradient descent optimization algorithm to reweight survey records to match administrative benchmarks.
+## Main Answer
 
-## Data Sources Used by PolicyEngine
+Yes, many of the targets discussed for ECPS/Populace are already in Arch:
 
-| Source | Description | Target Categories |
-|--------|-------------|-------------------|
-| IRS Statistics of Income (SOI) | Tax return data | Income, deductions, credits, filing patterns |
-| Census Population Projections | Demographic data | Age, geography, household composition |
-| Congressional Budget Office (CBO) | Program estimates | Benefit program costs, economic projections |
-| Treasury Expenditure Data | Government spending | Tax expenditure estimates |
-| Joint Committee on Taxation (JCT) | Tax expenditures | Credit and deduction costs |
-| Healthcare Spending Data | Medical costs | Insurance patterns, healthcare expenditures |
-| Social Security Administration (SSA) | Retirement/disability | OASDI, SSI participation and costs |
+- BEA NIPA full-population income, transfer, tax, and pension aggregates.
+- IRS SOI filer income, deduction, credit, wage, and state/district facts.
+- USDA SNAP participation and benefits.
+- HHS ACF TANF and LIHEAP administrative data.
+- SSA Social Security and SSI totals.
+- CMS Medicaid, CHIP, ACA, Medicare, and National Health Expenditure data.
+- Census PEP/ACS demographic controls and state individual income tax
+  collections.
 
-## Target Categories
+The missing piece was not another legacy `policyengine-us-data` comparison. It
+was an explicit coverage gate that tells consumers which Arch source families
+are hard target inputs, which are validation-only diagnostics, and which source
+packages are still missing for SPM-specific components.
 
-### 1. IRS SOI Tax Targets
+## Hard Target Inputs
 
-From `etl_irs_soi.py` in policyengine-us-data:
+These source families are appropriate Arch inputs for Populace target
+composition. Populace may still decide how to reconcile, age, activate, or map
+them to model variables.
 
-#### Income Variables
-| Variable Code | PolicyEngine Variable | Description |
-|---------------|----------------------|-------------|
-| 00100 | `adjusted_gross_income` | Total AGI |
-| 00300 | `taxable_interest_income` | Taxable interest |
-| 00400 | `tax_exempt_interest_income` | Tax-exempt interest |
-| 00600 | `dividend_income` | Dividend income |
-| 00650 | `qualified_dividend_income` | Qualified dividends |
-| 01000 | `net_capital_gain` | Net capital gains |
-| 01400 | `taxable_ira_distributions` | Taxable IRA distributions |
-| 01700 | `taxable_pension_income` | Taxable pension income |
-| 02300 | `unemployment_compensation` | Unemployment benefits |
-| 02500 | `taxable_social_security` | Taxable Social Security |
-| 26270 | `partnership_s_corp_income` | Pass-through income |
+| Family | Source scope | Arch aliases |
+|---|---|---|
+| Population by age, sex, state, and congressional district | Census PEP and ACS demographics | `census-pep-2024-national-age-sex`, `census-pep-2024-state-age-sex`, `census-acs-s0101-national-age-2024`, `census-acs-s0101-state-age-2024`, `census-acs-s0101-congressional-district-age-2024` |
+| NIPA personal income, transfers, taxes, and pensions | BEA NIPA full-population aggregates | `bea-nipa-total-wages-salaries`, `bea-nipa-personal-income-components`, `bea-nipa-personal-income-disposition`, `bea-nipa-pension-contributions` |
+| SOI filer income, taxes, deductions, and credits | IRS SOI administrative totals | `soi-table-1-1`, `soi-table-1-2`, `soi-table-1-4`, `soi-table-2-1`, `soi-table-2-5`, `soi-table-2-5-eitc-agi-children-2022`, `soi-table-4-3`, `soi-state-2022`, `soi-historic-table-2`, `soi-historic-table-2-state-agi-2022`, `soi-historic-table-2-state-broad-2022`, `soi-historic-table-2-state-eitc-2022`, `soi-w2-statistics-2020` |
+| Social Security and SSI | SSA administrative totals | `ssa-annual-statistical-supplement-2025`, `ssa-ssi-table-7b1-2024` |
+| SNAP | USDA FNS administrative totals | `usda-snap-fy69-to-current` |
+| TANF | HHS ACF caseload and financial totals | `hhs-acf-tanf-caseload-2024`, `hhs-acf-tanf-financial-2024` |
+| LIHEAP | HHS ACF LIHEAP profiles | `hhs-acf-liheap-fy2023-national-profile`, `hhs-acf-liheap-fy2024-national-profile` |
+| Health programs | CMS administrative enrollment and spending totals | `cms-medicaid-chip-monthly-enrollment-dataset`, `cms-medicaid-chip-monthly-enrollment-december-2024`, `cms-nhe-historical-service-source`, `cms-aca-oep-state-level`, `cms-aca-oep-state-level-2022`, `cms-aca-oep-state-level-2025`, `cms-aca-effectuated-enrollment-2022`, `cms-medicare-trustees-report-2025-part-b-premium-income` |
+| State individual income taxes | Census state tax collections | `census-stc-individual-income-tax` |
 
-#### Tax Variables
-| Variable Code | PolicyEngine Variable | Description |
-|---------------|----------------------|-------------|
-| 06500 | `income_tax` | Total income tax |
-| 11070 | `refundable_ctc` | Refundable CTC |
-| 59661-59664 | `eitc` | EITC by number of children (0, 1, 2, 3+) |
+BEA NIPA is especially important for nonfilers because it is a
+full-population macro control, not an SOI-only filer target. It currently gives
+Arch coverage for wages, proprietors' income, rental income, interest,
+dividends, UI, Social Security, SSI, SNAP, Medicare, Medicaid, TANF, personal
+taxes, disposable personal income, and pension contributions.
 
-#### Deduction Variables
-| Variable Code | PolicyEngine Variable | Description |
-|---------------|----------------------|-------------|
-| 04475 | `qualified_business_income_deduction` | QBI deduction |
-| 17000 | `medical_expense_deduction` | Medical expenses |
-| 18425 | `salt_deduction` | SALT deduction |
-| 18500 | `real_estate_taxes` | Real estate taxes |
+## Validation Only
 
-#### Stratification
-- **Geographic**: National, State, Congressional District
-- **Income**: 9 AGI brackets (from under $1 to over $500,000)
-- **Filing Status**: Single, Married Joint, Married Separate, Head of Household
+These sources are useful diagnostics, but they should not be hard targets for
+fixing CPS/Populace poverty resources:
 
-### 2. Census Demographic Targets
+| Family | Why validation-only |
+|---|---|
+| Census CPS ASEC SPM poverty, resources, and thresholds | This is the result we are trying to diagnose. Hard-targeting it would mask model/data errors. |
+| Distributional national accounts | Useful for reasonableness checks, but partly informed by survey distribution assumptions and not an independent SPM target. |
+| ACS poverty and income distributions | Independent of CPS sampling, but still survey-based and not the SPM resource definition. |
+| ACS S2201 SNAP congressional district estimates | Useful for local validation or allocation, not a national administrative hard target. |
+| CBO income and revenue projections | Useful for forecast/aging checks, not contemporaneous calibration. |
+| Federal Reserve household balance sheet | Useful for wealth/capital-income reasonableness, not an SPM resource target. |
 
-From `etl_age.py` in policyengine-us-data:
+## Source Gaps
 
-#### Age Distribution
-| Age Range | Variable |
-|-----------|----------|
-| 0-4 | `person_count` |
-| 5-9 | `person_count` |
-| 10-14 | `person_count` |
-| 15-19 | `person_count` |
-| 20-24 | `person_count` |
-| 25-29 | `person_count` |
-| 30-34 | `person_count` |
-| 35-39 | `person_count` |
-| 40-44 | `person_count` |
-| 45-49 | `person_count` |
-| 50-54 | `person_count` |
-| 55-59 | `person_count` |
-| 60-64 | `person_count` |
-| 65-69 | `person_count` |
-| 70-74 | `person_count` |
-| 75-79 | `person_count` |
-| 80-84 | `person_count` |
-| 85+ | `person_count` |
+These are the current poverty/SPM-specific gaps to add as source packages:
 
-**Source**: Census Table S0101 (Age and Sex)
+| Gap | Candidate source | Why it matters |
+|---|---|---|
+| Housing assistance and subsidy controls | HUD Picture of Subsidized Households; HUD assisted-housing unit or expenditure tables | SPM adds capped housing subsidy resources. |
+| WIC participation and benefits | USDA FNS WIC program data | SPM adds WIC resources. |
+| School lunch and breakfast benefits | USDA FNS National School Lunch and School Breakfast program data | SPM adds school meal resources. |
+| Child support received and paid | HHS OCSE annual report tables | Small in the SPM gap, but should be modeled and ledgered for completeness. |
+| Workers' compensation benefits | DOL, NASI, or state workers' compensation totals | BEA broad transfers are not a clean program-specific workers' comp target. |
+| MOOP, work expenses, and childcare expense validation | MEPS, BLS Consumer Expenditure, AHS, or childcare expenditure sources | These are SPM deductions. They should guide validation/imputation rather than be blind hard targets. |
 
-**Geographic Levels**:
-- National (1)
-- State (51)
-- Congressional District (436)
+## ECPS Gate Interpretation
 
-### 3. Benefit Program Targets
+The old ECPS-style gate was a source-backed target coverage gate: every active
+source-backed target family needed a ledgered source family, with reviewed
+exclusions for survey/model-only variables. That idea belongs here in Arch as
+source coverage, while Populace owns the active target profile.
 
-#### SNAP (etl_snap.py)
-| Variable | Description | Geographic Level |
-|----------|-------------|------------------|
-| `household_count` | SNAP households | State, Congressional District |
-| `snap` | Total benefit cost | State |
+The important distinction is:
 
-**Sources**:
-- Administrative data (Source ID 3): State totals
-- ACS Survey data (Source ID 4): Congressional district via Census Table S2201
-
-#### Medicaid (etl_medicaid.py)
-| Variable | Description | Geographic Level |
-|----------|-------------|------------------|
-| `person_count` | Medicaid enrollment | State, Congressional District |
-
-**Sources**:
-- State Medicaid administrative reports (Source ID 2)
-- Census ACS variable S2704_C02_006E
-
-### 4. Tax Expenditure Targets
-
-Referenced but specific structure not visible in code:
-
-- **Treasury**: Total tax expenditure estimates
-- **JCT**: Joint Committee on Taxation estimates for specific provisions
-
-## Database Schema
-
-PolicyEngine-US-Data uses a three-table schema:
-
-### strata
-| Column | Type | Description |
-|--------|------|-------------|
-| stratum_id | int | Primary key |
-| definition_hash | str(64) | SHA-256 hash of constraints |
-| parent_stratum_id | int | Hierarchical parent |
-| stratum_group_id | int | Groups related strata |
-| notes | str | Description |
-
-### stratum_constraints
-| Column | Type | Description |
-|--------|------|-------------|
-| stratum_id | int | Foreign key to strata |
-| constraint_variable | USVariable | PolicyEngine variable name |
-| operation | str | Comparison operator |
-| value | str | Threshold value |
-
-### targets
-| Column | Type | Description |
-|--------|------|-------------|
-| target_id | int | Primary key |
-| variable | USVariable | PolicyEngine variable |
-| period | int | Year |
-| stratum_id | int | Foreign key to strata |
-| reform_id | int | Policy scenario (0=baseline) |
-| value | float | Target amount |
-| source_id | int | Data source reference |
-| active | bool | Whether target is used |
-| tolerance | float | Acceptable error percentage |
-
-## Comparison: Arch vs PolicyEngine
-
-### Currently Implemented in Arch
-
-| Category | Source | ETL File | Status |
-|----------|--------|----------|--------|
-| **IRS SOI** | IRS Table 1.1 | `etl_soi.py` | Basic (national totals, AGI brackets, filing status) |
-| **IRS SOI State** | IRS Historic Table 2 | `etl_soi_state.py` | Partial (5 states, limited years) |
-| **SNAP** | USDA FNS | `etl_snap.py` | Basic (national + 10 states) |
-| **Census** | Population Estimates | `etl_census.py` | Basic (population, households, age groups) |
-| **CBO** | Budget Outlook | `etl_cbo.py` | Macro projections only |
-| **SSA** | Trustee Report | `etl_ssa.py` | Basic |
-| **BLS** | Employment | `etl_bls.py` | Basic |
-
-### Gaps vs PolicyEngine
-
-#### High Priority - Missing Target Categories
-
-1. **IRS SOI Income by Source** (Priority: High)
-   - Interest income, dividends, capital gains, pensions
-   - Partnership/S-Corp income
-   - Not in our SOI ETL
-
-2. **IRS SOI Credits** (Priority: High)
-   - EITC by number of children
-   - Refundable CTC
-   - We have docs but no ETL implementation
-
-3. **IRS SOI Deductions** (Priority: High)
-   - Medical expenses, SALT, real estate taxes
-   - QBI deduction
-   - Not implemented
-
-4. **Medicaid Enrollment** (Priority: High)
-   - State-level enrollment counts
-   - Congressional district estimates
-   - Missing entirely
-
-5. **Congressional District Geography** (Priority: Medium)
-   - PE has 436 district-level targets
-   - We only have state-level
-
-6. **Age Distribution Granularity** (Priority: Medium)
-   - PE has 18 age brackets
-   - We have 5 broad groups
-
-#### Medium Priority - Coverage Gaps
-
-7. **All 50 States + DC** (Priority: Medium)
-   - PE covers all states
-   - We only have top 10 by population
-
-8. **Healthcare Spending Patterns** (Priority: Medium)
-   - Insurance enrollment
-   - ACA marketplace data
-   - Missing entirely
-
-9. **SSI Targets** (Priority: Medium)
-   - Supplemental Security Income
-   - Not in SSA ETL
-
-#### Lower Priority - Enhancement Opportunities
-
-10. **Treasury Tax Expenditures** (Priority: Low)
-    - Annual tax expenditure estimates
-    - Would validate credit/deduction totals
-
-11. **JCT Estimates** (Priority: Low)
-    - Tax provision cost estimates
-    - Cross-validation source
-
-## Target Count Comparison
-
-| Category | PolicyEngine (est.) | policyengine (current) | Gap |
-|----------|---------------------|-------------------|-----|
-| IRS SOI Tax | ~500 | ~80 | ~420 |
-| Demographics | ~900 | ~50 | ~850 |
-| Benefit Programs | ~800 | ~75 | ~725 |
-| Healthcare | ~300 | 0 | ~300 |
-| Tax Expenditures | ~300 | 0 | ~300 |
-| **Total** | **~2,813** | **~205** | **~2,608** |
-
-## Implementation Recommendations
-
-### Phase 1: Core Tax Targets (Est. +400 targets)
-1. Expand IRS SOI to all 50 states + DC
-2. Add income by source (interest, dividends, capital gains)
-3. Add EITC targets by child count
-4. Add CTC/ACTC targets
-
-### Phase 2: Benefit Programs (Est. +500 targets)
-1. Add Medicaid enrollment (state + district)
-2. Expand SNAP to all states
-3. Add SSI participation and benefits
-4. Add TANF (if modeled)
-
-### Phase 3: Demographics (Est. +800 targets)
-1. Expand age brackets to 18 groups
-2. Add congressional district level
-3. Add race/ethnicity distributions
-
-### Phase 4: Healthcare & Advanced (Est. +400 targets)
-1. Add healthcare insurance enrollment
-2. Add ACA marketplace data
-3. Add tax expenditure cross-validation
-
-## Sources
-
-- [PolicyEngine US Data Documentation](https://policyengine.github.io/policyengine-us-data/)
-- [PolicyEngine US Data GitHub Repository](https://github.com/PolicyEngine/policyengine-us-data)
-- [PolicyEngine Microcalibrate Package](https://github.com/PolicyEngine/microcalibrate)
-- [IRS Statistics of Income](https://www.irs.gov/statistics/soi-tax-stats-statistics-of-income)
-- [Census Bureau Population Estimates](https://www.census.gov/programs-surveys/popest.html)
-- [CBO Budget and Economic Data](https://www.cbo.gov/data/budget-economic-data)
-- [USDA SNAP Data](https://www.fns.usda.gov/pd/supplemental-nutrition-assistance-program-snap)
-
----
-
-*Document created: 2024-12-22*
-*Based on: policyengine-us-data repository analysis*
+- NIPA, SOI, SSA, USDA, HHS ACF, CMS, and Census population/tax collections are
+  source-backed candidate inputs.
+- CPS SPM and DINA-style distributional outputs are validation diagnostics.
+- HUD housing, WIC, school meals, OCSE child support, workers comp, and
+  MOOP/work/childcare validation still need explicit source packages.

--- a/tests/test_us_poverty_target_coverage.py
+++ b/tests/test_us_poverty_target_coverage.py
@@ -1,0 +1,77 @@
+"""Tests for US poverty/nonfiler source-target coverage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from arch.source_package import SOURCE_PACKAGE_ALIASES, load_source_package
+from arch.targets.us_poverty import (
+    coverage_entries,
+    hard_target_package_aliases,
+    source_gap_family_ids,
+    validate_us_poverty_nonfiler_source_coverage,
+    validation_only_family_ids,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_us_poverty_hard_target_aliases_are_registered_and_packaged():
+    errors = validate_us_poverty_nonfiler_source_coverage(
+        package_root=REPO_ROOT / "packages",
+    )
+
+    assert errors == ()
+
+
+def test_us_poverty_all_named_package_aliases_are_registered():
+    aliases = {alias for entry in coverage_entries() for alias in entry.package_aliases}
+
+    assert aliases <= set(SOURCE_PACKAGE_ALIASES)
+
+
+def test_us_poverty_hard_target_aliases_cover_non_soi_sources():
+    aliases = set(hard_target_package_aliases())
+
+    assert "bea-nipa-personal-income-components" in aliases
+    assert "bea-nipa-personal-income-disposition" in aliases
+    assert "bea-nipa-pension-contributions" in aliases
+    assert "usda-snap-fy69-to-current" in aliases
+    assert "ssa-ssi-table-7b1-2024" in aliases
+    assert "hhs-acf-tanf-financial-2024" in aliases
+    assert "cms-medicaid-chip-monthly-enrollment-dataset" in aliases
+
+
+def test_existing_bea_pension_package_has_public_alias():
+    package = load_source_package("bea-nipa-pension-contributions")
+
+    assert SOURCE_PACKAGE_ALIASES["bea-nipa-pension-contributions"] == Path(
+        "bea/nipa_pension_contributions"
+    )
+    assert package.package_id == "bea-nipa-pension-contributions"
+
+
+def test_cps_and_dina_are_validation_only_not_hard_targets():
+    hard_target_ids = {
+        entry.family_id for entry in coverage_entries(role="hard_target")
+    }
+    validation_ids = set(validation_only_family_ids())
+
+    assert "census_cps_spm" not in hard_target_ids
+    assert "dina_distributional_accounts" not in hard_target_ids
+    assert "census_cps_spm" in validation_ids
+    assert "dina_distributional_accounts" in validation_ids
+
+
+def test_us_poverty_source_gaps_include_spm_specific_components():
+    gaps = set(source_gap_family_ids())
+
+    assert {
+        "hud_assisted_housing",
+        "usda_wic",
+        "usda_school_meals",
+        "ocse_child_support",
+        "dol_workers_compensation",
+        "moop_work_childcare_costs",
+    }.issubset(gaps)


### PR DESCRIPTION
## Summary
- add a machine-readable Arch coverage contract for US poverty/nonfiler target source families
- register the existing BEA NIPA pension contributions source package alias
- replace the stale PE-US-Data calibration target markdown with Populace-era hard-target, validation-only, and source-gap coverage

## Tests
- uv run ruff check arch/source_package.py arch/targets/__init__.py arch/targets/us_poverty.py tests/test_us_poverty_target_coverage.py
- uv run pytest tests/test_arch_boundaries.py tests/test_arch_source_package.py::test_source_package_alias_compiles_soi_table_1_1_specs tests/test_us_poverty_target_coverage.py