### PR TITLE
Fill missing source_id/package_id so publish-raw covers every manifest

### DIFF
--- a/db/data/bfp/economic_outlook_2026_06/manifest.yaml
+++ b/db/data/bfp/economic_outlook_2026_06/manifest.yaml
@@ -1,12 +1,14 @@
-source_id: bfp-economic-outlook-2026-06
+source_id: belgium
+package_id: bfp-economic-outlook-2026-06
 source_name: BFP economic outlook June 2026
-publisher: Federal Planning Bureau (Bureau fédéral du Plan / Federaal Planbureau)
+publisher: "Federal Planning Bureau (Bureau f\xE9d\xE9ral du Plan / Federaal Planbureau)"
 source_page: https://www.plan.be/en/publications/economic-budget-2026-2027-economic-outlook-2028
 files:
   2026:
     filename: bfp_economic_outlook_2026_06.csv
     source_url: https://www.plan.be/en/publications/economic-budget-2026-2027-economic-outlook-2028
-    source_table: Economic Budget 2026-2027 - Economic Outlook 2028-2031, June 2026 headline projections
+    source_table: Economic Budget 2026-2027 - Economic Outlook 2028-2031, June 2026
+      headline projections
     sha256: 925eb195ff31de15fbe46b694a78ee8e338a44fd56af52bc57ad72690c816c51
     size_bytes: 377
     storage:
@@ -19,15 +21,13 @@ files:
     - https://www.plan.be/en/publications/economic-budget-2026-2027-economic-outlook-2028
     - https://www.plan.be/sites/default/files/documents/FOR_MIDTERM_2631_13322_FR.pdf
     - https://www.plan.be/sites/default/files/documents/FOR_MIDTERM_2631_13322_NL.pdf
-    notes: >-
-      Headline projection figures published by the Federal Planning Bureau (the
-      Belgian OBR-analog) in its "Economic Budget 2026-2027 - Economic Outlook
-      2028-2031" of 12 June 2026. These are publisher projections, typed
-      assertion: source_projection. Only figures printed exactly on the
-      publication page are recorded: real GDP growth 2026 (0.7%), consumer price
-      inflation 2026 (3.4%) and end-of-period 2031 (1.7%), and the general
-      government deficit as a share of GDP in 2026 (5.1%) and 2031 (6.4%). The
-      employment figures on the page ("around 20 000" jobs in 2026, "nearly
-      230 000" over 2027-2031) are stated as rounded approximations and the
-      per-year 2027-2030 GDP path is not on the press page, so both are recorded
-      as gaps rather than facts pending extraction from the full report PDF.
+    notes: 'Headline projection figures published by the Federal Planning Bureau (the
+      Belgian OBR-analog) in its "Economic Budget 2026-2027 - Economic Outlook 2028-2031"
+      of 12 June 2026. These are publisher projections, typed assertion: source_projection.
+      Only figures printed exactly on the publication page are recorded: real GDP
+      growth 2026 (0.7%), consumer price inflation 2026 (3.4%) and end-of-period 2031
+      (1.7%), and the general government deficit as a share of GDP in 2026 (5.1%)
+      and 2031 (6.4%). The employment figures on the page ("around 20 000" jobs in
+      2026, "nearly 230 000" over 2027-2031) are stated as rounded approximations
+      and the per-year 2027-2030 GDP path is not on the press page, so both are recorded
+      as gaps rather than facts pending extraction from the full report PDF.'

--- a/db/data/cms_nhe/historical_service_source/manifest.yaml
+++ b/db/data/cms_nhe/historical_service_source/manifest.yaml
@@ -1,4 +1,5 @@
 source_id: cms-nhe
+package_id: cms-nhe-historical-service-source
 source_name: CMS National Health Expenditure Accounts
 publisher: Centers for Medicare & Medicaid Services
 source_page: https://www.cms.gov/data-research/statistics-trends-and-reports/national-health-expenditure-data/historical
@@ -9,5 +10,12 @@ files:
     csv_member: NHE2024.csv
     sha256: b6a9e26774ca36931d42add46204947d6335fc4898011780563196898f964746
     size_bytes: 123721
-    source_table: National Health Expenditures by type of service and source of funds, CY 1960-2024
+    source_table: National Health Expenditures by type of service and source of funds,
+      CY 1960-2024
     notes: Full CMS ZIP source preserved; values are reported in millions of dollars.
+    storage:
+      r2:
+        provider: r2
+        bucket: ledger-raw
+        key: raw/cms-nhe/cms-nhe-historical-service-source/historical_service_source/b6a9e26774ca36931d42add46204947d6335fc4898011780563196898f964746/national-health-expenditures-type-service-source-funds-cy-1960-2024.zip
+        uri: r2://ledger-raw/raw/cms-nhe/cms-nhe-historical-service-source/historical_service_source/b6a9e26774ca36931d42add46204947d6335fc4898011780563196898f964746/national-health-expenditures-type-service-source-funds-cy-1960-2024.zip

