### PR TITLE
Mint six docket-only placeholders for thesis#138 wave-1 admission

### DIFF
--- a/ledger/seeds/thesis_docket_series.json
+++ b/ledger/seeds/thesis_docket_series.json
@@ -1464,13 +1464,13 @@
       "catalogSlug": "additional-child-tax-credit-total-claims-ty2027-threshold-one-dollar",
       "dataPointId": "irs.actc.total_claims.2027.first_print.threshold_one_dollar",
       "conditionId": "cond.s3596-actc-threshold.enacted",
-      "conditional": "Legislation enacted by 2027-12-31 makes the IRC \u00a724(d)(1)(B)(i) earned-income threshold no more than $1 for tax year 2027."
+      "conditional": "Legislation enacted by 2027-12-31 makes the IRC §24(d)(1)(B)(i) earned-income threshold no more than $1 for tax year 2027."
      },
      {
       "catalogSlug": "additional-child-tax-credit-total-claims-ty2027-current-law",
       "dataPointId": "irs.actc.total_claims.2027.first_print.current_law",
       "conditionId": "cond.s3596-actc-threshold.current-law",
-      "conditional": "No legislation enacted by 2027-12-31 changes the IRC \u00a724(d)(1)(B)(i) earned-income threshold of $2,500 for tax year 2027; current law holds. The $2,500 operative amount is applied by IRC \u00a724(h)(6), while \u00a724(d)(1)(B)(i) contains the underlying $3,000 amount."
+      "conditional": "No legislation enacted by 2027-12-31 changes the IRC §24(d)(1)(B)(i) earned-income threshold of $2,500 for tax year 2027; current law holds. The $2,500 operative amount is applied by IRC §24(h)(6), while §24(d)(1)(B)(i) contains the underlying $3,000 amount."
      }
     ]
    },
@@ -1515,13 +1515,13 @@
       "catalogSlug": "spm-child-poverty-rate-cy2027-threshold-one-dollar",
       "dataPointId": "census.spm.child_poverty_rate.2027.first_print.threshold_one_dollar",
       "conditionId": "cond.s3596-actc-threshold.enacted",
-      "conditional": "For the CY2027 Census Supplemental Poverty Measure child-poverty outcome, legislation enacted by 2027-12-31 makes the IRC \u00a724(d)(1)(B)(i) earned-income threshold no more than $1 for tax year 2027."
+      "conditional": "For the CY2027 Census Supplemental Poverty Measure child-poverty outcome, legislation enacted by 2027-12-31 makes the IRC §24(d)(1)(B)(i) earned-income threshold no more than $1 for tax year 2027."
      },
      {
       "catalogSlug": "spm-child-poverty-rate-cy2027-current-law",
       "dataPointId": "census.spm.child_poverty_rate.2027.first_print.current_law",
       "conditionId": "cond.s3596-actc-threshold.current-law",
-      "conditional": "For the CY2027 Census Supplemental Poverty Measure child-poverty outcome, no legislation enacted by 2027-12-31 changes the IRC \u00a724(d)(1)(B)(i) earned-income threshold of $2,500 for tax year 2027; current law holds. The $2,500 operative amount is applied by IRC \u00a724(h)(6), while \u00a724(d)(1)(B)(i) contains the underlying $3,000 amount."
+      "conditional": "For the CY2027 Census Supplemental Poverty Measure child-poverty outcome, no legislation enacted by 2027-12-31 changes the IRC §24(d)(1)(B)(i) earned-income threshold of $2,500 for tax year 2027; current law holds. The $2,500 operative amount is applied by IRC §24(h)(6), while §24(d)(1)(B)(i) contains the underlying $3,000 amount."
      }
     ]
    },
@@ -1550,6 +1550,60 @@
      },
      "releasePolicy": "first_print"
     }
