### PR TITLE
Add JCT tax expenditure source package

### DIFF
--- a/arch/source_package.py
+++ b/arch/source_package.py
@@ -86,17 +86,11 @@ SOURCE_PACKAGE_ALIASES = {
     "census-acs-s2201-congressional-district-snap-2024": Path(
         "census/acs_s2201_district_2024"
     ),
-    "census-b01001-female-age-2023": Path(
-        "census/b01001_female_15_44_2023"
-    ),
+    "census-b01001-female-age-2023": Path("census/b01001_female_15_44_2023"),
     "census-pep-2024-national-age-sex": Path("census/pep_2024_national_age_sex"),
     "census-pep-2024-state-age-sex": Path("census/pep_2024_state_age_sex"),
-    "census-population-projections-2023": Path(
-        "census/population_projections_2023"
-    ),
-    "census-stc-individual-income-tax": Path(
-        "census/stc_individual_income_tax"
-    ),
+    "census-population-projections-2023": Path("census/population_projections_2023"),
+    "census-stc-individual-income-tax": Path("census/stc_individual_income_tax"),
     "cms-medicaid-chip-monthly-enrollment-december-2024": Path(
         "cms_medicaid/chip_monthly_enrollment_december_2024"
     ),
@@ -106,9 +100,7 @@ SOURCE_PACKAGE_ALIASES = {
     "cms-aca-oep-state-level": Path("cms_aca/oep_state_level"),
     "cms-aca-oep-state-level-2022": Path("cms_aca/oep_state_level_2022"),
     "cms-aca-oep-state-level-2025": Path("cms_aca/oep_state_level_2025"),
-    "cms-aca-effectuated-enrollment-2022": Path(
-        "cms_aca/effectuated_enrollment_2022"
-    ),
+    "cms-aca-effectuated-enrollment-2022": Path("cms_aca/effectuated_enrollment_2022"),
     "cms-medicare-trustees-report-2025-part-b-premium-income": Path(
         "cms_medicare/medicare_trustees_report_2025"
     ),
@@ -122,6 +114,7 @@ SOURCE_PACKAGE_ALIASES = {
     "hhs-acf-liheap-fy2024-national-profile": Path(
         "hhs_acf_liheap/fy2024_national_profile"
     ),
+    "jct-tax-expenditures-2024": Path("jct/tax_expenditures_2024"),
     "soi-table-1-1": Path("irs_soi/table_1_1"),
     "soi-table-1-2": Path("irs_soi/table_1_2"),
     "soi-table-1-4": Path("irs_soi/table_1_4"),
@@ -132,9 +125,7 @@ SOURCE_PACKAGE_ALIASES = {
     ),
     "soi-table-4-3": Path("irs_soi/table_4_3"),
     "soi-state-2022": Path("irs_soi/state_2022"),
-    "soi-congressional-district-2022": Path(
-        "irs_soi/congressional_district_2022"
-    ),
+    "soi-congressional-district-2022": Path("irs_soi/congressional_district_2022"),
     "soi-historic-table-2": Path("irs_soi/historic_table_2"),
     "soi-historic-table-2-state-agi-2022": Path(
         "irs_soi/historic_table_2_state_agi_2022"

--- a/db/data/jct/tax_expenditures_2024/jct_tax_expenditures_2024.csv
+++ b/db/data/jct/tax_expenditures_2024/jct_tax_expenditures_2024.csv
@@ -1,0 +1,6 @@
+tax_expenditure,label,jct_line_label,individual_revenue_loss_2024,definition_note
+salt_deduction,State and local tax deduction,Taxes paid deduction,21700000000,Individual income tax revenue loss for itemized state and local tax deduction.
+medical_expense_deduction,Medical expense deduction,Medical expenses deduction,11400000000,Individual income tax revenue loss for itemized medical expense deduction.
+charitable_deduction,Charitable contribution deduction,"Charitable contributions, other than education and health; charitable contributions, education; charitable contributions, health",60400000000,Sum of individual income tax revenue-loss rows for charitable contributions excluding corporate income tax estimates.
+deductible_mortgage_interest,Deductible mortgage interest,Deductibility of mortgage interest on owner-occupied homes,24800000000,Individual income tax revenue loss for deductible mortgage interest on owner-occupied homes.
+qualified_business_income_deduction,Qualified business income deduction,20-percent deduction for qualified business income,63100000000,Individual income tax revenue loss for qualified business income deduction.

--- a/db/data/jct/tax_expenditures_2024/manifest.yaml
+++ b/db/data/jct/tax_expenditures_2024/manifest.yaml
@@ -1,0 +1,30 @@
+id: jct-tax-expenditures-2024
+title: JCT Estimates of Federal Tax Expenditures for Fiscal Years 2024-2028
+publisher: Joint Committee on Taxation
+description: >
+  Selected calendar-year 2024 individual income tax revenue-loss estimates from
+  JCX-48-24 Table 1, curated for Populace fiscal calibration targets that must be
+  encoded as simple reforms rather than static PolicyEngine variables.
+source_page: https://www.jct.gov/publications/2024/jcx-48-24/
+source_url: https://www.jct.gov/getattachment/765709fb-9a4b-430a-8f9e-4d342ec97f7e/x-48-24.pdf
+retrieved_at: "2026-06-16T00:00:00Z"
+license: public-domain
+files:
+  2024:
+    filename: jct_tax_expenditures_2024.csv
+    source_url: https://www.jct.gov/getattachment/765709fb-9a4b-430a-8f9e-4d342ec97f7e/x-48-24.pdf
+    sha256: a6db137830f744ef140c796e23da2673480a70fb3fbcba848476d5ccbf27ffa8
+    size_bytes: 1154
+    source_table: Estimates of Federal Tax Expenditures for Fiscal Years 2024-2028
+    year: 2024
+    storage:
+      r2:
+        provider: r2
+        bucket: arch-raw
+        key: raw/jct/jct-tax-expenditures-2024/2024/a6db137830f744ef140c796e23da2673480a70fb3fbcba848476d5ccbf27ffa8/jct_tax_expenditures_2024.csv
+        uri: r2://arch-raw/raw/jct/jct-tax-expenditures-2024/2024/a6db137830f744ef140c796e23da2673480a70fb3fbcba848476d5ccbf27ffa8/jct_tax_expenditures_2024.csv
+notes:
+  - >
+    Calendar-year 2024 values use the individual income tax revenue-loss column
+    only. For charitable contributions, the value sums the three individual
+    charitable rows and excludes corporate revenue-loss columns.

--- a/packages/jct/tax_expenditures_2024/source_package.yaml
+++ b/packages/jct/tax_expenditures_2024/source_package.yaml
@@ -1,0 +1,114 @@
+schema_version: arch.source_package.v1
+package_id: jct-tax-expenditures-2024
+label: JCT 2024 individual income tax expenditure estimates
+artifact:
+  source_name: jct
+  source_table: Estimates of Federal Tax Expenditures for Fiscal Years 2024-2028
+  resource_package: db
+  resource_directory: data/jct/tax_expenditures_2024
+  manifest: manifest.yaml
+  vintage: jcx_48_24
+  extracted_at: "2026-06-16"
+  extraction_method: manual extraction from JCX-48-24 Table 1 individual income tax revenue-loss columns
+  parser: delimited_text_full_rows
+  sheet_name: jct_tax_expenditures_2024
+record_sets:
+  - record_set_id: jct.tax_expenditures.cy2024
+    record_set_spec_id: jct.individual_tax_expenditure_revenue_loss.v1
+    source_record_id_prefix: jct.tax_expenditures.cy2024
+    sheet_name: jct_tax_expenditures_2024
+    period_type: calendar_year
+    period: 2024
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: current
+    entity: tax_unit
+    entity_role: federal_income_tax_unit
+    domain: federal_income_tax
+    groupby_dimension: jct.tax_expenditure
+    rows:
+      - value_id: salt_deduction
+        label: State and local tax deduction
+        ordinal: 0
+        row_number: 2
+        expected_row_header_column: A
+        expected_row_header: salt_deduction
+        filters:
+          tax_expenditure: salt_deduction
+        constraints:
+          - variable: tax_expenditure
+            operator: "=="
+            value: salt_deduction
+            label: JCT tax expenditure row
+        table_record_kind: total
+      - value_id: medical_expense_deduction
+        label: Medical expense deduction
+        ordinal: 1
+        row_number: 3
+        expected_row_header_column: A
+        expected_row_header: medical_expense_deduction
+        filters:
+          tax_expenditure: medical_expense_deduction
+        constraints:
+          - variable: tax_expenditure
+            operator: "=="
+            value: medical_expense_deduction
+            label: JCT tax expenditure row
+        table_record_kind: total
+      - value_id: charitable_deduction
+        label: Charitable contribution deduction
+        ordinal: 2
+        row_number: 4
+        expected_row_header_column: A
+        expected_row_header: charitable_deduction
+        filters:
+          tax_expenditure: charitable_deduction
+        constraints:
+          - variable: tax_expenditure
+            operator: "=="
+            value: charitable_deduction
+            label: JCT tax expenditure row
+        table_record_kind: total
+      - value_id: deductible_mortgage_interest
+        label: Deductible mortgage interest
+        ordinal: 3
+        row_number: 5
+        expected_row_header_column: A
+        expected_row_header: deductible_mortgage_interest
+        filters:
+          tax_expenditure: deductible_mortgage_interest
+        constraints:
+          - variable: tax_expenditure
+            operator: "=="
+            value: deductible_mortgage_interest
+            label: JCT tax expenditure row
+        table_record_kind: total
+      - value_id: qualified_business_income_deduction
+        label: Qualified business income deduction
+        ordinal: 4
+        row_number: 6
+        expected_row_header_column: A
+        expected_row_header: qualified_business_income_deduction
+        filters:
+          tax_expenditure: qualified_business_income_deduction
+        constraints:
+          - variable: tax_expenditure
+            operator: "=="
+            value: qualified_business_income_deduction
+            label: JCT tax expenditure row
+        table_record_kind: total
+    measures:
+      - measure_id: revenue_loss
+        label: Individual income tax revenue loss
+        ordinal: 0
+        column: D
+        source_column_id: individual_revenue_loss_2024
+        expected_column_header_row: 1
+        expected_column_header: individual_revenue_loss_2024
+        concept: jct.individual_tax_expenditure_revenue_loss
+        source_concept: jct.individual_income_tax_revenue_loss
+        concept_relation: source_label
+        unit: usd
+        aggregation: sum
+        expected_cell_type: number

--- a/tests/test_arch_bundle.py
+++ b/tests/test_arch_bundle.py
@@ -16,9 +16,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
     output_dir = tmp_path / "bundle"
 
     report = build_bundle(output_dir, year=2023)
-    summary = json.loads(
-        (output_dir / "reports" / "build_bundle.json").read_text()
-    )
+    summary = json.loads((output_dir / "reports" / "build_bundle.json").read_text())
     rows = _load_jsonl(output_dir / "consumer_facts.jsonl")
     source_packages = json.loads((output_dir / "source_packages.json").read_text())
     coverage = json.loads((output_dir / "coverage.json").read_text())
@@ -144,11 +142,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
     ]
     assert (output_dir / "sources" / "soi-table-1-1" / "consumer_facts.jsonl").exists()
     assert (
-        output_dir
-        / "sources"
-        / "soi-table-1-4"
-        / "reports"
-        / "build_summary.json"
+        output_dir / "sources" / "soi-table-1-4" / "reports" / "build_summary.json"
     ).exists()
     assert (
         output_dir
@@ -163,7 +157,10 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         / "consumer_facts.jsonl"
     ).exists()
     assert (
-        output_dir / "sources" / "census-stc-individual-income-tax" / "consumer_facts.jsonl"
+        output_dir
+        / "sources"
+        / "census-stc-individual-income-tax"
+        / "consumer_facts.jsonl"
     ).exists()
     assert (
         output_dir
@@ -294,16 +291,45 @@ def test_build_bundle_cli_supports_ssa_supplement_source(tmp_path, capsys):
     assert payload["counts"]["fact_count"] == 6
     assert payload["coverage"]["counts"]["by_source"] == {"ssa": 6}
     assert payload["coverage"]["counts"]["by_entity"] == {"person": 6}
-    assert {
-        row["universe_constraints"]["constraints"][0]["value"]
-        for row in rows
-    } == {
+    assert {row["universe_constraints"]["constraints"][0]["value"] for row in rows} == {
         "social_security_benefits",
         "social_security_retirement_benefits",
         "social_security_survivors_benefits",
         "social_security_disability_benefits",
         "social_security_dependents_benefits",
         "ssi_payments",
+    }
+
+
+def test_build_bundle_cli_supports_jct_tax_expenditure_source(tmp_path, capsys):
+    output_dir = tmp_path / "bundle"
+
+    exit_code = harness_main(
+        [
+            "build-bundle",
+            "--year",
+            "2024",
+            "--source",
+            "jct-tax-expenditures-2024",
+            "--out",
+            str(output_dir),
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    rows = _load_jsonl(output_dir / "consumer_facts.jsonl")
+
+    assert exit_code == 0
+    assert payload["valid"]
+    assert payload["counts"]["source_package_count"] == 1
+    assert payload["counts"]["fact_count"] == 5
+    assert payload["coverage"]["counts"]["by_source"] == {"jct": 5}
+    assert payload["coverage"]["counts"]["by_entity"] == {"tax_unit": 5}
+    assert {row["lineage"]["source_record_id"] for row in rows} == {
+        "jct.tax_expenditures.cy2024.salt_deduction.revenue_loss",
+        "jct.tax_expenditures.cy2024.medical_expense_deduction.revenue_loss",
+        "jct.tax_expenditures.cy2024.charitable_deduction.revenue_loss",
+        "jct.tax_expenditures.cy2024.deductible_mortgage_interest.revenue_loss",
+        "jct.tax_expenditures.cy2024.qualified_business_income_deduction.revenue_loss",
     }
 
 

--- a/tests/test_arch_source_package.py
+++ b/tests/test_arch_source_package.py
@@ -153,9 +153,9 @@ def test_guard_cell_expected_value_changes_record_set_spec_hash(tmp_path):
         {"column": "A", "expected_value": "All returns"},
     ]
     changed = deepcopy(payload)
-    changed["record_sets"][0]["rows"][0]["guard_cells"][0][
-        "expected_value"
-    ] = "Different label"
+    changed["record_sets"][0]["rows"][0]["guard_cells"][0]["expected_value"] = (
+        "Different label"
+    )
 
     package_dir = tmp_path / "soi-original"
     changed_dir = tmp_path / "soi-changed-guard"
@@ -253,9 +253,7 @@ def test_source_package_path_builds_valid_soi_table_1_4_facts():
     assert validate_facts(facts).valid
     assert facts[0].source.source_table == "Publication 1304 Table 1.4"
     assert (
-        values_by_record[
-            "irs_soi.ty2023.table_1_4.all.alimony_received_amount"
-        ].value
+        values_by_record["irs_soi.ty2023.table_1_4.all.alimony_received_amount"].value
         == 6_686_429_000
     )
     assert (
@@ -477,12 +475,18 @@ def test_cbo_income_by_source_package_preserves_cbo_projection_concepts():
         row["concept_alignment"]["source_concept"]: row
         for row in consumer_fact_rows(facts)
     }
-    assert consumer_rows_by_source_concept["cbo.net_capital_gain"][
-        "concept_alignment"
-    ]["canonical_concept"] == "cbo.net_capital_gain_projection"
-    assert consumer_rows_by_source_concept["cbo.net_business_income"][
-        "concept_alignment"
-    ]["canonical_concept"] == "cbo.net_business_income_projection"
+    assert (
+        consumer_rows_by_source_concept["cbo.net_capital_gain"]["concept_alignment"][
+            "canonical_concept"
+        ]
+        == "cbo.net_capital_gain_projection"
+    )
+    assert (
+        consumer_rows_by_source_concept["cbo.net_business_income"]["concept_alignment"][
+            "canonical_concept"
+        ]
+        == "cbo.net_business_income_projection"
+    )
 
 
 def test_validate_source_package_reports_fixture_counts():
@@ -615,8 +619,7 @@ def test_soi_table_2_1_package_builds_itemized_deduction_details():
         "home_mortgage_personal_seller_amount"
     ]
     deductible_points = values_by_record[
-        "irs_soi.ty2023.table_2_1.itemized_all_returns.all."
-        "deductible_points_amount"
+        "irs_soi.ty2023.table_2_1.itemized_all_returns.all.deductible_points_amount"
     ]
     limited_salt = values_by_record[
         "irs_soi.ty2023.table_2_1.itemized_all_returns.all."
@@ -631,8 +634,7 @@ def test_soi_table_2_1_package_builds_itemized_deduction_details():
         "state_local_income_or_sales_tax_amount"
     ]
     real_estate_taxes = values_by_record[
-        "irs_soi.ty2023.table_2_1.itemized_all_returns.all."
-        "real_estate_taxes_amount"
+        "irs_soi.ty2023.table_2_1.itemized_all_returns.all.real_estate_taxes_amount"
     ]
 
     assert charitable.value == 211_975_123_000
@@ -972,8 +974,7 @@ def test_cms_medicare_trustees_package_builds_part_b_premium_fact():
     values_by_record = {fact.source_record_id: fact for fact in facts}
 
     assert (
-        package.package_id
-        == "cms-medicare-trustees-report-2025-part-b-premium-income"
+        package.package_id == "cms-medicare-trustees-report-2025-part-b-premium-income"
     )
     assert len(cells) == 93_486
     assert validate_source_cells(cells).valid
@@ -1003,6 +1004,56 @@ def test_cms_medicare_trustees_package_builds_part_b_premium_fact():
     assert values_by_record[record_id].entity.name == "government"
     assert values_by_record[record_id].filters["amount_basis"] == "actual"
     assert values_by_record[record_id].measure.unit == "usd"
+
+
+def test_jct_tax_expenditure_package_builds_selected_individual_facts():
+    package = load_source_package("jct-tax-expenditures-2024")
+    cells = package.build_source_cells(2024)
+    records = package.build_source_records(2024, cells=cells)
+    facts = package.build_facts(2024, cells=cells)
+    consumer_rows = consumer_fact_rows(facts)
+    values_by_record = {fact.source_record_id: fact for fact in facts}
+
+    assert package.package_id == "jct-tax-expenditures-2024"
+    assert len(cells) == 30
+    assert validate_source_cells(cells).valid
+    assert len(records) == 5
+    assert len(facts) == 5
+    assert validate_facts(facts).valid
+    assert validate_consumer_fact_contract(facts).valid
+    assert len(consumer_rows) == 5
+    assert all(fact.source.source_name == "jct" for fact in facts)
+    assert all(fact.source.raw_r2_uri for fact in facts)
+
+    expected_values = {
+        "jct.tax_expenditures.cy2024.salt_deduction.revenue_loss": 21_700_000_000,
+        "jct.tax_expenditures.cy2024.medical_expense_deduction.revenue_loss": 11_400_000_000,
+        "jct.tax_expenditures.cy2024.charitable_deduction.revenue_loss": 60_400_000_000,
+        "jct.tax_expenditures.cy2024.deductible_mortgage_interest.revenue_loss": 24_800_000_000,
+        "jct.tax_expenditures.cy2024.qualified_business_income_deduction.revenue_loss": 63_100_000_000,
+    }
+    assert {record.source_record_id for record in records} == set(expected_values)
+    assert {
+        record_id: fact.value for record_id, fact in values_by_record.items()
+    } == expected_values
+
+    salt = values_by_record["jct.tax_expenditures.cy2024.salt_deduction.revenue_loss"]
+    assert salt.measure.concept == "jct.individual_tax_expenditure_revenue_loss"
+    assert salt.measure.source_concept == "jct.individual_income_tax_revenue_loss"
+    assert salt.measure.unit == "usd"
+    assert salt.period.value == 2024
+    assert salt.geography.id == "0100000US"
+    assert salt.entity.name == "tax_unit"
+    assert salt.filters["tax_expenditure"] == "salt_deduction"
+    salt_row = next(
+        row
+        for row in consumer_rows
+        if row["lineage"]["source_record_id"]
+        == "jct.tax_expenditures.cy2024.salt_deduction.revenue_loss"
+    )
+    assert salt_row["universe_constraints"]["constraints"][0]["value"] == (
+        "salt_deduction"
+    )
 
 
 @pytest.mark.parametrize(
@@ -1048,8 +1099,7 @@ def test_hhs_acf_liheap_package_builds_household_count_fact(
     assert all(fact.source.raw_r2_uri for fact in facts)
 
     record_id = (
-        f"hhs_acf_liheap.fy{year}.national_profile."
-        "state_programs.households_served"
+        f"hhs_acf_liheap.fy{year}.national_profile.state_programs.households_served"
     )
     assert records[0].source_cell_addresses == addresses
     assert values_by_record[record_id].value == households
@@ -1095,12 +1145,12 @@ def test_soi_table_2_5_eitc_child_totals_build_2022_facts():
     assert three_child_amount.value == 14_000_930_000
     assert no_child_returns.filters == {"income_range": "all"}
     assert no_child_returns.layout.table_record_kind == "total"
-    assert {
-        constraint.variable for constraint in no_child_returns.constraints
-    } == {"us.tax.earned_income_credit_qualifying_children"}
-    assert {
-        constraint.operator for constraint in three_child_amount.constraints
-    } == {">="}
+    assert {constraint.variable for constraint in no_child_returns.constraints} == {
+        "us.tax.earned_income_credit_qualifying_children"
+    }
+    assert {constraint.operator for constraint in three_child_amount.constraints} == {
+        ">="
+    }
 
 
 def test_ssa_supplement_source_package_alias_validates_fixture_counts():
@@ -1240,9 +1290,7 @@ def test_source_package_alias_builds_census_population_projection_age_facts():
     }
 
     age_0 = "census.popproj2023.cy2025.national_population.age_0.population"
-    age_85_plus = (
-        "census.popproj2023.cy2025.national_population.age_85_plus.population"
-    )
+    age_85_plus = "census.popproj2023.cy2025.national_population.age_85_plus.population"
     assert records_by_id[age_0].source_cell_addresses == (
         "F2",
         "F3",
@@ -1314,9 +1362,7 @@ def test_census_acs_s0101_source_package_aliases_validate_fixture_counts():
 
 
 def test_census_acs_s0101_congressional_district_package_builds_age_facts():
-    package = load_source_package(
-        "census-acs-s0101-congressional-district-age-2024"
-    )
+    package = load_source_package("census-acs-s0101-congressional-district-age-2024")
     rows = package.build_source_rows(2024)
     cells = package.build_source_cells(2024, source_rows=rows)
     facts = package.build_facts(2024, cells=cells, source_rows=rows)
@@ -1368,16 +1414,13 @@ def test_census_b01001_female_age_source_package_builds_state_facts():
     assert all(fact.source.raw_r2_uri for fact in facts)
 
     al_age_15_to_17 = values_by_record[
-        "census_acs.acs1_2023.b01001.female_age.01."
-        "age_15_to_17.female_population"
+        "census_acs.acs1_2023.b01001.female_age.01.age_15_to_17.female_population"
     ]
     ca_age_40_to_44 = values_by_record[
-        "census_acs.acs1_2023.b01001.female_age.06."
-        "age_40_to_44.female_population"
+        "census_acs.acs1_2023.b01001.female_age.06.age_40_to_44.female_population"
     ]
     pr_age_40_to_44 = values_by_record[
-        "census_acs.acs1_2023.b01001.female_age.72."
-        "age_40_to_44.female_population"
+        "census_acs.acs1_2023.b01001.female_age.72.age_40_to_44.female_population"
     ]
 
     assert al_age_15_to_17.value == 100_354
@@ -1417,9 +1460,7 @@ def test_census_acs_s2201_source_package_alias_validates_fixture_counts():
 
 
 def test_census_acs_s2201_congressional_district_package_builds_snap_facts():
-    package = load_source_package(
-        "census-acs-s2201-congressional-district-snap-2024"
-    )
+    package = load_source_package("census-acs-s2201-congressional-district-snap-2024")
     rows = package.build_source_rows(2024)
     cells = package.build_source_cells(2024, source_rows=rows)
     facts = package.build_facts(2024, cells=cells, source_rows=rows)
@@ -1538,9 +1579,7 @@ def test_validate_source_package_reports_cms_aca_effectuated_enrollment_2022_cou
 
 
 def test_cms_medicaid_package_builds_december_2024_state_enrollment_facts():
-    package = load_source_package(
-        "cms-medicaid-chip-monthly-enrollment-december-2024"
-    )
+    package = load_source_package("cms-medicaid-chip-monthly-enrollment-december-2024")
     cells = package.build_source_cells(2023)
     records = package.build_source_records(2023, cells=cells)
     facts = package.build_facts(2023, cells=cells)
@@ -1555,24 +1594,19 @@ def test_cms_medicaid_package_builds_december_2024_state_enrollment_facts():
     assert all(fact.source.raw_r2_uri for fact in facts)
 
     us_medicaid = (
-        "cms_medicaid.month2024_12.state_enrollment.us."
-        "total_medicaid_enrollment"
+        "cms_medicaid.month2024_12.state_enrollment.us.total_medicaid_enrollment"
     )
     ca_medicaid = (
-        "cms_medicaid.month2024_12.state_enrollment.ca."
-        "total_medicaid_enrollment"
+        "cms_medicaid.month2024_12.state_enrollment.ca.total_medicaid_enrollment"
     )
     tx_medicaid_chip = (
-        "cms_medicaid.month2024_12.state_enrollment.tx."
-        "total_medicaid_chip_enrollment"
+        "cms_medicaid.month2024_12.state_enrollment.tx.total_medicaid_chip_enrollment"
     )
     ny_adult = (
-        "cms_medicaid.month2024_12.state_enrollment.ny."
-        "total_adult_medicaid_enrollment"
+        "cms_medicaid.month2024_12.state_enrollment.ny.total_adult_medicaid_enrollment"
     )
     fl_child = (
-        "cms_medicaid.month2024_12.state_enrollment.fl."
-        "medicaid_chip_child_enrollment"
+        "cms_medicaid.month2024_12.state_enrollment.fl.medicaid_chip_child_enrollment"
     )
 
     assert records_by_id[us_medicaid].source_cell_addresses[:3] == (
@@ -1636,8 +1670,7 @@ def test_cms_medicaid_monthly_dataset_builds_december_2025_state_enrollment_fact
     assert all(fact.source_row_keys for fact in facts)
     assert all(fact.source.source_name == "cms_medicaid" for fact in facts)
     assert all(
-        fact.source.source_file == "pi-dataset-april-2026-release.csv"
-        for fact in facts
+        fact.source.source_file == "pi-dataset-april-2026-release.csv" for fact in facts
     )
     assert all(fact.source.raw_r2_uri for fact in facts)
     assert {f"{fact.period.type}:{fact.period.value}" for fact in facts} == {
@@ -1645,31 +1678,23 @@ def test_cms_medicaid_monthly_dataset_builds_december_2025_state_enrollment_fact
     }
 
     ca_total = (
-        "cms_medicaid.month2025_12.state_enrollment.ca."
-        "total_medicaid_chip_enrollment"
+        "cms_medicaid.month2025_12.state_enrollment.ca.total_medicaid_chip_enrollment"
     )
     ca_medicaid = (
-        "cms_medicaid.month2025_12.state_enrollment.ca."
-        "total_medicaid_enrollment"
+        "cms_medicaid.month2025_12.state_enrollment.ca.total_medicaid_enrollment"
     )
-    ca_chip = (
-        "cms_medicaid.month2025_12.state_enrollment.ca.total_chip_enrollment"
-    )
+    ca_chip = "cms_medicaid.month2025_12.state_enrollment.ca.total_chip_enrollment"
     ca_child = (
-        "cms_medicaid.month2025_12.state_enrollment.ca."
-        "medicaid_chip_child_enrollment"
+        "cms_medicaid.month2025_12.state_enrollment.ca.medicaid_chip_child_enrollment"
     )
     ca_adult = (
-        "cms_medicaid.month2025_12.state_enrollment.ca."
-        "total_adult_medicaid_enrollment"
+        "cms_medicaid.month2025_12.state_enrollment.ca.total_adult_medicaid_enrollment"
     )
     tx_total = (
-        "cms_medicaid.month2025_12.state_enrollment.tx."
-        "total_medicaid_chip_enrollment"
+        "cms_medicaid.month2025_12.state_enrollment.tx.total_medicaid_chip_enrollment"
     )
     ny_total = (
-        "cms_medicaid.month2025_12.state_enrollment.ny."
-        "total_medicaid_chip_enrollment"
+        "cms_medicaid.month2025_12.state_enrollment.ny.total_medicaid_chip_enrollment"
     )
 
     assert records_by_id[ca_total].source_cell_addresses == (
@@ -1812,8 +1837,7 @@ def test_soi_congressional_district_2022_builds_all_return_facts():
         "al_01.adjusted_gross_income"
     ]
     ca_53_returns = values_by_record[
-        "irs_soi.ty2022.congressional_district_2022.all_returns."
-        "ca_53.return_count"
+        "irs_soi.ty2022.congressional_district_2022.all_returns.ca_53.return_count"
     ]
 
     assert al_01_agi.value == 22_915_824_000
@@ -1847,9 +1871,7 @@ def test_soi_historic_table_2_package_builds_2022_national_facts():
     ptc_returns = values_by_record[
         "irs_soi.ty2022.historic_table_2.us.all.premium_tax_credit_returns"
     ]
-    eitc_amount = values_by_record[
-        "irs_soi.ty2022.historic_table_2.us.all.eitc_amount"
-    ]
+    eitc_amount = values_by_record["irs_soi.ty2022.historic_table_2.us.all.eitc_amount"]
     real_estate_taxes = values_by_record[
         "irs_soi.ty2022.historic_table_2.us.all.real_estate_taxes_amount"
     ]
@@ -1865,18 +1887,12 @@ def test_soi_historic_table_2_package_builds_2022_national_facts():
     medical_dental = values_by_record[
         "irs_soi.ty2022.historic_table_2.us.all.medical_dental_expense_amount"
     ]
-    qbi = values_by_record[
-        "irs_soi.ty2022.historic_table_2.us.all.qbi_amount"
-    ]
+    qbi = values_by_record["irs_soi.ty2022.historic_table_2.us.all.qbi_amount"]
     rental = values_by_record[
         "irs_soi.ty2022.historic_table_2.us.all.rental_royalty_income_amount"
     ]
-    ctc = values_by_record[
-        "irs_soi.ty2022.historic_table_2.us.all.ctc_amount"
-    ]
-    actc = values_by_record[
-        "irs_soi.ty2022.historic_table_2.us.all.actc_amount"
-    ]
+    ctc = values_by_record["irs_soi.ty2022.historic_table_2.us.all.ctc_amount"]
+    actc = values_by_record["irs_soi.ty2022.historic_table_2.us.all.actc_amount"]
     agi_bracket_eitc_claims = values_by_record[
         "irs_soi.ty2022.historic_table_2.us.1_to_10k.eitc_claims"
     ]
@@ -1894,7 +1910,9 @@ def test_soi_historic_table_2_package_builds_2022_national_facts():
     assert ctc.value == 82_862_736_000
     assert actc.value == 33_857_987_000
     assert agi_bracket_eitc_claims.value == 5_013_220
-    assert {constraint.operator for constraint in agi_bracket_eitc_claims.constraints} == {
+    assert {
+        constraint.operator for constraint in agi_bracket_eitc_claims.constraints
+    } == {
         "<",
         ">=",
     }
@@ -1970,12 +1988,10 @@ def test_soi_historic_table_2_state_eitc_package_builds_child_count_facts():
     assert len(facts) == 510
 
     ca_one_child_amount = values_by_record[
-        "irs_soi.ty2022.historic_table_2.state_eitc.ca.ca."
-        "eitc_one_child_amount"
+        "irs_soi.ty2022.historic_table_2.state_eitc.ca.ca.eitc_one_child_amount"
     ]
     ca_two_children_claims = values_by_record[
-        "irs_soi.ty2022.historic_table_2.state_eitc.ca.ca."
-        "eitc_two_children_claims"
+        "irs_soi.ty2022.historic_table_2.state_eitc.ca.ca.eitc_two_children_claims"
     ]
     ca_three_or_more_amount = values_by_record[
         "irs_soi.ty2022.historic_table_2.state_eitc.ca.ca."
@@ -1986,9 +2002,9 @@ def test_soi_historic_table_2_state_eitc_package_builds_child_count_facts():
     assert ca_two_children_claims.value == 550_910
     assert ca_three_or_more_amount.value == 1_266_651_000
     assert ca_one_child_amount.filters["eitc_child_count"] == 1
-    assert {
-        constraint.variable for constraint in ca_one_child_amount.constraints
-    } == {"us.tax.earned_income_credit_qualifying_children"}
+    assert {constraint.variable for constraint in ca_one_child_amount.constraints} == {
+        "us.tax.earned_income_credit_qualifying_children"
+    }
     assert {
         constraint.operator for constraint in ca_three_or_more_amount.constraints
     } == {">="}


### PR DESCRIPTION
## Summary
- add a JCT 2024 tax expenditure source package for selected individual income tax revenue-loss estimates from JCX-48-24 Table 1
- include checked-in source rows, manifest provenance, source package metadata, alias, and bundle/source-package tests
- preserve source lineage so Populace can target these facts through simple reform deltas rather than storing target values locally

## Source
- JCT publication page: https://www.jct.gov/publications/2024/jcx-48-24/
- JCT PDF: https://www.jct.gov/getattachment/765709fb-9a4b-430a-8f9e-4d342ec97f7e/x-48-24.pdf

## Validation
- uv run ruff check arch/source_package.py tests/test_arch_source_package.py tests/test_arch_bundle.py
- uv run pytest tests/test_arch_source_package.py tests/test_arch_bundle.py -q -k "jct_tax_expenditure or jct_tax_expenditure_source"
- git diff --check