--- a/db/data/hmrc/vat_firm_sector_targets_2024_25/manifest.yaml
+++ b/db/data/hmrc/vat_firm_sector_targets_2024_25/manifest.yaml
@@ -1,4 +1,5 @@
-source_id: hmrc-vat-firm-sector-targets-2024-25
+source_id: hmrc
+package_id: hmrc-vat-firm-sector-targets-2024-25
 source_name: HMRC Annual UK VAT Statistics 2024 to 2025
 publisher: HM Revenue and Customs
 source_page: https://www.gov.uk/government/statistics/value-added-tax-vat-annual-statistics
@@ -6,8 +7,8 @@ files:
   2024:
     filename: hmrc_vat_firm_sector_targets_2024_25.csv
     source_url: https://www.gov.uk/government/statistics/value-added-tax-vat-annual-statistics
-    source_table: Annual UK VAT Statistics 2024 to 2025 VAT trader population and net VAT
-      liability by trade sector
+    source_table: Annual UK VAT Statistics 2024 to 2025 VAT trader population and
+      net VAT liability by trade sector
     sha256: 1ad4ad25fde9eeae3ddb57957921c03c3a3167aa924cbe8d5d99df73a63a95f8
     size_bytes: 17440
     storage:
@@ -18,5 +19,5 @@ files:
         uri: r2://ledger-raw/raw/hmrc/hmrc-vat-firm-sector-targets-2024-25/2024/1ad4ad25fde9eeae3ddb57957921c03c3a3167aa924cbe8d5d99df73a63a95f8/hmrc_vat_firm_sector_targets_2024_25.csv
     source_urls:
     - https://www.gov.uk/government/statistics/value-added-tax-vat-annual-statistics
-    notes: Curated trade-sector extract from HMRC Annual UK VAT Statistics 2024 to 2025 used
-      by firm-microsim-paper processed/2024-25.
+    notes: Curated trade-sector extract from HMRC Annual UK VAT Statistics 2024 to
+      2025 used by firm-microsim-paper processed/2024-25.

--- a/db/data/hmrc/vat_firm_targets_2024_25/manifest.yaml
+++ b/db/data/hmrc/vat_firm_targets_2024_25/manifest.yaml
@@ -1,4 +1,5 @@
-source_id: hmrc-vat-firm-targets-2024-25
+source_id: hmrc
+package_id: hmrc-vat-firm-targets-2024-25
 source_name: HMRC Annual UK VAT Statistics 2024 to 2025
 publisher: HM Revenue and Customs
 source_page: https://www.gov.uk/government/statistics/value-added-tax-vat-annual-statistics
@@ -6,7 +7,8 @@ files:
   2024:
     filename: hmrc_vat_firm_targets_2024_25.csv
     source_url: https://www.gov.uk/government/statistics/value-added-tax-vat-annual-statistics
-    source_table: Annual UK VAT Statistics 2024 to 2025 VAT trader population and net VAT liability by turnover band
+    source_table: Annual UK VAT Statistics 2024 to 2025 VAT trader population and
+      net VAT liability by turnover band
     sha256: c37f8d7980f9c3154ff6fdf39fcb8d4b9f2d0ddd0e9acae492bfe427f5318a52
     size_bytes: 2462
     storage:
@@ -16,8 +18,7 @@ files:
         key: raw/hmrc/hmrc-vat-firm-targets-2024-25/2024/c37f8d7980f9c3154ff6fdf39fcb8d4b9f2d0ddd0e9acae492bfe427f5318a52/hmrc_vat_firm_targets_2024_25.csv
         uri: r2://ledger-raw/raw/hmrc/hmrc-vat-firm-targets-2024-25/2024/c37f8d7980f9c3154ff6fdf39fcb8d4b9f2d0ddd0e9acae492bfe427f5318a52/hmrc_vat_firm_targets_2024_25.csv
     source_urls:
-      - https://www.gov.uk/government/statistics/value-added-tax-vat-annual-statistics
-    notes: >-
-      Curated national extract from HMRC Annual UK VAT Statistics 2024 to 2025.
-      Net VAT liability rows retain source values in GBP millions and are scaled
-      to GBP by the Ledger source package.
+    - https://www.gov.uk/government/statistics/value-added-tax-vat-annual-statistics
+    notes: Curated national extract from HMRC Annual UK VAT Statistics 2024 to 2025.
+      Net VAT liability rows retain source values in GBP millions and are scaled to
+      GBP by the Ledger source package.