+   }
+  },
+  {
+   "series": "bea.private_nonresidential_fixed_investment",
+   "cadence": "quarterly",
+   "comment": "Docket-only placeholder minted 2026-08-07 for thesis#138 wave-1 ingestion admission (containment gate); observations arrive with the source adapter.",
+   "extras": {
+    "targetUnit": "usd_billions",
+    "country": "US"
+   }
+  },
+  {
+   "series": "bea.research_and_development_fixed_investment",
+   "cadence": "quarterly",
+   "comment": "Docket-only placeholder minted 2026-08-07 for thesis#138 wave-1 ingestion admission (containment gate); observations arrive with the source adapter.",
+   "extras": {
+    "targetUnit": "usd_billions",
+    "country": "US"
+   }
+  },
+  {
+   "series": "usaspending.dhs.title_vi.award_transaction_obligations",
+   "cadence": "annual",
+   "comment": "Docket-only placeholder minted 2026-08-07 for thesis#138 wave-1 ingestion admission (containment gate); observations arrive with the source adapter.",
+   "extras": {
+    "targetUnit": "usd",
+    "country": "US"
+   }
+  },
+  {
+   "series": "irs.soi.credit_30d.total_claims",
+   "cadence": "annual",
+   "comment": "Docket-only placeholder minted 2026-08-07 for thesis#138 wave-1 ingestion admission (containment gate); observations arrive with the source adapter.",
+   "extras": {
+    "targetUnit": "count",
+    "country": "US"
+   }
+  },
+  {
+   "series": "irs.soi.credit_30d.total_credit_amount",
+   "cadence": "annual",
+   "comment": "Docket-only placeholder minted 2026-08-07 for thesis#138 wave-1 ingestion admission (containment gate); observations arrive with the source adapter.",
+   "extras": {
+    "targetUnit": "usd_millions",
+    "country": "US"
+   }
+  },
+  {
+   "series": "irs.actc.total_credit_amount",
+   "cadence": "annual",
+   "comment": "Docket-only placeholder minted 2026-08-07 for thesis#138 wave-1 ingestion admission (containment gate); observations arrive with the source adapter.",
+   "extras": {
+    "targetUnit": "usd_millions",
+    "country": "US"
    }
   }
  ]

--- a/ledger/series_catalog.json
+++ b/ledger/series_catalog.json
@@ -4,8 +4,8 @@
   "observations_sha256": "b0c29d7cb2aee323a5d30f8196eb59f62aa396066070131c5048740659d5e241",
   "observation_rows": 171,
   "current_assertion_rows": 171,
