### PR TITLE
SSA SSI federal-payment recipients by age band, December 2024

### DIFF
--- a/db/data/ssa/ssi_monthly_statistics_2024_12/manifest.yaml
+++ b/db/data/ssa/ssi_monthly_statistics_2024_12/manifest.yaml
@@ -1,0 +1,52 @@
+source_id: ssa
+package_id: ssa-ssi-monthly-statistics-2024-12
+dataset: ssa_ssi_monthly_statistics_2024_12
+source_page: https://www.ssa.gov/policy/docs/statcomps/ssi_monthly/2024-12/index.html
+table: 'SSI Monthly Statistics, December 2024, Table 1'
+files:
+  2024:
+    filename: ssi_monthly_2024_12_table01.csv
+    source_url: https://www.ssa.gov/policy/docs/statcomps/ssi_monthly/2024-12/table01.html
+    sha256: 44438b49392c2a581a239c7490492152c408213f313f450a762d84281de98e40
+    size_bytes: 475
+    fetched_at: '2026-07-21T09:01:31+00:00'
+    source_table: 'SSI Monthly Statistics, December 2024, Table 1'
+    notes: >-
+      Extracted the "Total with— Federal payment" row of SSA SSI Monthly
+      Statistics, December 2024, Table 1 (Number of recipients, total
+      payments, average monthly payment, and number of awards, by type of
+      payment, eligibility category, and age, December 2024) into long-form
+      age-group rows: all ages 7,289,843; under 18 1,001,922; 18-64
+      3,905,779; 65 or older 2,382,142. The publication is HTML-only; the
+      companion file ssi_monthly_2024_12_table01.html in this directory is
+      the verbatim capture of the published page these values were
+      extracted from. R2 storage below declares the canonical
+      content-addressed location; publish with `ledger publish-raw --root
+      db/data` from a ledger-raw-credentialed environment.
+    storage:
+      r2:
+        provider: r2
+        bucket: ledger-raw
+        key: raw/ssa/ssa-ssi-monthly-statistics-2024-12/2024/44438b49392c2a581a239c7490492152c408213f313f450a762d84281de98e40/ssi_monthly_2024_12_table01.csv
+        uri: r2://ledger-raw/raw/ssa/ssa-ssi-monthly-statistics-2024-12/2024/44438b49392c2a581a239c7490492152c408213f313f450a762d84281de98e40/ssi_monthly_2024_12_table01.csv
+  source_capture:
+    filename: ssi_monthly_2024_12_table01.html
+    source_url: https://www.ssa.gov/policy/docs/statcomps/ssi_monthly/2024-12/table01.html
+    sha256: fa999c78ffac664b6c269e57b9a115a2fa3c74fe7d894ee137f966fa68d69ad6
+    size_bytes: 17616
+    fetched_at: '2026-07-21T09:01:31+00:00'
+    notes: >-
+      Verbatim HTML capture of the published table page ("SSI Monthly
+      Statistics, December 2024 - Table 1"; DCTERMS dateCreated 2025-01,
+      dateCertified 2026-04-01). The three age-group counts (1,001,922 /
+      3,905,779 / 2,382,142) and the 7,289,843 all-ages total appear
+      verbatim in the "Total with— Federal payment" row. The page embeds
+      per-request Akamai mPulse analytics tokens inside an inline script
+      block, so refetched bytes differ there while the table content is
+      stable; the recorded sha256 pins exactly this capture.
+    storage:
+      r2:
+        provider: r2
+        bucket: ledger-raw
+        key: raw/ssa/ssa-ssi-monthly-statistics-2024-12/source_capture/fa999c78ffac664b6c269e57b9a115a2fa3c74fe7d894ee137f966fa68d69ad6/ssi_monthly_2024_12_table01.html
+        uri: r2://ledger-raw/raw/ssa/ssa-ssi-monthly-statistics-2024-12/source_capture/fa999c78ffac664b6c269e57b9a115a2fa3c74fe7d894ee137f966fa68d69ad6/ssi_monthly_2024_12_table01.html

--- a/db/data/ssa/ssi_monthly_statistics_2024_12/ssi_monthly_2024_12_table01.csv
+++ b/db/data/ssa/ssi_monthly_statistics_2024_12/ssi_monthly_2024_12_table01.csv
@@ -1,0 +1,5 @@
+payment_type,payment_type_label,geography_id,geography_level,geography_name,age,recipient_count
+federal_payment,Total with federal payment,0100000US,country,United States,All ages,7289843
+federal_payment,Total with federal payment,0100000US,country,United States,Aged 0-17,1001922
+federal_payment,Total with federal payment,0100000US,country,United States,Aged 18-64,3905779
+federal_payment,Total with federal payment,0100000US,country,United States,Aged 65 and over,2382142