--- a/db/data/jct/tax_expenditures_2024/manifest.yaml
+++ b/db/data/jct/tax_expenditures_2024/manifest.yaml
@@ -1,13 +1,16 @@
+source_id: jct
+package_id: jct-tax-expenditures-2024
 id: jct-tax-expenditures-2024
 title: JCT Estimates of Federal Tax Expenditures for Fiscal Years 2024-2028
 publisher: Joint Committee on Taxation
-description: >
-  Selected calendar-year 2024 individual income tax revenue-loss estimates from
-  JCX-48-24 Table 1, curated for Microcosm fiscal calibration targets that must be
-  encoded as simple reforms rather than static PolicyEngine variables.
+description: 'Selected calendar-year 2024 individual income tax revenue-loss estimates
+  from JCX-48-24 Table 1, curated for Microcosm fiscal calibration targets that must
+  be encoded as simple reforms rather than static PolicyEngine variables.
+
+  '
 source_page: https://www.jct.gov/publications/2024/jcx-48-24/
 source_url: https://www.jct.gov/getattachment/765709fb-9a4b-430a-8f9e-4d342ec97f7e/x-48-24.pdf
-retrieved_at: "2026-06-16T00:00:00Z"
+retrieved_at: '2026-06-16T00:00:00Z'
 license: public-domain
 files:
   2024:
@@ -24,7 +27,8 @@ files:
         key: raw/jct/jct-tax-expenditures-2024/2024/8bfdd02de4e44040bc52fde70134bc64d15bea536f3e48e5324b1964980218ce/jct_tax_expenditures_2024.csv
         uri: r2://ledger-raw/raw/jct/jct-tax-expenditures-2024/2024/8bfdd02de4e44040bc52fde70134bc64d15bea536f3e48e5324b1964980218ce/jct_tax_expenditures_2024.csv
 notes:
-  - >
-    Calendar-year 2024 values use the individual income tax revenue-loss column
-    only. For charitable contributions, the value sums the three individual
-    charitable rows and excludes corporate revenue-loss columns.
+- 'Calendar-year 2024 values use the individual income tax revenue-loss column only.
+  For charitable contributions, the value sums the three individual charitable rows
+  and excludes corporate revenue-loss columns.
+
+  '

--- a/db/data/jrc/euromod_be_baseline_statistics_2025/manifest.yaml
+++ b/db/data/jrc/euromod_be_baseline_statistics_2025/manifest.yaml
@@ -1,4 +1,5 @@
-source_id: jrc-euromod-be-baseline-statistics-2025
+source_id: belgium
+package_id: jrc-euromod-be-baseline-statistics-2025
 source_name: JRC EUROMOD-BE baseline statistics 2025
 publisher: European Commission Joint Research Centre
 source_page: https://euromod-web.jrc.ec.europa.eu/resources/country-reports
@@ -18,5 +19,5 @@ files:
     source_urls:
     - https://euromod-web.jrc.ec.europa.eu/resources/country-reports
     - https://euromod-web.jrc.ec.europa.eu/sites/default/files/2025-02/Y15_CR_BE_final.pdf
-    notes: Curated comparator rows from Annex 3 validation tables in the 2025 EUROMOD Country
-      Report for Belgium. Each row carries the report PDF URL.
+    notes: Curated comparator rows from Annex 3 validation tables in the 2025 EUROMOD
+      Country Report for Belgium. Each row carries the report PDF URL.

--- a/db/data/nbb/national_accounts_household_disposable_income_2024/manifest.yaml
+++ b/db/data/nbb/national_accounts_household_disposable_income_2024/manifest.yaml
@@ -1,4 +1,5 @@
-source_id: nbb-national-accounts-household-disposable-income-2024
+source_id: belgium
+package_id: nbb-national-accounts-household-disposable-income-2024
 source_name: NBB household income accounts 2024
 publisher: National Bank of Belgium
 source_page: https://dataexplorer.nbb.be/vis?df%5Bag%5D=BE2&df%5Bds%5D=disseminate&df%5Bid%5D=DF_REGHHINC_B&lc=en
@@ -6,8 +7,8 @@ files:
   2024:
     filename: nbb_household_disposable_income_2024.csv
     source_url: https://nsidisseminate-stat.nbb.be/rest/data/DF_REGHHINC_B/A.3R_B6G.000.CU?startPeriod=2022&endPeriod=2024
-    source_table: Household income accounts, gross disposable income, Belgium, current prices,
-      millions of euro
+    source_table: Household income accounts, gross disposable income, Belgium, current
+      prices, millions of euro
     sha256: 72067b13a0ae3d85cd10650bfb152aa3228657e12255c32175e11d06eee28bbe
     size_bytes: 292
     storage:
