### PR TITLE
Type CBO revenue-projection record sets as source_projection

### DIFF
--- a/packages/cbo/revenue_projections_income_by_source_2026_02/source_package.yaml
+++ b/packages/cbo/revenue_projections_income_by_source_2026_02/source_package.yaml
@@ -26,6 +26,7 @@ artifact:
 record_sets:
   - record_set_id: cbo.revenue_projection.ty{year}.income_by_source.adjusted_gross_income
     record_set_spec_id: cbo.revenue_projection.income_by_source.adjusted_gross_income.v1
+    assertion: source_projection
     source_record_id_prefix: cbo.revenue_projection.ty{year}.income_by_source
     sheet_name: income_by_source
     period_type: tax_year
@@ -87,6 +88,7 @@ record_sets:
         expected_cell_type: number
   - record_set_id: cbo.revenue_projection.ty{year}.income_by_source.wages_and_salaries
     record_set_spec_id: cbo.revenue_projection.income_by_source.wages_and_salaries.v1
+    assertion: source_projection
     source_record_id_prefix: cbo.revenue_projection.ty{year}.income_by_source
     sheet_name: income_by_source
     period_type: tax_year
@@ -133,6 +135,7 @@ record_sets:
         expected_cell_type: number
   - record_set_id: cbo.revenue_projection.ty{year}.income_by_source.taxable_interest_ordinary_dividends
     record_set_spec_id: cbo.revenue_projection.income_by_source.taxable_interest_ordinary_dividends.v1
+    assertion: source_projection
     source_record_id_prefix: cbo.revenue_projection.ty{year}.income_by_source
     sheet_name: income_by_source
     period_type: tax_year
@@ -182,6 +185,7 @@ record_sets:
         expected_cell_type: number
   - record_set_id: cbo.revenue_projection.ty{year}.income_by_source.qualified_dividend_income
     record_set_spec_id: cbo.revenue_projection.income_by_source.qualified_dividend_income.v1
+    assertion: source_projection
     source_record_id_prefix: cbo.revenue_projection.ty{year}.income_by_source
     sheet_name: income_by_source
     period_type: tax_year
@@ -228,6 +232,7 @@ record_sets:
         expected_cell_type: number
   - record_set_id: cbo.revenue_projection.ty{year}.income_by_source.net_capital_gain
     record_set_spec_id: cbo.revenue_projection.income_by_source.net_capital_gain.v1
+    assertion: source_projection
     source_record_id_prefix: cbo.revenue_projection.ty{year}.income_by_source
     sheet_name: income_by_source
     period_type: tax_year
@@ -274,6 +279,7 @@ record_sets:
         expected_cell_type: number
   - record_set_id: cbo.revenue_projection.ty{year}.income_by_source.net_business_income
     record_set_spec_id: cbo.revenue_projection.income_by_source.net_business_income.v1
+    assertion: source_projection
     source_record_id_prefix: cbo.revenue_projection.ty{year}.income_by_source
     sheet_name: income_by_source
     period_type: tax_year


### PR DESCRIPTION
The 6 income-by-source record sets in the February 2026 CBO revenue-projections package are publisher forward-looking estimates — the canonical `assertion: source_projection` case from #73's schema. Without the typing, assertion-aware consumers (populace's `cbo_growth_factor_aging`, PolicyEngine/populace#287) correctly refuse these rows as growth factors when they arrive stamped as observations. The receipts package's past-FY `actual_amount` rows stay observations, which is faithful.

Validated: `ledger validate-package` passes; related tests pass. Measured effect: with this typing, the real 2023/2024 bundle supplies aging factors for 2023-source dollar targets; 2022-source rows still lack a TY2022 CBO row (workbook coverage), tracked as a follow-on.

Refs #71, PolicyEngine/populace#287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)