### PR TITLE
Add SOI filing-season EITC AGI facts

### DIFF
--- a/arch/source_package.py
+++ b/arch/source_package.py
@@ -1061,6 +1061,17 @@ def _validate_record_set_authoring(
     for index, row in enumerate(record_set.rows):
         row_ids.setdefault(row.value_id, []).append(index)
         row_ordinals.setdefault(row.ordinal, []).append(index)
+        if row.column is not None and not EXCEL_COLUMN_RE.match(row.column):
+            errors.append(
+                SourcePackageIssue(
+                    code="malformed_row_column",
+                    message=(
+                        "Row column must be an Excel column name like B or AA."
+                    ),
+                    record_set_id=record_set.record_set_id,
+                    row_id=row.value_id,
+                )
+            )
         if _row_needs_constraints(row) and not row.constraints:
             errors.append(
                 SourcePackageIssue(
@@ -1266,6 +1277,7 @@ def _artifact_from_mapping(payload: dict[str, Any]) -> SourceArtifactSpec:
 
 
 def _row_from_mapping(payload: dict[str, Any], *, year: int) -> SourceRecordSetRow:
+    row_column = _optional_excel_column_from_mapping(payload, "column", year=year)
     return SourceRecordSetRow(
         value_id=_required(payload, "value_id", "row"),
         label=_required(payload, "label", "row"),
@@ -1276,6 +1288,26 @@ def _row_from_mapping(payload: dict[str, Any], *, year: int) -> SourceRecordSetR
             if payload.get("row_end_number") is not None
             else None
         ),
+        column=row_column,
+        source_column_id=(
+            str(_render_value(payload["source_column_id"], year=year))
+            if payload.get("source_column_id") is not None
+            else None
+        ),
+        expected_column_header_row=(
+            int(payload["expected_column_header_row"])
+            if payload.get("expected_column_header_row") is not None
+            else None
+        ),
+        expected_column_header=_render_value(
+            _year_mapping(payload["expected_column_header_by_year"], year)
+            if "expected_column_header_by_year" in payload
+            else payload["expected_column_header"],
+            year=year,
+        )
+        if "expected_column_header" in payload
+        or "expected_column_header_by_year" in payload
+        else None,
         geography_id=payload.get("geography_id"),
         geography_level=payload.get("geography_level"),
         geography_name=payload.get("geography_name"),
@@ -1475,6 +1507,24 @@ def _measure_column_from_mapping(payload: dict[str, Any], *, year: int) -> str:
     if "column_by_year" in payload:
         return str(_year_mapping(payload["column_by_year"], year))
     return str(_required(payload, "column", "measure"))
+
+
+def _optional_excel_column_from_mapping(
+    payload: dict[str, Any],
+    field: str,
+    *,
+    year: int,
+) -> str | None:
+    by_year_field = f"{field}_by_year"
+    if by_year_field in payload:
+        value = str(_year_mapping(payload[by_year_field], year)).upper()
+    elif payload.get(field) is not None:
+        value = str(_render_value(payload[field], year=year)).upper()
+    else:
+        return None
+    if EXCEL_COLUMN_RE.fullmatch(value) is None:
+        raise ValueError(f"Malformed row {field}: {value!r}")
+    return value
 
 
 def _record_set_period_from_mapping(

--- a/arch/sources/specs.py
+++ b/arch/sources/specs.py
@@ -121,6 +121,10 @@ class SourceRecordSetRow:
     ordinal: int
     row_number: int
     row_end_number: int | None = None
+    column: str | None = None
+    source_column_id: str | None = None
+    expected_column_header_row: int | None = None
+    expected_column_header: Scalar = None
     geography_id: str | None = None
     geography_level: str | None = None
     geography_name: str | None = None
@@ -206,6 +210,17 @@ def compile_source_record_set_specs(
     source_specs: list[SourceRecordSpec] = []
     for row in sorted(spec.rows, key=lambda item: item.ordinal):
         for measure in sorted(spec.measures, key=lambda item: item.ordinal):
+            source_column = row.column or measure.column
+            column_header_row = (
+                row.expected_column_header_row
+                if row.expected_column_header_row is not None
+                else measure.expected_column_header_row
+            )
+            column_header = (
+                row.expected_column_header
+                if row.expected_column_header is not None
+                else measure.expected_column_header
+            )
             source_record_id = (
                 f"{spec.source_record_id_prefix}.{row.value_id}.{measure.measure_id}"
             )
@@ -216,9 +231,9 @@ def compile_source_record_set_specs(
                     selector=CellSelectorSpec(
                         selector_id=f"{source_record_id}.selector",
                         sheet_name=spec.sheet_name,
-                        address=f"{measure.column}{row.row_number}",
+                        address=f"{source_column}{row.row_number}",
                         end_address=(
-                            f"{measure.column}{row.row_end_number}"
+                            f"{source_column}{row.row_end_number}"
                             if row.row_end_number is not None
                             else None
                         ),
@@ -232,11 +247,11 @@ def compile_source_record_set_specs(
                             else row.label
                         ),
                         expected_column_header_address=(
-                            f"{measure.column}{measure.expected_column_header_row}"
-                            if measure.expected_column_header_row is not None
+                            f"{source_column}{column_header_row}"
+                            if column_header_row is not None
                             else None
                         ),
-                        expected_column_header=measure.expected_column_header,
+                        expected_column_header=column_header,
                         guard_cells=_row_guard_cells(row),
                         range_label_guards=_row_range_label_guards(row),
                     ),
@@ -286,7 +301,9 @@ def compile_source_record_set_specs(
                         measure_ordinal=measure.ordinal,
                         source_row_id=row.source_row_id or row.value_id,
                         source_column_id=(
-                            measure.source_column_id or measure.measure_id
+                            row.source_column_id
+                            or measure.source_column_id
+                            or measure.measure_id
                         ),
                         table_record_kind=row.table_record_kind,
                     ),
@@ -308,6 +325,11 @@ def source_regions_from_record_set_spec(
     columns = [
         1,
         *(_excel_column_number(measure.column) for measure in spec.measures),
+        *(
+            _excel_column_number(row.column)
+            for row in spec.rows
+            if row.column is not None
+        ),
     ]
     return (
         SourceRegionSpec(
@@ -716,6 +738,14 @@ def _record_set_spec_hash(spec: SourceRecordSetSpec) -> str:
     for row in payload["rows"]:
         if row.get("row_end_number") is None:
             row.pop("row_end_number", None)
+        if row.get("column") is None:
+            row.pop("column", None)
+        if row.get("source_column_id") is None:
+            row.pop("source_column_id", None)
+        if row.get("expected_column_header_row") is None:
+            row.pop("expected_column_header_row", None)
+        if row.get("expected_column_header") is None:
+            row.pop("expected_column_header", None)
         if row.get("expected_row_header") is None:
             row.pop("expected_row_header", None)
         if row.get("expected_row_header_column") is None:

--- a/arch/targets/us_poverty.py
+++ b/arch/targets/us_poverty.py
@@ -82,6 +82,7 @@ US_POVERTY_NONFILER_TARGET_COVERAGE: tuple[TargetSourceCoverage, ...] = (
             "soi-table-2-1",
             "soi-table-2-5",
             "soi-table-2-5-eitc-agi-children-2023",
+            "soi-filing-season-week47-2024-eitc-total",
             "soi-table-4-3",
             "soi-state-2022",
             "soi-historic-table-2",

--- a/packages/irs_soi/filing_season_week47_2024/source_package.yaml
+++ b/packages/irs_soi/filing_season_week47_2024/source_package.yaml
@@ -1,6 +1,6 @@
 schema_version: arch.source_package.v1
 package_id: soi-filing-season-week47-2024-eitc-total
-label: IRS SOI filing season week 47 EITC totals 2024
+label: IRS SOI filing season week 47 EITC totals and AGI distribution 2024
 artifact:
   source_name: irs_soi
   source_table: Filing Season Statistics Table 1
@@ -91,6 +91,537 @@ record_sets:
             expected_value: "Earned income credit:\n    Number of returns"
             label: adjacent EITC return row
         table_record_kind: total
+    measures:
+      - measure_id: total_earned_income_credit_amount
+        label: Total earned income credit
+        ordinal: 0
+        column: B
+        source_column_id: total_returns
+        expected_column_header_row: 4
+        expected_column_header: "Total\nreturns"
+        concept: irs_soi.total_earned_income_credit
+        unit: usd
+        aggregation: sum
+        value_scale: 1000
+        expected_cell_type: number
+  - record_set_id: irs_soi.ty2024.filing_season_week47.eitc_by_agi.count
+    record_set_spec_id: irs_soi.filing_season_week47.eitc_by_agi_count.v1
+    source_record_id_prefix: irs_soi.ty2024.filing_season_week47.eitc_by_agi
+    sheet_name: Filing Season
+    period_type: tax_year
+    period: 2024
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: 2020_census
+    entity: tax_unit
+    entity_role: filing_unit
+    domain: all_individual_income_tax_returns
+    groupby_dimension: us:statutes/26/62#adjusted_gross_income
+    rows:
+      - value_id: under_1
+        label: No adjusted gross income and deficit
+        ordinal: 0
+        row_number: 115
+        column: C
+        source_column_id: under_1
+        expected_row_header_column: A
+        expected_row_header: "Earned income credit:\n    Number of returns"
+        expected_column_header_row: 4
+        expected_column_header: "No adjusted gross\nincome and deficit"
+        filters: {income_range: under_1}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 1, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 1_to_5k
+        label: $1 under $5,000
+        ordinal: 1
+        row_number: 115
+        column: D
+        source_column_id: 1_to_5k
+        expected_row_header_column: A
+        expected_row_header: "Earned income credit:\n    Number of returns"
+        expected_column_header_row: 4
+        expected_column_header: "$1 under\n$5,000"
+        filters: {income_range: 1_to_5k}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 1, unit: usd, label: Adjusted gross income lower bound}
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 5000, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 5k_to_10k
+        label: $5,000 under $10,000
+        ordinal: 2
+        row_number: 115
+        column: E
+        source_column_id: 5k_to_10k
+        expected_row_header_column: A
+        expected_row_header: "Earned income credit:\n    Number of returns"
+        expected_column_header_row: 4
+        expected_column_header: "$5,000 under\n$10,000"
+        filters: {income_range: 5k_to_10k}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 5000, unit: usd, label: Adjusted gross income lower bound}
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 10000, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 10k_to_15k
+        label: $10,000 under $15,000
+        ordinal: 3
+        row_number: 115
+        column: F
+        source_column_id: 10k_to_15k
+        expected_row_header_column: A
+        expected_row_header: "Earned income credit:\n    Number of returns"
+        expected_column_header_row: 4
+        expected_column_header: "$10,000 under\n$15,000"
+        filters: {income_range: 10k_to_15k}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 10000, unit: usd, label: Adjusted gross income lower bound}
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 15000, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 15k_to_20k
+        label: $15,000 under $20,000
+        ordinal: 4
+        row_number: 115
+        column: G
+        source_column_id: 15k_to_20k
+        expected_row_header_column: A
+        expected_row_header: "Earned income credit:\n    Number of returns"
+        expected_column_header_row: 4
+        expected_column_header: "$15,000 under\n$20,000"
+        filters: {income_range: 15k_to_20k}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 15000, unit: usd, label: Adjusted gross income lower bound}
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 20000, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 20k_to_25k
+        label: $20,000 under $25,000
+        ordinal: 5
+        row_number: 115
+        column: H
+        source_column_id: 20k_to_25k
+        expected_row_header_column: A
+        expected_row_header: "Earned income credit:\n    Number of returns"
+        expected_column_header_row: 4
+        expected_column_header: "$20,000 under\n$25,000"
+        filters: {income_range: 20k_to_25k}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 20000, unit: usd, label: Adjusted gross income lower bound}
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 25000, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 25k_to_30k
+        label: $25,000 under $30,000
+        ordinal: 6
+        row_number: 115
+        column: I
+        source_column_id: 25k_to_30k
+        expected_row_header_column: A
+        expected_row_header: "Earned income credit:\n    Number of returns"
+        expected_column_header_row: 4
+        expected_column_header: "$25,000 under\n$30,000"
+        filters: {income_range: 25k_to_30k}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 25000, unit: usd, label: Adjusted gross income lower bound}
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 30000, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 30k_to_40k
+        label: $30,000 under $40,000
+        ordinal: 7
+        row_number: 115
+        column: J
+        source_column_id: 30k_to_40k
+        expected_row_header_column: A
+        expected_row_header: "Earned income credit:\n    Number of returns"
+        expected_column_header_row: 4
+        expected_column_header: "$30,000 under\n$40,000"
+        filters: {income_range: 30k_to_40k}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 30000, unit: usd, label: Adjusted gross income lower bound}
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 40000, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 40k_to_50k
+        label: $40,000 under $50,000
+        ordinal: 8
+        row_number: 115
+        column: K
+        source_column_id: 40k_to_50k
+        expected_row_header_column: A
+        expected_row_header: "Earned income credit:\n    Number of returns"
+        expected_column_header_row: 4
+        expected_column_header: "$40,000 under\n$50,000"
+        filters: {income_range: 40k_to_50k}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 40000, unit: usd, label: Adjusted gross income lower bound}
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 50000, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 50k_to_75k
+        label: $50,000 under $75,000
+        ordinal: 9
+        row_number: 115
+        column: L
+        source_column_id: 50k_to_75k
+        expected_row_header_column: A
+        expected_row_header: "Earned income credit:\n    Number of returns"
+        expected_column_header_row: 4
+        expected_column_header: "$50,000 under\n$75,000"
+        filters: {income_range: 50k_to_75k}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 50000, unit: usd, label: Adjusted gross income lower bound}
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 75000, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 75k_to_100k
+        label: $75,000 under $100,000
+        ordinal: 10
+        row_number: 115
+        column: M
+        source_column_id: 75k_to_100k
+        expected_row_header_column: A
+        expected_row_header: "Earned income credit:\n    Number of returns"
+        expected_column_header_row: 4
+        expected_column_header: "$75,000 under\n$100,000"
+        filters: {income_range: 75k_to_100k}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 75000, unit: usd, label: Adjusted gross income lower bound}
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 100000, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 100k_to_200k
+        label: $100,000 under $200,000
+        ordinal: 11
+        row_number: 115
+        column: N
+        source_column_id: 100k_to_200k
+        expected_row_header_column: A
+        expected_row_header: "Earned income credit:\n    Number of returns"
+        expected_column_header_row: 4
+        expected_column_header: "$100,000 under\n$200,000"
+        filters: {income_range: 100k_to_200k}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 100000, unit: usd, label: Adjusted gross income lower bound}
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 200000, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 200k_to_250k
+        label: $200,000 under $250,000
+        ordinal: 12
+        row_number: 115
+        column: O
+        source_column_id: 200k_to_250k
+        expected_row_header_column: A
+        expected_row_header: "Earned income credit:\n    Number of returns"
+        expected_column_header_row: 4
+        expected_column_header: "$200,000 under\n$250,000"
+        filters: {income_range: 200k_to_250k}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 200000, unit: usd, label: Adjusted gross income lower bound}
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 250000, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 250k_to_500k
+        label: $250,000 under $500,000
+        ordinal: 13
+        row_number: 115
+        column: P
+        source_column_id: 250k_to_500k
+        expected_row_header_column: A
+        expected_row_header: "Earned income credit:\n    Number of returns"
+        expected_column_header_row: 4
+        expected_column_header: "$250,000 under\n$500,000"
+        filters: {income_range: 250k_to_500k}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 250000, unit: usd, label: Adjusted gross income lower bound}
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 500000, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 500k_to_1m
+        label: $500,000 under $1,000,000
+        ordinal: 14
+        row_number: 115
+        column: Q
+        source_column_id: 500k_to_1m
+        expected_row_header_column: A
+        expected_row_header: "Earned income credit:\n    Number of returns"
+        expected_column_header_row: 4
+        expected_column_header: "$500,000 under\n$1,000,000"
+        filters: {income_range: 500k_to_1m}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 500000, unit: usd, label: Adjusted gross income lower bound}
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 1000000, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 1m_plus
+        label: $1,000,000 or more
+        ordinal: 15
+        row_number: 115
+        column: R
+        source_column_id: 1m_plus
+        expected_row_header_column: A
+        expected_row_header: "Earned income credit:\n    Number of returns"
+        expected_column_header_row: 4
+        expected_column_header: "$1,000,000 or\nmore"
+        filters: {income_range: 1m_plus}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 1000000, unit: usd, label: Adjusted gross income lower bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+    measures:
+      - measure_id: total_earned_income_credit_returns
+        label: Returns with total earned income credit
+        ordinal: 0
+        column: B
+        source_column_id: total_returns
+        expected_column_header_row: 4
+        expected_column_header: "Total\nreturns"
+        concept: irs_soi.returns_with_total_earned_income_credit
+        unit: count
+        aggregation: count
+        expected_cell_type: number
+  - record_set_id: irs_soi.ty2024.filing_season_week47.eitc_by_agi.amount
+    record_set_spec_id: irs_soi.filing_season_week47.eitc_by_agi_amount.v1
+    source_record_id_prefix: irs_soi.ty2024.filing_season_week47.eitc_by_agi
+    sheet_name: Filing Season
+    period_type: tax_year
+    period: 2024
+    geography_id: 0100000US
+    geography_level: country
+    geography_name: United States
+    geography_vintage: 2020_census
+    entity: tax_unit
+    entity_role: filing_unit
+    domain: all_individual_income_tax_returns
+    groupby_dimension: us:statutes/26/62#adjusted_gross_income
+    rows:
+      - value_id: under_1
+        label: No adjusted gross income and deficit
+        ordinal: 0
+        row_number: 116
+        column: C
+        source_column_id: under_1
+        expected_row_header_column: A
+        expected_row_header: "    Amount"
+        expected_column_header_row: 4
+        expected_column_header: "No adjusted gross\nincome and deficit"
+        filters: {income_range: under_1}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 1, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 1_to_5k
+        label: $1 under $5,000
+        ordinal: 1
+        row_number: 116
+        column: D
+        source_column_id: 1_to_5k
+        expected_row_header_column: A
+        expected_row_header: "    Amount"
+        expected_column_header_row: 4
+        expected_column_header: "$1 under\n$5,000"
+        filters: {income_range: 1_to_5k}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 1, unit: usd, label: Adjusted gross income lower bound}
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 5000, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 5k_to_10k
+        label: $5,000 under $10,000
+        ordinal: 2
+        row_number: 116
+        column: E
+        source_column_id: 5k_to_10k
+        expected_row_header_column: A
+        expected_row_header: "    Amount"
+        expected_column_header_row: 4
+        expected_column_header: "$5,000 under\n$10,000"
+        filters: {income_range: 5k_to_10k}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 5000, unit: usd, label: Adjusted gross income lower bound}
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 10000, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 10k_to_15k
+        label: $10,000 under $15,000
+        ordinal: 3
+        row_number: 116
+        column: F
+        source_column_id: 10k_to_15k
+        expected_row_header_column: A
+        expected_row_header: "    Amount"
+        expected_column_header_row: 4
+        expected_column_header: "$10,000 under\n$15,000"
+        filters: {income_range: 10k_to_15k}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 10000, unit: usd, label: Adjusted gross income lower bound}
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 15000, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 15k_to_20k
+        label: $15,000 under $20,000
+        ordinal: 4
+        row_number: 116
+        column: G
+        source_column_id: 15k_to_20k
+        expected_row_header_column: A
+        expected_row_header: "    Amount"
+        expected_column_header_row: 4
+        expected_column_header: "$15,000 under\n$20,000"
+        filters: {income_range: 15k_to_20k}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 15000, unit: usd, label: Adjusted gross income lower bound}
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 20000, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 20k_to_25k
+        label: $20,000 under $25,000
+        ordinal: 5
+        row_number: 116
+        column: H
+        source_column_id: 20k_to_25k
+        expected_row_header_column: A
+        expected_row_header: "    Amount"
+        expected_column_header_row: 4
+        expected_column_header: "$20,000 under\n$25,000"
+        filters: {income_range: 20k_to_25k}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 20000, unit: usd, label: Adjusted gross income lower bound}
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 25000, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 25k_to_30k
+        label: $25,000 under $30,000
+        ordinal: 6
+        row_number: 116
+        column: I
+        source_column_id: 25k_to_30k
+        expected_row_header_column: A
+        expected_row_header: "    Amount"
+        expected_column_header_row: 4
+        expected_column_header: "$25,000 under\n$30,000"
+        filters: {income_range: 25k_to_30k}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 25000, unit: usd, label: Adjusted gross income lower bound}
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 30000, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 30k_to_40k
+        label: $30,000 under $40,000
+        ordinal: 7
+        row_number: 116
+        column: J
+        source_column_id: 30k_to_40k
+        expected_row_header_column: A
+        expected_row_header: "    Amount"
+        expected_column_header_row: 4
+        expected_column_header: "$30,000 under\n$40,000"
+        filters: {income_range: 30k_to_40k}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 30000, unit: usd, label: Adjusted gross income lower bound}
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 40000, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 40k_to_50k
+        label: $40,000 under $50,000
+        ordinal: 8
+        row_number: 116
+        column: K
+        source_column_id: 40k_to_50k
+        expected_row_header_column: A
+        expected_row_header: "    Amount"
+        expected_column_header_row: 4
+        expected_column_header: "$40,000 under\n$50,000"
+        filters: {income_range: 40k_to_50k}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 40000, unit: usd, label: Adjusted gross income lower bound}
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 50000, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 50k_to_75k
+        label: $50,000 under $75,000
+        ordinal: 9
+        row_number: 116
+        column: L
+        source_column_id: 50k_to_75k
+        expected_row_header_column: A
+        expected_row_header: "    Amount"
+        expected_column_header_row: 4
+        expected_column_header: "$50,000 under\n$75,000"
+        filters: {income_range: 50k_to_75k}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 50000, unit: usd, label: Adjusted gross income lower bound}
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 75000, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 75k_to_100k
+        label: $75,000 under $100,000
+        ordinal: 10
+        row_number: 116
+        column: M
+        source_column_id: 75k_to_100k
+        expected_row_header_column: A
+        expected_row_header: "    Amount"
+        expected_column_header_row: 4
+        expected_column_header: "$75,000 under\n$100,000"
+        filters: {income_range: 75k_to_100k}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 75000, unit: usd, label: Adjusted gross income lower bound}
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 100000, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 100k_to_200k
+        label: $100,000 under $200,000
+        ordinal: 11
+        row_number: 116
+        column: N
+        source_column_id: 100k_to_200k
+        expected_row_header_column: A
+        expected_row_header: "    Amount"
+        expected_column_header_row: 4
+        expected_column_header: "$100,000 under\n$200,000"
+        filters: {income_range: 100k_to_200k}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 100000, unit: usd, label: Adjusted gross income lower bound}
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 200000, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 200k_to_250k
+        label: $200,000 under $250,000
+        ordinal: 12
+        row_number: 116
+        column: O
+        source_column_id: 200k_to_250k
+        expected_row_header_column: A
+        expected_row_header: "    Amount"
+        expected_column_header_row: 4
+        expected_column_header: "$200,000 under\n$250,000"
+        filters: {income_range: 200k_to_250k}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 200000, unit: usd, label: Adjusted gross income lower bound}
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 250000, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 250k_to_500k
+        label: $250,000 under $500,000
+        ordinal: 13
+        row_number: 116
+        column: P
+        source_column_id: 250k_to_500k
+        expected_row_header_column: A
+        expected_row_header: "    Amount"
+        expected_column_header_row: 4
+        expected_column_header: "$250,000 under\n$500,000"
+        filters: {income_range: 250k_to_500k}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 250000, unit: usd, label: Adjusted gross income lower bound}
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 500000, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 500k_to_1m
+        label: $500,000 under $1,000,000
+        ordinal: 14
+        row_number: 116
+        column: Q
+        source_column_id: 500k_to_1m
+        expected_row_header_column: A
+        expected_row_header: "    Amount"
+        expected_column_header_row: 4
+        expected_column_header: "$500,000 under\n$1,000,000"
+        filters: {income_range: 500k_to_1m}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 500000, unit: usd, label: Adjusted gross income lower bound}
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '<', value: 1000000, unit: usd, label: Adjusted gross income upper bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
+      - value_id: 1m_plus
+        label: $1,000,000 or more
+        ordinal: 15
+        row_number: 116
+        column: R
+        source_column_id: 1m_plus
+        expected_row_header_column: A
+        expected_row_header: "    Amount"
+        expected_column_header_row: 4
+        expected_column_header: "$1,000,000 or\nmore"
+        filters: {income_range: 1m_plus}
+        constraints:
+          - {variable: us:statutes/26/62#adjusted_gross_income, operator: '>=', value: 1000000, unit: usd, label: Adjusted gross income lower bound}
+        guard_cells: [{column: A, row: 1, expected_value: "Table 1.  All Individual Returns: Selected Income Items, Adjustments, \nCredits, and Taxes, by Size of Adjusted Gross Income, Tax Year 2024 \n(through Filing Season 2025 Cycle 47, November 20, 2025) [1]", label: table title}]
     measures:
       - measure_id: total_earned_income_credit_amount
         label: Total earned income credit

--- a/tests/test_arch_source_package.py
+++ b/tests/test_arch_source_package.py
@@ -588,11 +588,11 @@ def test_national_soi_source_package_aliases_validate_fixture_counts():
             "source_region_count": 4,
         },
         "soi-filing-season-week47-2024-eitc-total": {
-            "record_set_count": 2,
-            "row_count": 2,
-            "measure_count": 2,
-            "source_record_count": 2,
-            "source_region_count": 2,
+            "record_set_count": 4,
+            "row_count": 34,
+            "measure_count": 4,
+            "source_record_count": 34,
+            "source_region_count": 4,
         },
         "soi-table-4-3": {
             "record_set_count": 1,
@@ -1272,10 +1272,40 @@ def test_soi_filing_season_week47_2024_eitc_total_builds_facts():
         "irs_soi.ty2024.filing_season_week47.eitc_all_returns."
         "earned_income_credit.total_earned_income_credit_amount"
     ]