@@ -19,4 +20,5 @@ files:
     source_urls:
     - https://dataexplorer.nbb.be/vis?df%5Bag%5D=BE2&df%5Bds%5D=disseminate&df%5Bid%5D=DF_REGHHINC_B&lc=en
     - https://nsidisseminate-stat.nbb.be/rest/data/DF_REGHHINC_B/A.3R_B6G.000.CU?startPeriod=2022&endPeriod=2024
-    notes: Direct CSV extract from NBB SDMX REST API for DF_REGHHINC_B/A.3R_B6G.000.CU, 2022-2024.
+    notes: Direct CSV extract from NBB SDMX REST API for DF_REGHHINC_B/A.3R_B6G.000.CU,
+      2022-2024.

--- a/db/data/onem_rva/unemployment_2024/manifest.yaml
+++ b/db/data/onem_rva/unemployment_2024/manifest.yaml
@@ -1,4 +1,5 @@
-source_id: onem-rva-unemployment-2024
+source_id: belgium
+package_id: onem-rva-unemployment-2024
 source_name: ONEM/RVA complete unemployment 2024
 publisher: ONEM / RVA
 source_page: https://rapportannuel.onem.be/accueil/une-evolution-des-allocations/chomage-complet/
@@ -17,5 +18,5 @@ files:
         uri: r2://ledger-raw/raw/belgium/onem-rva-unemployment-2024/2024/b0b42bc0e0e5d449108290be3b235c4736f5e160a817ea5bf32edbc4779c62f7/onem_rva_unemployment_2024.csv
     source_urls:
     - https://rapportannuel.onem.be/accueil/une-evolution-des-allocations/chomage-complet/
-    notes: Curated 2024 annual report table for complete unemployment benefit-recipient monthly
-      averages.
+    notes: Curated 2024 annual report table for complete unemployment benefit-recipient
+      monthly averages.

--- a/db/data/ons/uk_business_firm_sector_targets_2025/manifest.yaml
+++ b/db/data/ons/uk_business_firm_sector_targets_2025/manifest.yaml
@@ -1,4 +1,5 @@
-source_id: ons-uk-business-firm-sector-targets-2025
+source_id: ons
+package_id: ons-uk-business-firm-sector-targets-2025
 source_name: ONS UK Business, Activity, Size and Location 2025
 publisher: Office for National Statistics
 source_page: https://www.ons.gov.uk/businessindustryandtrade/business/activitysizeandlocation/datasets/ukbusinessactivitysizeandlocation
@@ -6,8 +7,8 @@ files:
   2025:
     filename: ons_uk_business_firm_sector_targets_2025.csv
     source_url: https://www.ons.gov.uk/businessindustryandtrade/business/activitysizeandlocation/datasets/ukbusinessactivitysizeandlocation
-    source_table: UK Business, Activity, Size and Location 2025 enterprise counts by SIC division,
-      turnover band, and employment size band
+    source_table: UK Business, Activity, Size and Location 2025 enterprise counts
+      by SIC division, turnover band, and employment size band
     sha256: 7bd5266da7cbeecf0d23f5b7bc98f14ad588ef399decaa2469a83b1f846b4962
     size_bytes: 188745
     storage:
@@ -18,5 +19,5 @@ files:
         uri: r2://ledger-raw/raw/ons/ons-uk-business-firm-sector-targets-2025/2025/7bd5266da7cbeecf0d23f5b7bc98f14ad588ef399decaa2469a83b1f846b4962/ons_uk_business_firm_sector_targets_2025.csv
     source_urls:
     - https://www.ons.gov.uk/businessindustryandtrade/business/activitysizeandlocation/datasets/ukbusinessactivitysizeandlocation
-    notes: Curated sector-by-band extract from the ONS UK Business 2025 workbook used by firm-microsim-paper
-      processed/2024-25.
+    notes: Curated sector-by-band extract from the ONS UK Business 2025 workbook used
+      by firm-microsim-paper processed/2024-25.

--- a/db/data/ons/uk_business_firm_targets_2025/manifest.yaml
+++ b/db/data/ons/uk_business_firm_targets_2025/manifest.yaml
@@ -1,4 +1,5 @@
-source_id: ons-uk-business-firm-targets-2025
+source_id: ons
+package_id: ons-uk-business-firm-targets-2025
 source_name: ONS UK Business, Activity, Size and Location 2025
 publisher: Office for National Statistics
 source_page: https://www.ons.gov.uk/businessindustryandtrade/business/activitysizeandlocation/datasets/ukbusinessactivitysizeandlocation
@@ -6,7 +7,8 @@ files:
   2025:
     filename: ons_uk_business_firm_targets_2025.csv
     source_url: https://www.ons.gov.uk/businessindustryandtrade/business/activitysizeandlocation/datasets/ukbusinessactivitysizeandlocation
