### PR TITLE
Add academic_year period type to the source-package contract

### DIFF
--- a/chronicle/core.py
+++ b/chronicle/core.py
@@ -16,7 +16,18 @@ from typing import Any
 
 Scalar = str | int | float | bool | None
 
-ALLOWED_PERIOD_TYPES = {"calendar_year", "tax_year", "fiscal_year", "month"}
+# Year-typed periods store one integer. Split-label years store the opening
+# year of the publisher's label: UK fiscal year FY2024-25 is fiscal_year 2024
+# (packages/hmrc/vat_firm_targets_2024_25) and academic year AY 2024/25 is
+# academic_year 2024 (#131). Publishers that label a fiscal year with a single
+# year keep that label year (US federal FY2025 -> 2025).
+ALLOWED_PERIOD_TYPES = {
+    "calendar_year",
+    "tax_year",
+    "fiscal_year",
+    "academic_year",
+    "month",
+}
 ALLOWED_GEOGRAPHY_LEVELS = {
     "country",
     "region",

--- a/chronicle/core.py
+++ b/chronicle/core.py
@@ -20,7 +20,11 @@ Scalar = str | int | float | bool | None
 # year of the publisher's label: UK fiscal year FY2024-25 is fiscal_year 2024
 # (packages/hmrc/vat_firm_targets_2024_25) and academic year AY 2024/25 is
 # academic_year 2024 (#131). Publishers that label a fiscal year with a single
-# year keep that label year (US federal FY2025 -> 2025).
+# year keep that label year (US federal FY2024 -> 2024,
+# packages/cbo/individual_income_tax_receipts_2026_02). Caution: the EES
+# helper _academic_year_end (ledger/sources/rows.py) names value COLUMNS by
+# the academic year's END year; that is source-layout naming only and must
+# not leak into fact periods.
 ALLOWED_PERIOD_TYPES = {
     "calendar_year",
     "tax_year",

--- a/chronicle/core.py
+++ b/chronicle/core.py
@@ -22,9 +22,9 @@ Scalar = str | int | float | bool | None
 # academic_year 2024 (#131). Publishers that label a fiscal year with a single
 # year keep that label year (US federal FY2024 -> 2024,
 # packages/cbo/individual_income_tax_receipts_2026_02). Caution: the EES
-# helper _academic_year_end (ledger/sources/rows.py) names value COLUMNS by
-# the academic year's END year; that is source-layout naming only and must
-# not leak into fact periods.
+# helper _academic_year_end (chronicle/sources/rows.py) names value COLUMNS
+# by the academic year's END year ("2024/25" -> 2025); that is source-layout
+# naming only and must not leak into fact periods.
 ALLOWED_PERIOD_TYPES = {
     "calendar_year",
     "tax_year",

--- a/docs/schemas/consumer_fact.v1.schema.json
+++ b/docs/schemas/consumer_fact.v1.schema.json
@@ -117,7 +117,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "Publisher-asserted period kind; the ledger.core.ALLOWED_PERIOD_TYPES vocabulary: calendar_year, tax_year, fiscal_year, academic_year, month. Split-label years store the opening year of the publisher's label (UK FY2024-25 -> fiscal_year 2024; AY 2024/25 -> academic_year 2024)."
+          "description": "Publisher-asserted period kind; the ledger.core.ALLOWED_PERIOD_TYPES vocabulary: calendar_year, tax_year, fiscal_year, academic_year, month. Split-label years store the opening year of the publisher's label (UK FY2024-25 -> fiscal_year 2024; AY 2024/25 -> academic_year 2024). Publishers labelling a fiscal year with a single year keep that label year (US federal FY2024 -> 2024)."
         },
         "value": {
           "type": [

--- a/docs/schemas/consumer_fact.v1.schema.json
+++ b/docs/schemas/consumer_fact.v1.schema.json
@@ -116,7 +116,8 @@
       ],
       "properties": {
         "type": {
-          "type": "string"
+          "type": "string",
+          "description": "Publisher-asserted period kind; the ledger.core.ALLOWED_PERIOD_TYPES vocabulary: calendar_year, tax_year, fiscal_year, academic_year, month. Split-label years store the opening year of the publisher's label (UK FY2024-25 -> fiscal_year 2024; AY 2024/25 -> academic_year 2024)."
         },
         "value": {
           "type": [

--- a/policyengine_chronicle/schemas/consumer_fact.v1.schema.json
+++ b/policyengine_chronicle/schemas/consumer_fact.v1.schema.json
@@ -117,7 +117,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "description": "Publisher-asserted period kind; the ledger.core.ALLOWED_PERIOD_TYPES vocabulary: calendar_year, tax_year, fiscal_year, academic_year, month. Split-label years store the opening year of the publisher's label (UK FY2024-25 -> fiscal_year 2024; AY 2024/25 -> academic_year 2024)."
+          "description": "Publisher-asserted period kind; the ledger.core.ALLOWED_PERIOD_TYPES vocabulary: calendar_year, tax_year, fiscal_year, academic_year, month. Split-label years store the opening year of the publisher's label (UK FY2024-25 -> fiscal_year 2024; AY 2024/25 -> academic_year 2024). Publishers labelling a fiscal year with a single year keep that label year (US federal FY2024 -> 2024)."
         },
         "value": {
           "type": [

--- a/policyengine_chronicle/schemas/consumer_fact.v1.schema.json
+++ b/policyengine_chronicle/schemas/consumer_fact.v1.schema.json
@@ -116,7 +116,8 @@
       ],
       "properties": {
         "type": {
-          "type": "string"
+          "type": "string",
+          "description": "Publisher-asserted period kind; the ledger.core.ALLOWED_PERIOD_TYPES vocabulary: calendar_year, tax_year, fiscal_year, academic_year, month. Split-label years store the opening year of the publisher's label (UK FY2024-25 -> fiscal_year 2024; AY 2024/25 -> academic_year 2024)."
         },
         "value": {
           "type": [

--- a/tests/test_chronicle_consumer_contract.py
+++ b/tests/test_chronicle_consumer_contract.py
@@ -24,11 +24,18 @@ from chronicle.consumer_contract import (
 from chronicle.core import (
     AggregateConstraint,
     Measure,
+    PeriodDimension,
     build_aggregate_constraints,
 )
 from chronicle.harness import main
 from chronicle.jurisdictions.us.soi import build_soi_table_1_1_facts
 from chronicle.store import save_facts_jsonl
+from policyengine_chronicle.consumer import (
+    build_consumer_artifact,
+    load_consumer_artifact,
+    resolve_profile_targets,
+)
+from policyengine_chronicle.target_profiles import target_profile_from_mapping
 
 CONSUMER_FACT_SCHEMA_PATH = (
     Path(__file__).parents[1] / "docs" / "schemas" / "consumer_fact.v1.schema.json"
@@ -428,6 +435,92 @@ def test_write_consumer_facts_jsonl(tmp_path):
     }
     assert len(rows) == 1
     assert rows[0]["aggregate_fact_key"].startswith("ledger.aggregate_fact.v2:")
+
+
+def test_academic_year_rows_round_trip_through_consumer_artifact(tmp_path):
+    base = _soi_agi_fact()
+    facts = [
+        replace(
+            base,
+            period=PeriodDimension(type="academic_year", value=2023),
+            source_record_id=(
+                "irs_soi.ay2023.table_1_1.all.adjusted_gross_income"
+            ),
+            source_cell_keys=("ledger.source_cell.v1:ay2023agi",),
+            value=90.0,
+        ),
+        replace(
+            base,
+            period=PeriodDimension(type="academic_year", value=2024),
+            source_record_id=(
+                "irs_soi.ay2024.table_1_1.all.adjusted_gross_income"
+            ),
+            source_cell_keys=("ledger.source_cell.v1:ay2024agi",),
+            value=100.0,
+        ),
+    ]
+    facts_path = tmp_path / "consumer_facts.jsonl"
+    write_consumer_facts_jsonl(facts, facts_path)
+    rows = _load_jsonl(facts_path)
+    assert [row["period"] for row in rows] == [
+        {"type": "academic_year", "value": 2023},
+        {"type": "academic_year", "value": 2024},
+    ]
+
+    profile_mapping = {
+        "schema_version": "policyengine_ledger.target_profile.v1",
+        "profile_id": "academic_year_round_trip",
+        "country": "us",
+        "label": "Academic-year period round trip",
+        "defaults": {
+            "base_period_policy": "latest_not_after_build_base_period",
+            "operation": "sum",
+        },
+        "targets": [
+            {
+                "target_id": "soi.agi.academic_year_probe",
+                "family": "irs_soi",
+                "geography_levels": ["country"],
+                "ledger_selector": {
+                    "source_name": rows[0]["source"]["source_name"],
+                    "source_measure_id": rows[0]["observed_measure"][
+                        "source_measure_id"
+                    ],
+                },
+                "measurement": {
+                    "entity": "tax_unit",
+                    "concept": "us.agi",
+                },
+                "bindings": {
+                    "policyengine": {
+                        "metric_name": "soi/agi/academic_year_probe",
+                    }
+                },
+            }
+        ],
+    }
+    target_profile_from_mapping(profile_mapping)
+    profile_path = tmp_path / "academic_year_round_trip.json"
+    profile_path.write_text(json.dumps(profile_mapping, indent=2) + "\n")
+
+    artifact_dir = tmp_path / "artifact"
+    build_consumer_artifact(
+        artifact_dir,
+        facts_path=facts_path,
+        profile_paths=[profile_path],
+    )
+    artifact = load_consumer_artifact(artifact_dir)
+
+    report = resolve_profile_targets(
+        artifact.profiles["academic_year_round_trip"],
+        artifact.rows,
+        {"type": "academic_year", "value": 2024},
+    )
+    assert report.valid
+    (resolved,) = report.resolved
+    assert resolved.basis == "fact"
+    assert resolved.value == 100.0
+    assert resolved.fact_period == {"type": "academic_year", "value": 2024}
 
 
 def test_consumer_fact_row_marks_decimal_values_as_decimal_strings():

--- a/tests/test_chronicle_consumer_contract.py
+++ b/tests/test_chronicle_consumer_contract.py
@@ -26,11 +26,13 @@ from chronicle.core import (
     Measure,
     PeriodDimension,
     build_aggregate_constraints,
+    validate_facts,
 )
 from chronicle.harness import main
 from chronicle.jurisdictions.us.soi import build_soi_table_1_1_facts
 from chronicle.store import save_facts_jsonl
 from policyengine_chronicle.consumer import (
+    PeriodContractError,
     build_consumer_artifact,
     load_consumer_artifact,
     resolve_profile_targets,
@@ -459,6 +461,7 @@ def test_academic_year_rows_round_trip_through_consumer_artifact(tmp_path):
             value=100.0,
         ),
     ]
+    assert validate_facts(facts).valid  # the vocabulary gate itself
     facts_path = tmp_path / "consumer_facts.jsonl"
     write_consumer_facts_jsonl(facts, facts_path)
     rows = _load_jsonl(facts_path)
@@ -481,7 +484,7 @@ def test_academic_year_rows_round_trip_through_consumer_artifact(tmp_path):
                 "target_id": "soi.agi.academic_year_probe",
                 "family": "irs_soi",
                 "geography_levels": ["country"],
-                "ledger_selector": {
+                "chronicle_selector": {
                     "source_name": rows[0]["source"]["source_name"],
                     "source_measure_id": rows[0]["observed_measure"][
                         "source_measure_id"
@@ -521,6 +524,13 @@ def test_academic_year_rows_round_trip_through_consumer_artifact(tmp_path):
     assert resolved.basis == "fact"
     assert resolved.value == 100.0
     assert resolved.fact_period == {"type": "academic_year", "value": 2024}
+
+    with pytest.raises(PeriodContractError):
+        resolve_profile_targets(
+            artifact.profiles["academic_year_round_trip"],
+            artifact.rows,
+            {"type": "fiscal_year", "value": 2024},
+        )
 
 
 def test_consumer_fact_row_marks_decimal_values_as_decimal_strings():

--- a/tests/test_chronicle_consumer_contract.py
+++ b/tests/test_chronicle_consumer_contract.py
@@ -23,6 +23,8 @@ from chronicle.consumer_contract import (
 )
 from chronicle.core import (
     AggregateConstraint,
+    EntityDimension,
+    GeographyDimension,
     Measure,
     PeriodDimension,
     build_aggregate_constraints,
@@ -439,26 +441,61 @@ def test_write_consumer_facts_jsonl(tmp_path):
     assert rows[0]["aggregate_fact_key"].startswith("ledger.aggregate_fact.v2:")
 
 
-def test_academic_year_rows_round_trip_through_consumer_artifact(tmp_path):
+def _slc_student_support_fact(academic_year, value):
+    """A fact shaped like the SLC/EES student-support rows this vocabulary
+    exists for: recipients of maintenance loans in England, published per
+    academic year (AY 2023/24 -> academic_year 2023, the opening year)."""
     base = _soi_agi_fact()
+    return replace(
+        base,
+        value=value,
+        period=PeriodDimension(type="academic_year", value=academic_year),
+        geography=GeographyDimension(
+            level="country", id="E92000001", vintage="current", name="England"
+        ),
+        entity=EntityDimension(name="person", role="student_support_recipient"),
+        measure=replace(
+            base.measure,
+            concept="slc.maintenance_loan_recipients",
+            unit="count",
+            source_concept="slc.maintenance_loan_recipients",
+            concept_relation="source_label",
+            concept_authority="slc",
+            concept_evidence_url=(
+                "https://explore-education-statistics.service.gov.uk/"
+                "data-tables/permalink/6ff75517-7124-487c-cb4e-08de6eccf22d"
+            ),
+            concept_evidence_notes=(
+                "Synthetic test fixture shaped like the EES student-support "
+                "rows: maintenance-loan recipients per academic year."
+            ),
+            legal_vintage=None,
+        ),
+        source=replace(
+            base.source,
+            source_name="slc",
+            source_table="Student support for higher education in England",
+        ),
+        provenance_class="administrative",
+        filters={},
+        constraints=(),
+        domain="student_support",
+        label=f"Maintenance loan recipients, AY {academic_year}/"
+        f"{(academic_year + 1) % 100:02d}",
+    )
+
+
+def test_academic_year_rows_round_trip_through_consumer_artifact(tmp_path):
     facts = [
         replace(
-            base,
-            period=PeriodDimension(type="academic_year", value=2023),
-            source_record_id=(
-                "irs_soi.ay2023.table_1_1.all.adjusted_gross_income"
-            ),
-            source_cell_keys=("ledger.source_cell.v1:ay2023agi",),
-            value=90.0,
+            _slc_student_support_fact(2023, 90.0),
+            source_record_id="slc.ay2023.student_support.maintenance_loan_recipients",
+            source_cell_keys=("ledger.source_cell.v1:ay2023slc",),
         ),
         replace(
-            base,
-            period=PeriodDimension(type="academic_year", value=2024),
-            source_record_id=(
-                "irs_soi.ay2024.table_1_1.all.adjusted_gross_income"
-            ),
-            source_cell_keys=("ledger.source_cell.v1:ay2024agi",),
-            value=100.0,
+            _slc_student_support_fact(2024, 100.0),
+            source_record_id="slc.ay2024.student_support.maintenance_loan_recipients",
+            source_cell_keys=("ledger.source_cell.v1:ay2024slc",),
         ),
     ]
     assert validate_facts(facts).valid  # the vocabulary gate itself
@@ -473,7 +510,7 @@ def test_academic_year_rows_round_trip_through_consumer_artifact(tmp_path):
     profile_mapping = {
         "schema_version": "policyengine_ledger.target_profile.v1",
         "profile_id": "academic_year_round_trip",
-        "country": "us",
+        "country": "uk",
         "label": "Academic-year period round trip",
         "defaults": {
             "base_period_policy": "latest_not_after_build_base_period",
@@ -481,8 +518,8 @@ def test_academic_year_rows_round_trip_through_consumer_artifact(tmp_path):
         },
         "targets": [
             {
-                "target_id": "soi.agi.academic_year_probe",
-                "family": "irs_soi",
+                "target_id": "slc.maintenance_loan_recipients",
+                "family": "slc",
                 "geography_levels": ["country"],
                 "chronicle_selector": {
                     "source_name": rows[0]["source"]["source_name"],
@@ -491,12 +528,12 @@ def test_academic_year_rows_round_trip_through_consumer_artifact(tmp_path):
                     ],
                 },
                 "measurement": {
-                    "entity": "tax_unit",
-                    "concept": "us.agi",
+                    "entity": "person",
+                    "concept": "uk.education.maintenance_loan_recipients",
                 },
                 "bindings": {
                     "policyengine": {
-                        "metric_name": "soi/agi/academic_year_probe",
+                        "metric_name": "slc/maintenance_loan/recipients",
                     }
                 },
             }

--- a/tests/test_chronicle_core.py
+++ b/tests/test_chronicle_core.py
@@ -53,6 +53,16 @@ def test_valid_fact_passes_validation():
     assert validate_facts([_fact()]).valid
 
 
+def test_academic_year_period_type_is_valid():
+    fact = _fact(period=PeriodDimension(type="academic_year", value=2024))
+    assert validate_fact(fact) == ()
+
+
+def test_unknown_period_type_is_rejected():
+    fact = _fact(period=PeriodDimension(type="school_year", value=2024))
+    assert any(issue.code == "malformed_period" for issue in validate_fact(fact))
+
+
 def test_stable_key_ignores_human_label():
     fact = _fact()
     relabeled = _fact(label="A different display label")


### PR DESCRIPTION
Closes #131.

**Lane:** `ledger-contract-maintainer` (`.github/ledger-agents.yml`) — judges `ledger-contract` + `ledger-boundary`. This is the one contract change the UK target migration needs, isolated per #131 so no data wave drags through contract review. Unblocks the SLC packages in #132 (wave 1) and #133 (`slc_repayments`).

## What changed

- **`ledger/core.py`** — `academic_year` joins `ALLOWED_PERIOD_TYPES`, with a comment documenting the period-integer convention for split-label years: the stored integer is the opening year of the publisher's label — UK FY2024-25 → `fiscal_year 2024` (the existing `packages/hmrc/vat_firm_targets_2024_25` precedent), AY 2024/25 → `academic_year 2024`. Publishers that label a fiscal year with a single year keep that label year (US federal FY2025 → 2025).
- **`docs/schemas/consumer_fact.v1.schema.json` + `policyengine_ledger/schemas/consumer_fact.v1.schema.json`** — byte-identical `description` added to `period.type` documenting the vocabulary and the opening-year convention. Deliberately a description, **not an enum**: the single enforcement point for the vocabulary stays `validate_fact`; the schema documents, it does not duplicate the gate.
- **Tests** — `test_ledger_core.py`: `academic_year` facts validate; unknown period types still fail with `malformed_period`. `test_ledger_consumer_contract.py`: full round trip — two `academic_year` facts → `write_consumer_facts_jsonl` → `build_consumer_artifact` (profile shipped through the artifact) → `load_consumer_artifact` (schema-validates every row) → `resolve_profile_targets` at `{type: academic_year, value: 2024}` resolves the exact fact on `fact` basis.

## Behavior notes

- `CONSUMER_FACT_SCHEMA_SHA256` derives from the packaged schema bytes, so it moves with this change. Newly built artifacts carry the new sha; `load_consumer_artifact` will reject artifacts whose manifests pin the old sha — the designed exact-contract behavior. Existing consumer artifacts need a rebuild with the matching wheel.
- Period-integer alignment downstream (e.g. policyengine-uk-data's AY 2024/25 → calendar 2025 mapping) is a consumer concern; facts store what the publisher asserted.
- No existing package or fact changes behavior: the vocabulary only widens, and the schema edit is documentation-only for row validation.

## Checks

- `uv run ruff check ledger policyengine_ledger db scripts tests` (repo-pinned, CI scope) — clean.
- Full `uv run pytest -q` — green on this branch (614 passed, 1 skipped).
- Deterministic checks per the lane: schema validation, consumer-contract validation, package import compatibility, raw-facts boundary validation — all exercised by the suite above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