--- a/db/data/ssa/ssi_monthly_statistics_2024_12/ssi_monthly_2024_12_table01.html
+++ b/db/data/ssa/ssi_monthly_statistics_2024_12/ssi_monthly_2024_12_table01.html
@@ -1,0 +1,259 @@
+<!doctype html>
+<html lang="en" class="no-js">
+<head>
+<meta charset="UTF-8" />
+<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>SSI Monthly Statistics, December 2024 - Table 1</title>
+<meta name="DCTERMS:dateCreated" content="2025-01" />
+<meta name="DCTERMS:contentOffice" content="CIO:TCDAI:RAPA" />
+<meta name="DCTERMS:contentOwner" content="jdalrymple;op.webmaster@ssa.gov" />
+<meta name="DCTERMS:coderOffice" content="CIO:TCDAI:RAPA" />
+<meta name="DCTERMS:coder" content="jdalrymple;op.webmaster@ssa.gov" />
+<meta name="DCTERMS:dateCertified" content="2026-04-01" />
+<meta name="description" content="Social Security Administration Research, Statistics, and Policy Analysis" />
+<meta property="og:site_name" content="Social Security Administration Research, Statistics, and Policy Analysis"/>
+<link rel="stylesheet" href="/policy/styles/doc.css" />
+<link rel="stylesheet" href="/policy/styles/global.css" />
+<!-- SSA INTERNET HEAD SCRIPTS -->
+<script src="/policy/js/jquery.min.js"></script>
+<script src="/framework/js/ssa.internet.head.js"></script>
+
+<script>(window.BOOMR_mq=window.BOOMR_mq||[]).push(["addVar",{"rua.upush":"false","rua.cpush":"false","rua.upre":"false","rua.cpre":"false","rua.uprl":"false","rua.cprl":"false","rua.cprf":"false","rua.trans":"","rua.cook":"false","rua.ims":"false","rua.ufprl":"false","rua.cfprl":"false","rua.isuxp":"false","rua.texp":"norulematch","rua.ceh":"false","rua.ueh":"false","rua.ieh.st":"0"}]);</script>
+                                <script>!function(e){var n="https://s.go-mpulse.net/boomerang/";if("False"=="True")e.BOOMR_config=e.BOOMR_config||{},e.BOOMR_config.PageParams=e.BOOMR_config.PageParams||{},e.BOOMR_config.PageParams.pci=!0,n="https://s2.go-mpulse.net/boomerang/";if(window.BOOMR_API_key="LERZW-HECFS-R8H4E-23UQ7-ERMQB",function(){function e(){if(!i){var e=document.createElement("script");e.id="boomr-scr-as",e.src=window.BOOMR.url,e.async=!0,o.parentNode.appendChild(e),i=!0}}function t(e){i=!0;var n,t,a,r,d=document,O=window;if(window.BOOMR.snippetMethod=e?"if":"i",t=function(e,n){var t=d.createElement("script");t.id=n||"boomr-if-as",t.src=window.BOOMR.url,BOOMR_lstart=(new Date).getTime(),e=e||d.body,e.appendChild(t)},!window.addEventListener&&window.attachEvent&&navigator.userAgent.match(/MSIE [67]\./))return window.BOOMR.snippetMethod="s",void t(o.parentNode,"boomr-async");a=document.createElement("IFRAME"),a.src="about:blank",a.title="",a.role="presentation",a.loading="eager",r=(a.frameElement||a).style,r.width=0,r.height=0,r.border=0,r.display="none",o.parentNode.appendChild(a);try{O=a.contentWindow,d=O.document.open()}catch(_){n=document.domain,a.src="javascript:var d=document.open();d.domain='"+n+"';void(0);",O=a.contentWindow,d=O.document.open()}if(n)d._boomrl=function(){this.domain=n,t()},d.write("<bo"+"dy onload='document._boomrl();'>");else if(O._boomrl=function(){t()},O.addEventListener)O.addEventListener("load",O._boomrl,!1);else if(O.attachEvent)O.attachEvent("onload",O._boomrl);d.close()}function a(e){window.BOOMR_onload=e&&e.timeStamp||(new Date).getTime()}if(!window.BOOMR||!window.BOOMR.version&&!window.BOOMR.snippetExecuted){window.BOOMR=window.BOOMR||{},window.BOOMR.snippetStart=(new Date).getTime(),window.BOOMR.snippetExecuted=!0,window.BOOMR.snippetVersion=12,window.BOOMR.url=n+"LERZW-HECFS-R8H4E-23UQ7-ERMQB";var o=document.currentScript||document.getElementsByTagName("script")[0],i=!1,r=document.createElement("link");if(r.relList&&"function"==typeof r.relList.supports&&r.relList.supports("preload")&&"as"in r)window.BOOMR.snippetMethod="p",r.href=window.BOOMR.url,r.rel="preload",r.as="script",r.addEventListener("load",e),r.addEventListener("error",function(){t(!0)}),setTimeout(function(){if(!i)t(!0)},3e3),BOOMR_lstart=(new Date).getTime(),o.parentNode.appendChild(r);else t(!1);if(window.addEventListener)window.addEventListener("load",a,!1);else if(window.attachEvent)window.attachEvent("onload",a)}}(),"".length>0)if(e&&"performance"in e&&e.performance&&"function"==typeof e.performance.setResourceTimingBufferSize)e.performance.setResourceTimingBufferSize();!function(){if(BOOMR=e.BOOMR||{},BOOMR.plugins=BOOMR.plugins||{},!BOOMR.plugins.AK){var n=""=="true"?1:0,t="",a="2h4ynyqxzfqkg2s7gvvq-f-7c54b9096-clientnsv4-s.akamaihd.net",o="false"=="true"?2:1,i={"ak.v":"41","ak.cp":"1204614","ak.ai":parseInt("728289",10),"ak.ol":"0","ak.cr":34,"ak.ipv":4,"ak.proto":"h3","ak.rid":"19ba78d8","ak.r":50991,"ak.a2":n,"ak.m":"","ak.n":"essl","ak.cport":57133,"ak.gh":"23.197.54.163","ak.quicv":"0x00000001","ak.tlsv":"tls1.3","ak.0rtt":"","ak.0rtt.ed":"","ak.csrc":"-","ak.acc":"","ak.t":"1784624491","ak.ak":"hOBiQwZUYzCg5VSAfCLimQ==p4BTiecicdLvWpTjvy2LhcEmsIm/8xtK8SJ+nOu5f4ZA+zzGJP4eIyfFbkD0AJ/xmS1RLsCXc0ucaZqP9UB1ZS24ldIFPFXieg00W7YTlULD6/ZnYjfngCyboEHCFzk/oK8CFIfmZLc2q+uJpRj+kM8i29uf/poMU/LVxSAV6dClcWzJAL2x7nlr2lViEpkCbirr8Bnc8r/uQynIxB+kUjpfjEGr8sgq9rlfdlLVZI4plSHrCbPCeJhMHW8uxELN4y91U00F9W/IBokGb3OHGQsAO+tiYv4X0cnr+U5E8G6UVtC/mcz1VWgltKIn+gi6tpaxz2kwtxvdEgt4k3OsKhj5giCh/GH86tPGsNjYMCvswpFhf54excBaM3zfW0akTeRyP/SvFja7hm+JY5oMy+oMfSvEnGytMj8r29YHjp4=","ak.pv":"143","ak.dpoabenc":"","ak.tf":o};if(""!==t)i["ak.ruds"]=t;var r={i:!1,av:function(n){var t="http.initiator";if(n&&(!n[t]||"spa_hard"===n[t]))i["ak.feo"]=void 0!==e.aFeoApplied?1:0,BOOMR.addVar(i)},rv:function(){var e=["ak.cport","ak.cr","ak.csrc","ak.gh","ak.ipv","ak.m","ak.n","ak.ol","ak.proto","ak.quicv","ak.tlsv","ak.0rtt","ak.0rtt.ed","ak.r","ak.acc","ak.t","ak.tf"];BOOMR.removeVar(e)}};BOOMR.plugins.AK={akVars:i,akDNSPreFetchDomain:a,init:function(){if(!r.i){var e=BOOMR.subscribe;e("before_beacon",r.av,null,null),e("onbeacon",r.rv,null,null),r.i=!0}return this},is_complete:function(){return!0}}}}()}(window);</script></head>
+<body>
+<article>
+  <header>
+    <div id="hLogo"><a class="navLogo" href="/policy/index.html">Social Security</a><a class="navSearch" href="https://search.ssa.gov/search?affiliate=ssa">SEARCH</a></div>
+    <div id="hRedBar">
+      <div id="hDocInfo">
+        <h1><abbr class="spell">SSI</abbr> Monthly Statistics, December&nbsp;2024</h1>
+      </div>
+    </div>
+  </header>
+  <nav>
+    <div id="breadcrumbs" itemscope itemtype="http://schema.org/BreadcrumbList">You are here: <span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><a href="/" itemprop="item"><span itemprop="name">Social Security Administration</span></a>
+      <meta itemprop="position" content="1" />
+      </span> &gt; <span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><a href="/policy/index.html" itemprop="item"><span itemprop="name">Research, Statistics &amp; Policy Analysis</span></a>
+      <meta itemprop="position" content="2" />
+      </span> &gt; <span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem"><a href="index.html" itemprop="item"><span itemprop="name"><abbr class="spell">SSI</abbr> Monthly Statistics, December&nbsp;2024</span></a>
+      <meta itemprop="position" content="3" />
+      </span></div>
+  </nav>
+  <div class="innards">
+    <h2 class="ssim">All Federally Administered Payments</h2>
+    <div class="table" id="table1">
+      <table>
+        <caption><span class="tableNumber">Table&nbsp;1. </span>Number of recipients, total payments, average monthly payment, and number of awards, by type of payment, eligibility category, and age, December&nbsp;2024</caption>
+        <colgroup span="1" style="width:16.5em"></colgroup>
+        <colgroup span="6" style="width:6.5em"></colgroup>
+        <thead>
+          <tr>
+            <th rowspan="2" class="stubHeading" id="c1">Type of payment</th>
+            <th rowspan="2" id="c2">All recipients</th>
+            <th colspan="2" class="spanner" id="c3">Eligibility category</th>
+            <th colspan="3" class="spanner" id="c4">Age</th>
+          </tr>
+          <tr>
+            <th id="c5" headers="c3">Aged</th>
+            <th id="c6" headers="c3">Blind and disabled&nbsp;<sup>a</sup></th>
+            <th id="c7" headers="c4">Under 18</th>
+            <th id="c8" headers="c4"><span class="nobr">18&ndash;64</span></th>
+            <th id="c9" headers="c4">65 or older&nbsp;<sup>b</sup></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>&nbsp;</td>
+            <th colspan="6" class="panel" id="r1">Number&nbsp;of&nbsp;recipients&nbsp;<sup>c</sup></th>
+          </tr>
+          <tr>
+            <th class="stub2" id="r2" headers="r1 c1">Total</th>
+            <td headers="r1 r2 c2">7,423,856</td>
+            <td headers="r1 r2 c3 c5">1,190,660</td>
+            <td headers="r1 r2 c3 c6">6,233,196</td>
+            <td headers="r1 r2 c4 c7">1,002,887</td>
+            <td headers="r1 r2 c4 c8">3,951,866</td>
+            <td headers="r1 r2 c4 c9">2,469,103</td>
+          </tr>
+          <tr class="topPad1">
+            <th class="stub0" id="r3" headers="r1 c1">Federal payment only</th>
+            <td headers="r1 r3 c2">6,096,703</td>
+            <td headers="r1 r3 c3 c5">788,597</td>
+            <td headers="r1 r3 c3 c6">5,308,106</td>
+            <td headers="r1 r3 c4 c7">893,939</td>
+            <td headers="r1 r3 c4 c8">3,412,777</td>
+            <td headers="r1 r3 c4 c9">1,789,987</td>
+          </tr>
+          <tr>
+            <th class="stub0" id="r4" headers="r1 c1">Federal payment and state supplementation</th>
+            <td headers="r1 r4 c2">1,193,140</td>
+            <td headers="r1 r4 c3 c5">350,587</td>
+            <td headers="r1 r4 c3 c6">842,553</td>
+            <td headers="r1 r4 c4 c7">107,983</td>
+            <td headers="r1 r4 c4 c8">493,002</td>
+            <td headers="r1 r4 c4 c9">592,155</td>
+          </tr>
+          <tr>
+            <th class="stub0" id="r5" headers="r1 c1">State supplementation only</th>
+            <td headers="r1 r5 c2">134,013</td>
+            <td headers="r1 r5 c3 c5">51,476</td>
+            <td headers="r1 r5 c3 c6">82,537</td>
+            <td headers="r1 r5 c4 c7">965</td>
+            <td headers="r1 r5 c4 c8">46,087</td>
+            <td headers="r1 r5 c4 c9">86,961</td>
+          </tr>
+          <tr>
+            <th class="stub0" id="r6" headers="r1 c1">Total with&mdash;</th>
+            <td colspan="6">&nbsp;</td>
+          </tr>
+          <tr>
+            <th class="stub1" id="r7" headers="r1 r6 c1">Federal payment</th>
+            <td headers="r1 r6 r7 c2">7,289,843</td>
+            <td headers="r1 r6 r7 c3 c5">1,139,184</td>
+            <td headers="r1 r6 r7 c3 c6">6,150,659</td>
+            <td headers="r1 r6 r7 c4 c7">1,001,922</td>
+            <td headers="r1 r6 r7 c4 c8">3,905,779</td>
+            <td headers="r1 r6 r7 c4 c9">2,382,142</td>
+          </tr>
+          <tr>
+            <th class="stub1" id="r8" headers="r1 r6 c1">State supplementation</th>
+            <td headers="r1 r6 r8 c2">1,327,153</td>
+            <td headers="r1 r6 r8 c3 c5">402,063</td>
+            <td headers="r1 r6 r8 c3 c6">925,090</td>
+            <td headers="r1 r6 r8 c4 c7">108,948</td>
+            <td headers="r1 r6 r8 c4 c8">539,089</td>
+            <td headers="r1 r6 r8 c4 c9">679,116</td>
+          </tr>
+          <tr class="topPad1">
+            <th class="stub0" id="r9" headers="r1 c1">Also receiving <abbr class="spell">OASDI</abbr> benefits</th>
+            <td headers="r1 r9 c2">2,548,159</td>
+            <td headers="r1 r9 c3 c5">679,531</td>
+            <td headers="r1 r9 c3 c6">1,868,628</td>
+            <td headers="r1 r9 c4 c7">56,705</td>
+            <td headers="r1 r9 c4 c8">1,080,790</td>
+            <td headers="r1 r9 c4 c9">1,410,664</td>
+          </tr>
+          <tr>
+            <td>&nbsp;</td>
+            <th colspan="6" class="panel" id="r10">Total&nbsp;payments&nbsp;<sup>c</sup>&nbsp;(thousands&nbsp;of&nbsp;dollars)</th>
+          </tr>
+          <tr>
+            <th class="stub2" id="r11" headers="r10 c1">Total</th>
+            <td headers="r10 r11 c2">5,528,062</td>
+            <td headers="r10 r11 c3 c5">677,097</td>
+            <td headers="r10 r11 c3 c6">4,850,966</td>
+            <td headers="r10 r11 c4 c7">895,681</td>
+            <td headers="r10 r11 c4 c8">3,200,945</td>
+            <td headers="r10 r11 c4 c9">1,431,436</td>
+          </tr>
+          <tr class="topPad1">
+            <th class="stub0" id="r12" headers="r10 c1">Federal payments</th>
+            <td headers="r10 r12 c2">5,233,633</td>
+            <td headers="r10 r12 c3 c5">586,397</td>
+            <td headers="r10 r12 c3 c6">4,647,236</td>
+            <td headers="r10 r12 c4 c7">885,088</td>
+            <td headers="r10 r12 c4 c8">3,072,111</td>
+            <td headers="r10 r12 c4 c9">1,276,435</td>
+          </tr>
+          <tr>
+            <th class="stub0" id="r13" headers="r10 c1">State supplementation</th>
+            <td headers="r10 r13 c2">294,430</td>
+            <td headers="r10 r13 c3 c5">90,700</td>
+            <td headers="r10 r13 c3 c6">203,730</td>
+            <td headers="r10 r13 c4 c7">10,593</td>
+            <td headers="r10 r13 c4 c8">128,835</td>
+            <td headers="r10 r13 c4 c9">155,002</td>
+          </tr>
+          <tr>
+            <td>&nbsp;</td>
+            <th colspan="6" class="panel" id="r14">Average&nbsp;monthly&nbsp;payment&nbsp;<sup>d</sup>&nbsp;(dollars)</th>
+          </tr>
+          <tr>
+            <th class="stub2" id="r15" headers="r14 c1">Total</th>
+            <td headers="r14 r15 c2">696.70</td>
+            <td headers="r14 r15 c3 c5">564.14</td>
+            <td headers="r14 r15 c3 c6">722.06</td>
+            <td headers="r14 r15 c4 c7">812.54</td>
+            <td headers="r14 r15 c4 c8">743.12</td>
+            <td headers="r14 r15 c4 c9">575.59</td>
+          </tr>
+          <tr class="topPad1">
+            <th class="stub0" id="r16" headers="r14 c1">Federal payments</th>
+            <td headers="r14 r16 c2">670.65</td>
+            <td headers="r14 r16 c3 c5">510.61</td>
+            <td headers="r14 r16 c3 c6">700.35</td>
+            <td headers="r14 r16 c4 c7">803.90</td>
+            <td headers="r14 r16 c4 c8">721.22</td>
+            <td headers="r14 r16 c4 c9">532.04</td>
+          </tr>
+          <tr>
+            <th class="stub0" id="r17" headers="r14 c1">State supplementation</th>
+            <td headers="r14 r17 c2">212.86</td>
+            <td headers="r14 r17 c3 c5">222.87</td>
+            <td headers="r14 r17 c3 c6">208.51</td>
+            <td headers="r14 r17 c4 c7">87.19</td>
+            <td headers="r14 r17 c4 c8">222.14</td>
+            <td headers="r14 r17 c4 c9">225.65</td>
+          </tr>
+          <tr>
+            <td>&nbsp;</td>
+            <th colspan="6" class="panel" id="r18">Number&nbsp;of&nbsp;awards&nbsp;<sup>e</sup></th>
+          </tr>
+          <tr>
+            <th class="stub0" id="r19" headers="r18 c1">Total</th>
+            <td headers="r18 r19 c2">55,706</td>
+            <td headers="r18 r19 c3 c5">9,925</td>
+            <td headers="r18 r19 c3 c6">45,781</td>
+            <td headers="r18 r19 c4 c7">13,990</td>
+            <td headers="r18 r19 c4 c8">31,457</td>
+            <td headers="r18 r19 c4 c9">10,259</td>
+          </tr>
+        </tbody>
+        <tfoot>
+          <tr>
+            <td class="firstNote" colspan="7">SOURCE: Social Security Administration, Supplemental Security Record, 100&nbsp;percent data.</td>
+          </tr>
+          <tr>
+            <td class="note" colspan="7">a. Includes 6,169,449 disabled and 63,747 blind recipients.</td>
+          </tr>
+          <tr>
+            <td class="note" colspan="7">b. Includes 1,265,326 disabled and 13,117 blind recipients aged&nbsp;65 or older.</td>
+          </tr>
+          <tr>
+            <td class="note" colspan="7">c. Includes retroactive payments.</td>
+          </tr>
+          <tr>
+            <td class="note" colspan="7">d. Excludes retroactive payments.</td>
+          </tr>
+          <tr>
+            <td class="note" colspan="7">e. Preliminary data. In the first 2&nbsp;months after their release, numbers may be adjusted downward to reflect returned checks.</td>
+          </tr>
+          <tr>
+            <td class="lastNote" colspan="7">CONTACT: <a href="mailto:statistics@ssa.gov">statistics@ssa.gov</a>.</td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  </div>
+</article>
+<nav>
+  <div class="docNav"><a class="toTop" href="#hLogo">Top of page</a>&nbsp;<a class="toTOC" href="index.html#fileListSpaced">Table of contents</a>&nbsp;<a class="next" href="table02.html">Next: Table 2</a></div>
+</nav>
+<footer><div id="footer">
+    <div class="important-info">
+      <ul><li><a href="/agency/">About Us</a></li>
+      	<li><a href="/accessibility/">Accessibility</a></li>
+        <li><a href="/foia/">FOIA</a></li>
+        <li><a href="/open/">Open Government</a></li>
+        <li><a href="/privacy/">Privacy</a></li>
+        <li><a href="https://oig.ssa.gov/report/">Report Fraud, Waste or Abuse</a></li>
+        <li><a href="/agency/websitepolicies.html">Website Policies</a></li></ul>
+    </div>
+    <p class="align-center margin-top">This website is produced and published at U.S. taxpayer expense.</p>
+</div></footer>
+<!-- SSA INTERNET BODY SCRIPTS --> 
+<script src="/policy/js/rspa.doc.js"></script>
+<script src="/policy/js/rspa-shared.js"></script>
+<script src="/framework/js/ssa.internet.body.js"></script>
+</body></html>