-  "docket_seed_sha256": "85b98646f25bcca6a39ec746cbb322842bb82efaa002ba6b78f62098bfbd0776",
-  "uuid_registry_sha256": "9f0048ee4c8dcc1e7f7c49840fc8dfb65ff341eaa4a01496e76dde4982122b38",
+  "docket_seed_sha256": "08266fc9db0b0a3ccadf6095902f8e1b67dd1a5a199cd3841b58b1681434fa13",
+  "uuid_registry_sha256": "c3db1149d74dedfe63bc903fa088bde00c5a6dc6c02e32665cf093fcb40b7ba8",
   "suspect_segments": [],
   "stripped_segments": {
     "2026-05": [
@@ -754,6 +754,29 @@
       "observation_count": 1
     },
     {
+      "uuid": "2e36a67f-ae8d-4717-a70e-9de016e28d3f",
+      "concept": "bea.private_nonresidential_fixed_investment",
+      "family_patterns": [
+        "bea.private_nonresidential_fixed_investment"
+      ],
+      "status": "docket-only",
+      "unit": "usd_billions",
+      "cadence": "quarter",
+      "geography": {
+        "level": "country",
+        "id": "0100000US",
+        "name": "United States"
+      },
+      "entity": null,
+      "sources": [],
+      "aliases": [],
+      "source_concepts": [],
+      "rid_patterns": [],
+      "first_observed_period": null,
+      "last_observed_period": null,
+      "observation_count": 0
+    },
+    {
       "uuid": "83094ec4-c890-435b-8a6a-83273c3e9077",
       "concept": "bea.real_gdp.saar.third_estimate",
       "family_patterns": [
@@ -787,6 +810,29 @@
       "first_observed_period": "2026-01",
       "last_observed_period": "2026-01",
       "observation_count": 1
+    },
+    {
+      "uuid": "3efd33de-5be6-4150-bf62-6e4a1e9a1291",
+      "concept": "bea.research_and_development_fixed_investment",
+      "family_patterns": [
+        "bea.research_and_development_fixed_investment"
+      ],
+      "status": "docket-only",
+      "unit": "usd_billions",
+      "cadence": "quarter",
+      "geography": {
+        "level": "country",
+        "id": "0100000US",
+        "name": "United States"
+      },
+      "entity": null,
+      "sources": [],
+      "aliases": [],
+      "source_concepts": [],
+      "rid_patterns": [],
+      "first_observed_period": null,
+      "last_observed_period": null,
+      "observation_count": 0
     },
     {
       "uuid": "7be75093-832c-4734-a002-a0ff19c610ce",
@@ -5131,6 +5177,75 @@
       "observation_count": 0
     },
     {
+      "uuid": "05d4b329-d6c0-4050-ab25-f1a1deddf465",
+      "concept": "irs.actc.total_credit_amount",
+      "family_patterns": [
+        "irs.actc.total_credit_amount"
+      ],
+      "status": "docket-only",
+      "unit": "usd_millions",
+      "cadence": "year",
+      "geography": {
+        "level": "country",
+        "id": "0100000US",
+        "name": "United States"
+      },
+      "entity": null,
+      "sources": [],
+      "aliases": [],
+      "source_concepts": [],
+      "rid_patterns": [],
+      "first_observed_period": null,
+      "last_observed_period": null,
+      "observation_count": 0
+    },
+    {
+      "uuid": "f5eacf8a-ce09-4721-a92a-9b19766a0d3c",
+      "concept": "irs.soi.credit_30d.total_claims",
+      "family_patterns": [
+        "irs.soi.credit_30d.total_claims"
+      ],
+      "status": "docket-only",
+      "unit": "count",
+      "cadence": "year",
+      "geography": {
+        "level": "country",
+        "id": "0100000US",
+        "name": "United States"
+      },
+      "entity": null,
+      "sources": [],
+      "aliases": [],
+      "source_concepts": [],
+      "rid_patterns": [],
+      "first_observed_period": null,
+      "last_observed_period": null,
+      "observation_count": 0
+    },
+    {
+      "uuid": "c70d0bc6-d299-4727-959a-3c7bdb324861",
+      "concept": "irs.soi.credit_30d.total_credit_amount",
+      "family_patterns": [
+        "irs.soi.credit_30d.total_credit_amount"
+      ],
+      "status": "docket-only",
+      "unit": "usd_millions",
+      "cadence": "year",
+      "geography": {
+        "level": "country",
+        "id": "0100000US",
+        "name": "United States"
+      },
+      "entity": null,
+      "sources": [],
+      "aliases": [],
+      "source_concepts": [],
+      "rid_patterns": [],
+      "first_observed_period": null,
+      "last_observed_period": null,
+      "observation_count": 0
+    },
+    {
       "uuid": "a3e8d1fb-5f29-40a8-ab14-a06a53ecb6af",
       "concept": "nbb.business_barometer.overall",
       "family_patterns": [
@@ -6326,6 +6441,29 @@
       "first_observed_period": "2026-05",
       "last_observed_period": "2026-05",
       "observation_count": 1
+    },
+    {
+      "uuid": "e64ea5db-b72a-4a46-8948-6142dbc59d91",
+      "concept": "usaspending.dhs.title_vi.award_transaction_obligations",
+      "family_patterns": [
+        "usaspending.dhs.title_vi.award_transaction_obligations"
+      ],
+      "status": "docket-only",
+      "unit": "usd",
+      "cadence": "year",
+      "geography": {
+        "level": "country",
+        "id": "0100000US",
+        "name": "United States"
+      },
+      "entity": null,
+      "sources": [],
+      "aliases": [],
+      "source_concepts": [],
+      "rid_patterns": [],
+      "first_observed_period": null,
+      "last_observed_period": null,
+      "observation_count": 0
     },
     {
       "uuid": "8146ecb0-3ef3-49eb-b8a0-e61d15aa276e",

--- a/ledger/series_uuid_registry.jsonl
+++ b/ledger/series_uuid_registry.jsonl
@@ -205,3 +205,9 @@
 {"concept": "census.construction_spending.total_mom", "geography": {"level": "country", "id": "0100000US", "vintage": "current"}, "entity": {"name": "economy", "role": "aggregate"}, "uuid": "63222847-045a-4784-bd89-4d7878a2a6d8", "succeeds": {"concept": "census.construction_spending.total_mom", "geography": null, "entity": null}}
 {"concept": "irs.actc.total_claims", "geography": {"level": "country", "id": "0100000US", "vintage": null}, "entity": null, "uuid": "23396038-b31d-43cd-be08-4aa9fe916b56"}
 {"concept": "census.spm.child_poverty_rate", "geography": {"level": "country", "id": "0100000US", "vintage": null}, "entity": null, "uuid": "37841d30-5bd6-42a0-aea7-fc7b6d32dbcc"}
+{"concept": "bea.private_nonresidential_fixed_investment", "geography": {"level": "country", "id": "0100000US", "vintage": null}, "entity": null, "uuid": "2e36a67f-ae8d-4717-a70e-9de016e28d3f"}
+{"concept": "bea.research_and_development_fixed_investment", "geography": {"level": "country", "id": "0100000US", "vintage": null}, "entity": null, "uuid": "3efd33de-5be6-4150-bf62-6e4a1e9a1291"}
+{"concept": "irs.actc.total_credit_amount", "geography": {"level": "country", "id": "0100000US", "vintage": null}, "entity": null, "uuid": "05d4b329-d6c0-4050-ab25-f1a1deddf465"}
+{"concept": "irs.soi.credit_30d.total_claims", "geography": {"level": "country", "id": "0100000US", "vintage": null}, "entity": null, "uuid": "f5eacf8a-ce09-4721-a92a-9b19766a0d3c"}
+{"concept": "irs.soi.credit_30d.total_credit_amount", "geography": {"level": "country", "id": "0100000US", "vintage": null}, "entity": null, "uuid": "c70d0bc6-d299-4727-959a-3c7bdb324861"}
+{"concept": "usaspending.dhs.title_vi.award_transaction_obligations", "geography": {"level": "country", "id": "0100000US", "vintage": null}, "entity": null, "uuid": "e64ea5db-b72a-4a46-8948-6142dbc59d91"}

--- a/tests/test_build_series_catalog.py
+++ b/tests/test_build_series_catalog.py
@@ -792,7 +792,7 @@ def test_committed_catalog_is_current_and_valid() -> None:
     assert committed["docket_seed_sha256"] is not None
     assert committed["uuid_registry_sha256"] == registry.sha256()
     assert bsc.DOCKET_SEED.exists()
-    assert len(committed["series"]) == 203
+    assert len(committed["series"]) == 209
 
 
 def test_rebuild_without_prior_catalog_is_gated(
@@ -1165,7 +1165,10 @@ def test_identity_uuid_map_matches_reviewed_anchor() -> None:
     # registered census.spm.child_poverty_rate; its placeholder joins the
     # seed snapshot. All 205 prior bindings unchanged.
     assert digest == (
-        "9ecc2df99e887195b35f0f2f5106a1b0f7d9c12bd2713a8aca201b6673aedf82"
+        # 2026-08-07: +6 docket-only mints for thesis#138 wave-1 admission
+            # (bea fixed-investment x2, usaspending dhs title-vi, irs soi 30D
+            # claims+amount, irs actc amount) — see the seed diff in this commit.
+            "396e27996b2494c1defe94d834db4977c36e5b1ec179f71c198a0e20955cbd1e"
     )
 
 


### PR DESCRIPTION
Requested by the Thesis session (wave-1 ingestion containment gate): six US-national, entity-null, observation-free docket-only series, following the census.spm.child_poverty_rate precedent (#140).

| concept | unit | cadence |
|---|---|---|
| bea.private_nonresidential_fixed_investment | usd_billions | quarter |
| bea.research_and_development_fixed_investment | usd_billions | quarter |
| usaspending.dhs.title_vi.award_transaction_obligations | usd | year |
| irs.soi.credit_30d.total_claims | count | year |
| irs.soi.credit_30d.total_credit_amount | usd_millions | year |
| irs.actc.total_credit_amount | usd_millions | year |

- `scripts/build_series_catalog.py`: minted=6, catalog 209 series (52 docket-only), `--check` current, `--verify-registry-append-only` vs base ok (no supersedes/retires).
- Reviewed identity-anchor sha + series-count pins updated in the same diff, per the tests' own update doctrine.
- tests/test_build_series_catalog.py: 151 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)