-    source_table: UK Business, Activity, Size and Location 2025 enterprise turnover and employment size bands
+    source_table: UK Business, Activity, Size and Location 2025 enterprise turnover
+      and employment size bands
     sha256: 717cd268d8e59575b61e0806c9dbf00555944ead82fb5f601b3fbc6d64687d33
     size_bytes: 1378
     storage:
@@ -16,7 +18,6 @@ files:
         key: raw/ons/ons-uk-business-firm-targets-2025/2025/717cd268d8e59575b61e0806c9dbf00555944ead82fb5f601b3fbc6d64687d33/ons_uk_business_firm_targets_2025.csv
         uri: r2://ledger-raw/raw/ons/ons-uk-business-firm-targets-2025/2025/717cd268d8e59575b61e0806c9dbf00555944ead82fb5f601b3fbc6d64687d33/ons_uk_business_firm_targets_2025.csv
     source_urls:
-      - https://www.ons.gov.uk/businessindustryandtrade/business/activitysizeandlocation/datasets/ukbusinessactivitysizeandlocation
-    notes: >-
-      Curated national extract from the ONS UK Business 2025 workbook. Rows
-      retain published enterprise counts by turnover and employment size band.
+    - https://www.ons.gov.uk/businessindustryandtrade/business/activitysizeandlocation/datasets/ukbusinessactivitysizeandlocation
+    notes: Curated national extract from the ONS UK Business 2025 workbook. Rows retain
+      published enterprise counts by turnover and employment size band.

--- a/db/data/onss/contributions_2024/manifest.yaml
+++ b/db/data/onss/contributions_2024/manifest.yaml
@@ -1,4 +1,5 @@
-source_id: onss-contributions-2024
+source_id: belgium
+package_id: onss-contributions-2024
 source_name: ONSS declared contributions 2024
 publisher: ONSS / RSZ
 source_page: https://www.onss.be/stats/cotisations-declarees

--- a/db/data/opgroeien/groeipakket_caseload_2025/manifest.yaml
+++ b/db/data/opgroeien/groeipakket_caseload_2025/manifest.yaml
@@ -1,4 +1,5 @@
-source_id: opgroeien-groeipakket-caseload-2025
+source_id: belgium
+package_id: opgroeien-groeipakket-caseload-2025
 source_name: Opgroeien Groeipakket caseload 2025
 publisher: Opgroeien (Agentschap Opgroeien regie), Flemish Community
 source_page: https://www.opgroeien.be/kennis/cijfers-en-onderzoek/groeipakket
@@ -18,11 +19,10 @@ files:
     source_urls:
     - https://www.opgroeien.be/kennis/cijfers-en-onderzoek/groeipakket
     - https://www.opgroeien.be/kennis/cijfers-en-onderzoek/groeipakket/cijfers-op-maat
-    notes: >-
-      Curated per-component Groeipakket caseload counts published by Opgroeien
-      (the Flemish government agency administering the Groeipakket) on its
-      statistics page. Each component carries its own published reference basis
-      (end 2025, December 2025, or school year 2025-2026). The basisbedrag child
-      count is published only as "more than 1.6 million" (a rounded lower bound),
-      so it is omitted from the child record set and recorded as a gap; the exact
-      basisbedrag family count (930,010) is published and retained.
+    notes: Curated per-component Groeipakket caseload counts published by Opgroeien
+      (the Flemish government agency administering the Groeipakket) on its statistics
+      page. Each component carries its own published reference basis (end 2025, December
+      2025, or school year 2025-2026). The basisbedrag child count is published only
+      as "more than 1.6 million" (a rounded lower bound), so it is omitted from the
+      child record set and recorded as a gap; the exact basisbedrag family count (930,010)
+      is published and retained.

--- a/db/data/sfpd/legal_pension_caseload_2025/manifest.yaml
+++ b/db/data/sfpd/legal_pension_caseload_2025/manifest.yaml
@@ -1,6 +1,7 @@
-source_id: sfpd-legal-pension-caseload-2025
+source_id: belgium
+package_id: sfpd-legal-pension-caseload-2025
 source_name: SFPD/SFP legal pension caseload 2025
-publisher: Service fédéral des Pensions (SFP/SFPD), via PensionStat.be
+publisher: "Service f\xE9d\xE9ral des Pensions (SFP/SFPD), via PensionStat.be"
 source_page: https://www.pensionstat.be/fr
 files:
   2025:
@@ -18,13 +19,12 @@ files:
     source_urls:
     - https://www.pensionstat.be/fr
     - https://www.pensionstat.be/fr/chiffres-cles/pension-legale/pensionnes