+    low_agi_returns = values_by_record[
+        "irs_soi.ty2024.filing_season_week47.eitc_by_agi."
+        "1_to_5k.total_earned_income_credit_returns"
+    ]
+    low_agi_amount = values_by_record[
+        "irs_soi.ty2024.filing_season_week47.eitc_by_agi."
+        "1_to_5k.total_earned_income_credit_amount"
+    ]
+    mid_agi_amount = values_by_record[
+        "irs_soi.ty2024.filing_season_week47.eitc_by_agi."
+        "50k_to_75k.total_earned_income_credit_amount"
+    ]
+    high_agi_returns = values_by_record[
+        "irs_soi.ty2024.filing_season_week47.eitc_by_agi."
+        "75k_to_100k.total_earned_income_credit_returns"
+    ]
 
     assert returns.value == 23_837_149
     assert amount.value == 69_041_649_000
+    assert low_agi_returns.value == 1_587_131
+    assert low_agi_amount.value == 695_555_000
+    assert mid_agi_amount.value == 1_575_950_000
+    assert high_agi_returns.value == 0
     assert returns.layout.source_column_id == "total_returns"
+    assert low_agi_returns.layout.groupby_dimension == (
+        "us:statutes/26/62#adjusted_gross_income"
+    )
+    assert low_agi_returns.layout.groupby_value_id == "1_to_5k"
+    assert low_agi_returns.layout.source_column_id == "1_to_5k"
+    assert low_agi_returns.filters == {"income_range": "1_to_5k"}
+    assert {constraint.operator for constraint in low_agi_returns.constraints} == {
+        ">=",
+        "<",
+    }
     assert amount.source.source_file == "25inweek47.xlsx"
     assert amount.source.url == "https://www.irs.gov/pub/irs-soi/25inweek47.xlsx"
     assert amount.source.source_sha256 == (

--- a/tests/test_us_poverty_target_coverage.py
+++ b/tests/test_us_poverty_target_coverage.py
@@ -31,12 +31,13 @@ def test_us_poverty_all_named_package_aliases_are_registered():
     assert aliases <= set(SOURCE_PACKAGE_ALIASES)
 
 
-def test_us_poverty_hard_target_aliases_cover_non_soi_sources():
+def test_us_poverty_hard_target_aliases_cover_required_sources():
     aliases = set(hard_target_package_aliases())
 
     assert "bea-nipa-personal-income-components" in aliases
     assert "bea-nipa-personal-income-disposition" in aliases
     assert "bea-nipa-pension-contributions" in aliases
+    assert "soi-filing-season-week47-2024-eitc-total" in aliases
     assert "usda-snap-fy69-to-current" in aliases
     assert "ssa-ssi-table-7b1-2024" in aliases
     assert "hhs-acf-tanf-financial-2024" in aliases


### PR DESCRIPTION
## Summary
- add row-level Excel column/header overrides for source packages so transposed publisher tables can compile into one fact per source column
- extend the 2024 IRS SOI filing-season EITC package with AGI-bucket return and amount facts from Table 1
- mark the filing-season EITC package as a hard-target source coverage input and add focused assertions for the new facts

## Notes
- the 2024 filing-season source has EITC by AGI bucket, but not by qualifying-child count; Populace can use these facts for AGI-specific uprating while preserving the latest child split from TY2023 Table 2.5
- this PR only makes the source-backed Ledger facts available; Populace target-registry consumption is the next step

## Validation
- uv run pytest tests/test_arch_source_package.py::test_soi_filing_season_week47_2024_eitc_total_builds_facts tests/test_arch_source_package.py::test_national_soi_source_package_aliases_validate_fixture_counts tests/test_us_poverty_target_coverage.py -q
- uv run ruff check arch/source_package.py arch/sources/specs.py arch/targets/us_poverty.py tests/test_arch_source_package.py tests/test_us_poverty_target_coverage.py
- git diff --check