--- a/ledger/source_package.py
+++ b/ledger/source_package.py
@@ -179,6 +179,7 @@ SOURCE_PACKAGE_ALIASES = {
     "ssa-annual-statistical-supplement-2025": Path(
         "ssa/annual_statistical_supplement_2025"
     ),
+    "ssa-ssi-monthly-statistics-2024-12": Path("ssa/ssi_monthly_statistics_2024_12"),
     "ssa-ssi-table-7b1-2024": Path("ssa/ssi_table_7b1_2024"),
     "hhs-acf-tanf-caseload-2024": Path("hhs_acf/tanf_caseload_2024"),
     "hhs-acf-tanf-financial-2024": Path("hhs_acf/tanf_financial_2024"),

--- a/packages/ssa/ssi_monthly_statistics_2024_12/source_package.yaml
+++ b/packages/ssa/ssi_monthly_statistics_2024_12/source_package.yaml
@@ -1,0 +1,163 @@
+schema_version: ledger.source_package.v1
+package_id: ssa-ssi-monthly-statistics-2024-12
+label: SSA SSI Monthly Statistics December 2024 Table 1 federal payment recipients by age
+artifact:
+  source_name: ssa
+  source_table: 'SSI Monthly Statistics, December 2024, Table 1'
+  resource_package: db
+  resource_directory: data/ssa/ssi_monthly_statistics_2024_12
+  manifest: manifest.yaml
+  vintage: ssi_monthly_statistics_2024_12
+  extracted_at: '2026-07-21'
+  extraction_method: >-
+    manual table extraction from SSA SSI Monthly Statistics, December 2024,
+    Table 1 HTML ("Total with— Federal payment" row transcribed to long-form
+    age-group rows); the verbatim page capture is committed alongside the
+    extracted CSV in the manifest directory
+  parser: delimited_text_full_rows
+  artifact_year: 2024
+  sheet_name: ssi_monthly_2024_12_table01
+record_sets:
+- record_set_id: ssa_ssi_monthly.month2024_12.ssi_federal_payment_recipients.by_age
+  record_set_spec_id: ssa_ssi_monthly.ssi_federal_payment_recipients.by_age.v1
+  source_record_id_prefix: ssa_ssi_monthly.month2024_12.ssi_federal_payment_recipients.by_age
+  sheet_name: ssi_monthly_2024_12_table01
+  period_type: month
+  period: '2024-12'
+  geography_id: 0100000US
+  geography_level: country
+  geography_name: United States
+  geography_vintage: current
+  entity: person
+  entity_role: ssi_recipient
+  domain: social_security_and_ssi_payments
+  groupby_dimension: age
+  rows:
+  - value_id: all_ages
+    label: SSI federal payment recipients all ages
+    ordinal: 0
+    row_number: 2
+    expected_row_header_column: A
+    expected_row_header: federal_payment
+    filters: {}
+    constraints: []
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: All ages
+      label: age group
+    - column: B
+      row: start
+      expected_value: Total with federal payment
+      label: SSA Table 1 stub line
+    table_record_kind: total
+  - value_id: under_18
+    label: SSI federal payment recipients under 18
+    ordinal: 1
+    row_number: 3
+    expected_row_header_column: A
+    expected_row_header: federal_payment
+    constraints:
+    - variable: age
+      operator: '>='
+      value: 0
+      unit: years
+      label: Age lower bound
+    - variable: age
+      operator: <
+      value: 18
+      unit: years
+      label: Age upper bound
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: Aged 0-17
+      label: age group
+    - column: B
+      row: start
+      expected_value: Total with federal payment
+      label: SSA Table 1 stub line
+    table_record_kind: detail
+  - value_id: age_18_to_64
+    label: SSI federal payment recipients aged 18 to 64
+    ordinal: 2
+    row_number: 4
+    expected_row_header_column: A
+    expected_row_header: federal_payment
+    constraints:
+    - variable: age
+      operator: '>='
+      value: 18
+      unit: years
+      label: Age lower bound
+    - variable: age
+      operator: <
+      value: 65
+      unit: years
+      label: Age upper bound
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: Aged 18-64
+      label: age group
+    - column: B
+      row: start
+      expected_value: Total with federal payment
+      label: SSA Table 1 stub line
+    table_record_kind: detail
+  - value_id: age_65_or_older
+    label: SSI federal payment recipients aged 65 or older
+    ordinal: 3
+    row_number: 5
+    expected_row_header_column: A
+    expected_row_header: federal_payment
+    constraints:
+    - variable: age
+      operator: '>='
+      value: 65
+      unit: years
+      label: Age lower bound
+    guard_cells:
+    - column: F
+      row: start
+      expected_value: Aged 65 and over
+      label: age group
+    - column: B
+      row: start
+      expected_value: Total with federal payment
+      label: SSA Table 1 stub line
+    table_record_kind: detail
+  measures:
+  - measure_id: recipient_count
+    label: SSI federal payment recipients
+    ordinal: 0
+    column: G
+    source_column_id: recipient_count
+    concept: ssa.ssi_federal_payment_recipient_count
+    source_concept: ssa_ssi_monthly.table_1.federal_payment_recipient_count
+    concept_relation: exact
+    concept_authority: ledger-us
+    concept_evidence_url: https://www.ssa.gov/policy/docs/statcomps/ssi_monthly/2024-12/table01.html
+    concept_evidence_notes: >-
+      SSA SSI Monthly Statistics, December 2024, Table 1 (Number of
+      recipients, total payments, average monthly payment, and number of
+      awards, by type of payment, eligibility category, and age, December
+      2024), "Total with— Federal payment" row: persons receiving a federal
+      SSI payment in December 2024, by the three published age groups (under
+      18 / 18-64 / 65 or older; all ages 7,289,843 = 1,001,922 + 3,905,779 +
+      2,382,142). The line counts everyone whose federally administered
+      December 2024 payment included a federal SSI payment, with or without
+      state supplementation, and excludes the 134,013 people receiving
+      federally administered state supplementation only; counts include
+      retroactive payments per table footnote c. Populace binds these
+      age-group rows as age-band indicator count targets on the SSI take-up
+      flag (PolicyEngine/populace#470); they are the published table behind
+      the hardcoded US_SSI_TAKE_UP_AGE_TARGETS constants and, with the
+      count-match take-up assignment machinery removed in
+      PolicyEngine/populace#469, anchor the characteristic-varying take-up
+      priors of PolicyEngine/populace#473.
+    unit: count
+    aggregation: sum
+    expected_cell_type: number
+    expected_column_header_row: 1
+    expected_column_header: recipient_count

--- a/tests/test_ledger_bundle.py
+++ b/tests/test_ledger_bundle.py
@@ -27,19 +27,19 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "aggregate_duplicate_key_count": 0,
         "entity_count": 8,
         "error_count": 0,
-        "fact_count": 39215,
+        "fact_count": 39219,
         "geography_count": 1053,
         "period_count": 16,
         "semantic_duplicate_key_count": 12,
         "skipped_source_count": 9,
         "source_count": 29,
-        "source_package_count": 59,
+        "source_package_count": 60,
         "warning_count": 1,
     }
-    assert len(rows) == 39215
+    assert len(rows) == 39219
     assert rows[0]["aggregate_fact_key"].startswith("ledger.aggregate_fact.v2:")
     assert rows[0]["semantic_fact_key"].startswith("ledger.semantic_fact.v2:")
-    assert source_packages["source_package_count"] == 59
+    assert source_packages["source_package_count"] == 60
     assert source_packages["skipped_source_count"] == 9
     assert sorted(item["source"] for item in source_packages["skipped_sources"]) == [
         "census-acs-s0101-congressional-district-age-2024",
@@ -52,7 +52,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "cms-aca-oep-state-level-2025",
         "jct-tax-expenditures-2024",
     ]
-    assert coverage["fact_count"] == 39215
+    assert coverage["fact_count"] == 39219
     assert coverage["counts"]["by_source"] == {
         "bea": 445,
         "bfp_economic_outlook": 5,
@@ -79,13 +79,13 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "opgroeien_groeipakket": 11,
         "sfpd_pensions": 4,
         "spf_finances_pit": 1,
-        "ssa": 422,
+        "ssa": 426,
         "statbel_fiscal_income": 565,
         "statbel_population_structure": 18,
         "usda_snap": 216,
     }
     table_counts = coverage["counts"]["by_source_table"]
-    assert len(table_counts) == 54
+    assert len(table_counts) == 55
     assert table_counts["irs_soi:Congressional District Data 2022"] == 26880
     assert (
         table_counts[
@@ -94,6 +94,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         ]
         == 2
     )
+    assert table_counts["ssa:SSI Monthly Statistics, December 2024, Table 1"] == 4
     assert table_counts["irs_soi:Publication 1304 Table 1.1"] == 80
     assert (
         table_counts[
@@ -215,7 +216,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "calendar_year:2031": 2,
         "fiscal_year:2023": 48,
         "fiscal_year:2024": 520,
-        "month:2024-12": 260,
+        "month:2024-12": 264,
         "month:2025-12": 255,
         "tax_year:2022": 5886,
         "tax_year:2023": 28429,
@@ -226,7 +227,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
     assert coverage["counts"]["by_geography"]["nuts1:BE2"] == 17
     assert coverage["counts"]["by_geography"]["nuts1:BE3"] == 6
     assert coverage["counts"]["by_geography"]["commune:11002"] == 1
-    assert coverage["counts"]["by_geography"]["country:0100000US"] == 2105
+    assert coverage["counts"]["by_geography"]["country:0100000US"] == 2109
     assert coverage["counts"]["by_geography"]["state:0400000US06"] == 217
     assert (
         coverage["counts"]["by_geography"]["congressional_district:5001700US0601"] == 56
@@ -240,7 +241,7 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
         "household": 62,
         "institutional_sector": 13,
         "pension_plan": 2,
-        "person": 3684,
+        "person": 3688,
         "tax_unit": 33783,
     }
     assert not coverage["duplicates"]["aggregate_fact_keys"]
@@ -329,6 +330,12 @@ def test_build_bundle_writes_merged_consumer_contract(tmp_path):
     ).exists()
     assert (
         output_dir / "sources" / "ssa-ssi-table-7b1-2024" / "consumer_facts.jsonl"
+    ).exists()
+    assert (
+        output_dir
+        / "sources"
+        / "ssa-ssi-monthly-statistics-2024-12"
+        / "consumer_facts.jsonl"
     ).exists()
     assert (
         output_dir

--- a/tests/test_ledger_source_package.py
+++ b/tests/test_ledger_source_package.py
@@ -1463,6 +1463,102 @@ def test_ssa_ssi_table_7b1_source_package_builds_area_category_facts():
     assert ca_disabled_payments.geography.id == "0400000US06"
 
 
+def test_ssa_ssi_monthly_2024_12_source_package_alias_validates_counts():
+    report = validate_source_package("ssa-ssi-monthly-statistics-2024-12", year=2024)
+
+    assert report.valid
+    assert report.counts == {
+        "record_set_count": 1,
+        "row_count": 4,
+        "measure_count": 1,
+        "source_record_count": 4,
+        "source_region_count": 1,
+    }
+
+
+def test_ssa_ssi_monthly_2024_12_package_builds_federal_payment_age_facts():
+    package = load_source_package("ssa-ssi-monthly-statistics-2024-12")
+    rows = package.build_source_rows(2024)
+    cells = package.build_source_cells(2024, source_rows=rows)
+    facts = package.build_facts(2024, cells=cells, source_rows=rows)
+    values_by_record = {fact.source_record_id: fact for fact in facts}
+
+    assert package.package_id == "ssa-ssi-monthly-statistics-2024-12"
+    assert len(rows) == 4
+    assert validate_source_rows(rows).valid
+    assert validate_source_cells(cells).valid
+    assert len(cells) == 35
+    assert len(facts) == 4
+    assert validate_facts(facts).valid
+    assert validate_consumer_fact_contract(facts).valid
+    assert all(fact.source.raw_r2_uri for fact in facts)
+
+    prefix = "ssa_ssi_monthly.month2024_12.ssi_federal_payment_recipients.by_age."
+    all_ages = values_by_record[prefix + "all_ages.recipient_count"]
+    under_18 = values_by_record[prefix + "under_18.recipient_count"]
+    aged_18_to_64 = values_by_record[prefix + "age_18_to_64.recipient_count"]
+    aged_65_or_older = values_by_record[prefix + "age_65_or_older.recipient_count"]
+
+    # SSA SSI Monthly Statistics, December 2024, Table 1, "Total with—
+    # Federal payment" row: persons receiving a federal SSI payment in
+    # December 2024, by the three published age groups. These are the
+    # PolicyEngine/populace#470 age-band take-up count targets.
+    assert all_ages.value == 7_289_843
+    assert under_18.value == 1_001_922
+    assert aged_18_to_64.value == 3_905_779
+    assert aged_65_or_older.value == 2_382_142
+    assert (
+        under_18.value + aged_18_to_64.value + aged_65_or_older.value
+        == all_ages.value
+    )
+
+    assert all_ages.period.type == "month"
+    assert all_ages.period.value == "2024-12"
+    assert all_ages.geography.id == "0100000US"
+    assert all_ages.entity.name == "person"
+    assert all_ages.entity.role == "ssi_recipient"
+    assert all_ages.constraints == ()
+    assert all_ages.layout.table_record_kind == "total"
+
+    assert {
+        (item.variable, item.operator, item.value)
+        for item in under_18.constraints
+    } == {("age", ">=", 0), ("age", "<", 18)}
+    assert {
+        (item.variable, item.operator, item.value)
+        for item in aged_18_to_64.constraints
+    } == {("age", ">=", 18), ("age", "<", 65)}
+    assert {
+        (item.variable, item.operator, item.value)
+        for item in aged_65_or_older.constraints
+    } == {("age", ">=", 65)}
+    assert under_18.layout.groupby_dimension == "age"
+    assert under_18.layout.groupby_value_id == "under_18"
+
+    measure = under_18.measure
+    assert measure.concept == "ssa.ssi_federal_payment_recipient_count"
+    assert measure.source_concept == (
+        "ssa_ssi_monthly.table_1.federal_payment_recipient_count"
+    )
+    assert measure.concept_relation == "exact"
+    assert measure.concept_authority == "ledger-us"
+    assert measure.concept_evidence_url == (
+        "https://www.ssa.gov/policy/docs/statcomps/ssi_monthly/2024-12/table01.html"
+    )
+    assert "federal SSI payment in December 2024" in measure.concept_evidence_notes
+    assert "PolicyEngine/populace#470" in measure.concept_evidence_notes
+    assert "PolicyEngine/populace#469" in measure.concept_evidence_notes
+    assert "PolicyEngine/populace#473" in measure.concept_evidence_notes
+
+    assert under_18.source.source_file == "ssi_monthly_2024_12_table01.csv"
+    assert under_18.source.url == (
+        "https://www.ssa.gov/policy/docs/statcomps/ssi_monthly/2024-12/table01.html"
+    )
+    assert under_18.source.source_sha256 == (
+        "44438b49392c2a581a239c7490492152c408213f313f450a762d84281de98e40"
+    )
+
+
 def test_ons_uk_business_firm_targets_source_package_alias_validates_counts():
     report = validate_source_package("ons-uk-business-firm-targets-2025", year=2025)
 


### PR DESCRIPTION
Ledger half of PolicyEngine/populace#470: SSI federal-payment recipient counts by age group from SSA's SSI Monthly Statistics December 2024 Table 1 — the exact primary page populace's hardcoded `US_SSI_TAKE_UP_AGE_TARGETS` constants cite. Four facts under `ssa_ssi_monthly.month2024_12.ssi_federal_payment_recipients.by_age.*`: all-ages **7,289,843**, under-18 **1,001,922**, 18–64 **3,905,779**, 65+ **2,382,142** — every value verbatim from the published row, bands summing exactly to the total, each band fact carrying first-class age constraints (the census-S0101 pattern) so populace can bind them as indicator count targets and delete the constants (#469/#473 machinery removal).

Provenance note: SSA 403s non-browser fetches, so the committed byte-exact HTML capture was fetched in a real browser with sha256 computed in page context and proven equal to the on-disk file; the parsed CSV artifact follows the repo's ssa HTML-source convention. Both files sha-recorded in the manifest with canonical R2 keys — the object upload shares the existing credentialed-machine residual (`ledger publish-raw`, same as cms-nhe-table-24).

Validation: validate-package + build-suite green (4 facts, acceptance clean, lineage 1.0); rebased mid-task onto the #87 consumer-fact schema enforcement and re-verified — full CI-parity pytest **582 passed / 1 skipped** incl. the bundle, ruff clean, wheel smoke reproduces the oracle values from packaged resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)