-    notes: >-
-      Legal pension beneficiary counts published by the Federal Pensions Service
-      (SFP/SFPD) via PensionStat.be (a Sigedis / SFP / INASTI initiative),
-      January 2025 reference. The three scheme counts (employee, self-employed,
-      civil servant) sum to 3,653,050, which exceeds the 2,674,520 all-schemes
-      total because a person with a mixed career is counted in each scheme they
-      draw from; the scheme rows are therefore per-scheme recipient counts, not a
-      partition of the total. Total legal pension expenditure is published only
-      as a rounded "69 billion EUR" without an exact figure or reference year on
-      the source page, so it is recorded as a gap rather than a fact.
+    notes: Legal pension beneficiary counts published by the Federal Pensions Service
+      (SFP/SFPD) via PensionStat.be (a Sigedis / SFP / INASTI initiative), January
+      2025 reference. The three scheme counts (employee, self-employed, civil servant)
+      sum to 3,653,050, which exceeds the 2,674,520 all-schemes total because a person
+      with a mixed career is counted in each scheme they draw from; the scheme rows
+      are therefore per-scheme recipient counts, not a partition of the total. Total
+      legal pension expenditure is published only as a rounded "69 billion EUR" without
+      an exact figure or reference year on the source page, so it is recorded as a
+      gap rather than a fact.

--- a/db/data/spf_finances/pit_2023/manifest.yaml
+++ b/db/data/spf_finances/pit_2023/manifest.yaml
@@ -1,4 +1,5 @@
-source_id: spf-finances-pit-2023
+source_id: belgium
+package_id: spf-finances-pit-2023
 source_name: SPF Finances personal income tax 2023
 publisher: SPF Finances / Statbel
 source_page: https://statbel.fgov.be/en/themes/households/taxable-income
@@ -18,5 +19,5 @@ files:
     source_urls:
     - https://statbel.fgov.be/en/themes/households/taxable-income
     - https://statbel.fgov.be/sites/default/files/files/opendata/arbeid/TF_PSNL_INC_TAX_MUNTY.zip
-    notes: Curated national total taxes from Statbel personal income tax statistics for income
-      year 2023, assessment year 2024.
+    notes: Curated national total taxes from Statbel personal income tax statistics
+      for income year 2023, assessment year 2024.

--- a/db/data/ssa/annual_statistical_supplement_2025/manifest.yaml
+++ b/db/data/ssa/annual_statistical_supplement_2025/manifest.yaml
@@ -1,4 +1,5 @@
-source_id: ssa-annual-statistical-supplement
+source_id: ssa
+package_id: ssa-annual-statistical-supplement-2025
 source_name: SSA Annual Statistical Supplement, 2025
 publisher: Social Security Administration
 source_page: https://www.ssa.gov/policy/docs/statcomps/supplement/2025/index.html
@@ -15,12 +16,22 @@ files:
         key: raw/ssa/ssa-annual-statistical-supplement-2025/2024/ebc5a7327f818e3fe21c51d1cffe6f80f585e468802d3948dc2cfbf7a0cc384b/ssa_oasdi_ssi_2024.csv
         uri: r2://ledger-raw/raw/ssa/ssa-annual-statistical-supplement-2025/2024/ebc5a7327f818e3fe21c51d1cffe6f80f585e468802d3948dc2cfbf7a0cc384b/ssa_oasdi_ssi_2024.csv
     source_urls:
-      - https://www.ssa.gov/policy/docs/statcomps/supplement/2025/4a.html
-      - https://www.ssa.gov/policy/docs/statcomps/supplement/2025/7b.html
-    notes: Extracted 2024 national rows from SSA Annual Statistical Supplement tables 4.A5, 4.A6, and 7.B1.
+    - https://www.ssa.gov/policy/docs/statcomps/supplement/2025/4a.html
+    - https://www.ssa.gov/policy/docs/statcomps/supplement/2025/7b.html
+    notes: Extracted 2024 national rows from SSA Annual Statistical Supplement tables
+      4.A5, 4.A6, and 7.B1.
   extracted_targets:
     filename: ssa_oasdi_ssi_2024.csv
     source_urls:
-      - https://www.ssa.gov/policy/docs/statcomps/supplement/2025/4a.html
-      - https://www.ssa.gov/policy/docs/statcomps/supplement/2025/7b.html
-    notes: Extracted 2024 national rows from SSA Annual Statistical Supplement tables 4.A5, 4.A6, and 7.B1.
+    - https://www.ssa.gov/policy/docs/statcomps/supplement/2025/4a.html
+    - https://www.ssa.gov/policy/docs/statcomps/supplement/2025/7b.html
+    notes: Extracted 2024 national rows from SSA Annual Statistical Supplement tables
+      4.A5, 4.A6, and 7.B1.
+    sha256: ebc5a7327f818e3fe21c51d1cffe6f80f585e468802d3948dc2cfbf7a0cc384b
+    size_bytes: 1793
+    storage:
+      r2:
+        provider: r2
+        bucket: ledger-raw
+        key: raw/ssa/ssa-annual-statistical-supplement-2025/extracted_targets/ebc5a7327f818e3fe21c51d1cffe6f80f585e468802d3948dc2cfbf7a0cc384b/ssa_oasdi_ssi_2024.csv
+        uri: r2://ledger-raw/raw/ssa/ssa-annual-statistical-supplement-2025/extracted_targets/ebc5a7327f818e3fe21c51d1cffe6f80f585e468802d3948dc2cfbf7a0cc384b/ssa_oasdi_ssi_2024.csv

