### PR TITLE
Document the vidimus-backed verifier invocation

### DIFF
--- a/releases/README.md
+++ b/releases/README.md
@@ -73,8 +73,12 @@ key.
 Clone the repository at the state you want to inspect and run:
 
 ```console
-python3 scripts/verify_release_chain.py --full
+uv run --locked python scripts/verify_release_chain.py --full
 ```
+
+The verifier is a thin shim over the `vidimus` package (hash-pinned in
+`uv.lock`; trust anchors stay committed in this repository under
+`scripts/vidimus_pins.py`), so the locked environment is required.
 
 The verifier needs Python, OpenSSL, the committed manifests, signatures and
 receipts, the committed anchors, and the ledger files. The project environment's


### PR DESCRIPTION
Docs-only. Deliberately the first PR whose base commit (4823afe) carries the shims: its base gate must provision the locked env and import vidimus to judge this PR — the end-to-end proof of the consumption rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)