--- a/db/data/ssa/ssi_table_7b1_2024/manifest.yaml
+++ b/db/data/ssa/ssi_table_7b1_2024/manifest.yaml
@@ -1,4 +1,5 @@
-source_id: ssa-ssi-table-7b1-2024
+source_id: ssa
+package_id: ssa-ssi-table-7b1-2024
 source_name: SSA Annual Statistical Supplement, 2025
 publisher: Social Security Administration
 source_page: https://www.ssa.gov/policy/docs/statcomps/supplement/2025/7b.html
@@ -12,8 +13,8 @@ files:
       r2:
         provider: r2
         bucket: ledger-raw
-        key: raw/ssa/ssa-annual-statistical-supplement-2025/2024/4935f2b90d5abedc869e660f8a68df33b6f935630ebab2b159c09de7e4bf2401/ssi_table_7b1_2024.csv
-        uri: r2://ledger-raw/raw/ssa/ssa-annual-statistical-supplement-2025/2024/4935f2b90d5abedc869e660f8a68df33b6f935630ebab2b159c09de7e4bf2401/ssi_table_7b1_2024.csv
+        key: raw/ssa/ssa-ssi-table-7b1-2024/2024/4935f2b90d5abedc869e660f8a68df33b6f935630ebab2b159c09de7e4bf2401/ssi_table_7b1_2024.csv
+        uri: r2://ledger-raw/raw/ssa/ssa-ssi-table-7b1-2024/2024/4935f2b90d5abedc869e660f8a68df33b6f935630ebab2b159c09de7e4bf2401/ssi_table_7b1_2024.csv
     source_urls:
     - https://www.ssa.gov/policy/docs/statcomps/supplement/2025/7b.html
     notes: Extracted selected 2024 All areas, state, and DC rows from SSA Annual Statistical
@@ -24,3 +25,11 @@ files:
     - https://www.ssa.gov/policy/docs/statcomps/supplement/2025/7b.html
     notes: Extracted selected 2024 SSI recipient and payment rows from SSA Annual
       Statistical Supplement 2025 Table 7.B1.
+    sha256: 4935f2b90d5abedc869e660f8a68df33b6f935630ebab2b159c09de7e4bf2401
+    size_bytes: 13990
+    storage:
+      r2:
+        provider: r2
+        bucket: ledger-raw
+        key: raw/ssa/ssa-ssi-table-7b1-2024/extracted_targets/4935f2b90d5abedc869e660f8a68df33b6f935630ebab2b159c09de7e4bf2401/ssi_table_7b1_2024.csv
+        uri: r2://ledger-raw/raw/ssa/ssa-ssi-table-7b1-2024/extracted_targets/4935f2b90d5abedc869e660f8a68df33b6f935630ebab2b159c09de7e4bf2401/ssi_table_7b1_2024.csv

--- a/db/data/statbel/fiscal_income_commune_2023_nis_2025/manifest.yaml
+++ b/db/data/statbel/fiscal_income_commune_2023_nis_2025/manifest.yaml
@@ -1,4 +1,5 @@
-source_id: statbel-fiscal-income-2023-nis-2025
+source_id: belgium
+package_id: statbel-fiscal-income-2023-nis-2025
 source_name: Statbel fiscal income 2023 by 2025 commune
 publisher: Statbel
 source_page: https://statbel.fgov.be/en/themes/households/taxable-income
@@ -6,8 +7,8 @@ files:
   2023:
     filename: statbel_fiscal_income_commune_2023_nis_2025.csv
     source_url: https://statbel.fgov.be/en/themes/households/taxable-income
-    source_table: Personal income tax statistics by municipality, income year 2023, aggregated
-      to 2025 NIS communes
+    source_table: Personal income tax statistics by municipality, income year 2023,
+      aggregated to 2025 NIS communes
     sha256: 732bb3945d080c06bba2609bd55d24af0f12859840d6f6b7c3c85de8f93eed75
     size_bytes: 101316
     storage:
@@ -21,5 +22,5 @@ files:
     - https://statbel.fgov.be/sites/default/files/files/opendata/arbeid/TF_PSNL_INC_TAX_MUNTY.zip
     - https://statbel.fgov.be/en/news/modification-nsi-codes-municipalities-1-january-2025-onwards
     - https://statbel.fgov.be/sites/default/files/Over_Statbel_FR/Nomenclaturen/REFNIS_2025.csv
-    notes: Curated 2023 income-year total net taxable income by municipality, aggregated from
-      581 2019-2024 NIS codes to the 565-code 2025 NIS commune vintage.
+    notes: Curated 2023 income-year total net taxable income by municipality, aggregated
+      from 581 2019-2024 NIS codes to the 565-code 2025 NIS commune vintage.

--- a/db/data/statbel/nis_2025_commune_crosswalk/manifest.yaml
+++ b/db/data/statbel/nis_2025_commune_crosswalk/manifest.yaml
@@ -1,4 +1,5 @@
-source_id: statbel-nis-2025-commune-crosswalk
+source_id: belgium
+package_id: statbel-nis-2025-commune-crosswalk
 source_name: Statbel NIS 2025 commune crosswalk
 publisher: Statbel
 source_page: https://statbel.fgov.be/en/news/modification-nsi-codes-municipalities-1-january-2025-onwards
@@ -19,5 +20,5 @@ files:
     - https://statbel.fgov.be/en/news/modification-nsi-codes-municipalities-1-january-2025-onwards
     - https://statbel.fgov.be/sites/default/files/Over_Statbel_FR/Nomenclaturen/REFNIS_2025.csv
     - https://www.publisys.eu/list-of-the-nsi-codes/
-    notes: Curated old-to-2025 municipality crosswalk for the 30 municipality codes affected
-      by the 2024-2025 mergers, plus unchanged 2023 municipality codes.
+    notes: Curated old-to-2025 municipality crosswalk for the 30 municipality codes
+      affected by the 2024-2025 mergers, plus unchanged 2023 municipality codes.

--- a/db/data/statbel/population_structure_nuts1_2026/manifest.yaml
+++ b/db/data/statbel/population_structure_nuts1_2026/manifest.yaml
@@ -1,4 +1,5 @@
-source_id: statbel-population-structure-2026
+source_id: belgium
+package_id: statbel-population-structure-2026
 source_name: Statbel population structure 2026
 publisher: Statbel
 source_page: https://data.gov.be/en/datasets/nodeid5468
@@ -6,8 +7,8 @@ files:
   2026:
     filename: statbel_population_structure_nuts1_2026.csv
     source_url: https://data.gov.be/en/datasets/nodeid5468
-    source_table: Population by place of residence, nationality, marital status, age and sex,
-      2026
+    source_table: Population by place of residence, nationality, marital status, age
+      and sex, 2026
     sha256: b8456b6a7dfd71caf50184ded4f270206f3b36ae188392ade8c4375aad1ecd52
     size_bytes: 5210
     storage:
@@ -19,5 +20,5 @@ files:
     source_urls:
     - https://data.gov.be/en/datasets/nodeid5468
     - https://statbel.fgov.be/sites/default/files/files/opendata/bevolking%20naar%20woonplaats%2C%20nationaliteit%20burgelijke%20staat%20%2C%20leeftijd%20en%20geslacht/TF_SOC_POP_STRUCT_2026.zip
-    notes: Curated NUTS1 extract aggregated from the official Statbel 2026 population structure
-      text file over municipalities, nationality and marital status.
+    notes: Curated NUTS1 extract aggregated from the official Statbel 2026 population
+      structure text file over municipalities, nationality and marital status.


### PR DESCRIPTION
## What

Nineteen `db/data` manifests predated the source/package id split — they carried the package slug in `source_id` and had no `package_id`, so `chronicle publish-raw` skipped them with "Manifest missing package_id/source_id" scan errors. Both ids are now filled, derived from each manifest's existing content-addressed R2 keys (path convention for `cms_nhe/historical_service_source`, which had no storage yet), so republishing reproduces the historical keys exactly.

One deliberate correction: `ssa/ssi_table_7b1_2024`'s artifact had been uploaded under `ssa-annual-statistical-supplement-2025`'s package path; it now lives at its own `ssa-ssi-table-7b1-2024` key.

## Verification

Ran `publish-raw` per directory over all 19 (with #148's tooling fixes): **21/21 artifacts uploaded, 0 failures, 0 scan errors** to the PolicyEngine account's `ledger-raw`. Storage keys: 17 byte-identical to the committed ones, 1 corrected (7b1), 3 first-time entries (including two `extracted_targets` label entries that only became publishable with #148's label-year fix). Spot round-trip (sfpd Belgian pension caseload) sha256-verified.

Companion to #148, which pins the Cloudflare account and fixes the publish tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)