### PR TITLE
Enrichment demands the live binding; stale-UUID staging test

### DIFF
--- a/docs/catalog-curation-backlog.md
+++ b/docs/catalog-curation-backlog.md
@@ -35,3 +35,21 @@ on `person/ui_claimant` under UUID
 `1ad67747-d9d8-4ff9-9ebc-58206e658518`. Correct the two upstream rows'
 period and entity metadata before folding these lineages; an alias cannot
 bridge either mismatch safely.
+
+## Builder polish
+
+The two LOW residuals accepted in the chronicle#145 merge disposition
+were closed on 2026-08-09 by chronicle#153:
+
+- `_plan_enrichment` now verifies the live binding owns the catalog
+  row's UUID (`registry.binding(prior_own_key) == row_uuid`) instead of
+  inferring ownership from the historical first-owner map plus key
+  liveness. A stale catalog row carrying a UUID its key superseded away
+  from fails at plan time with the UUID-reuse ceremony diagnostic;
+  previously the invalid retire + succeeds plan was only rejected later,
+  by staging replay. Builder output for valid states is byte-unchanged.
+- The previously untested state — a stale catalog UUID after the same
+  placeholder key was superseded — is pinned by two regressions: staging
+  replay rejects the hand-forged plan before any write reaches disk, and
+  the builder end-to-end refuses the stale catalog, leaving both
+  artifacts untouched.

--- a/scripts/build_series_catalog.py
+++ b/scripts/build_series_catalog.py
@@ -1641,10 +1641,16 @@ def build_catalog(
                 )
             )
         )
+        # uuid_owner records FIRST ownership and never moves, so alone it
+        # would accept a stale catalog row still carrying a UUID its key
+        # has since superseded away from. The contract is about the LIVE
+        # binding: demand it be row_uuid itself. Staging replay would
+        # reject such a plan anyway; this fails at plan time instead.
         if not (
             enrichment_shaped
             and owner_key == prior_own_key
             and registry.is_live(prior_own_key)
+            and registry.binding(prior_own_key) == row_uuid
         ):
             return False
         # Docket-placeholder enrichment: the binding MOVES to the observed

--- a/tests/test_build_series_catalog.py
+++ b/tests/test_build_series_catalog.py
@@ -2320,3 +2320,85 @@ def test_malformed_succeeds_geography_is_a_schema_finding(
     )
     with pytest.raises(SystemExit, match="must be an object or null"):
         bsc.UuidRegistry.load(path)
+
+
+def test_stage_rejects_stale_uuid_retire_after_supersede(
+    tmp_path: pathlib.Path,
+) -> None:
+    # Fifteenth-review follow-up: a stale catalog row can retain U1 after
+    # its own placeholder key superseded to U2. The enrichment plan the
+    # old guard built from that row — retire(A/U1) + succeeds(B/U1) —
+    # must die in staging replay before anything reaches disk.
+    entries = [
+        _mint("census.m3.new_orders", U1),
+        dict(_mint("census.m3.new_orders", U2), supersedes=U1,
+             note="curated remint of the placeholder"),
+    ]
+    registry = _registry(tmp_path, entries)
+    raw_before = (tmp_path / "registry.jsonl").read_bytes()
+    b_geo = {"level": "country", "id": "0100000US", "vintage": "current"}
+    b_ent = {"name": "economy", "role": "aggregate"}
+    invalid = [
+        dict(_mint("census.m3.new_orders", U1), retired=True,
+             note="docket placeholder enriched by first observed identity"),
+        dict(_mint("census.m3.new_orders", U1, geography=b_geo,
+                   entity=b_ent),
+             succeeds={"concept": "census.m3.new_orders",
+                       "geography": None, "entity": None}),
+    ]
+    with pytest.raises(SystemExit, match="must keep uuid"):
+        registry.stage(invalid)
+    assert (tmp_path / "registry.jsonl").read_bytes() == raw_before
+
+
+def test_stale_catalog_uuid_after_supersede_fails_before_write(
+    tmp_path: pathlib.Path,
+) -> None:
+    # Fifteenth-review follow-up: the builder itself must refuse the
+    # stale row at plan time — the LIVE binding, not historical UUID
+    # ownership, decides enrichment — and leave both artifacts untouched.
+    seed = {
+        "series": [
+            {
+                "series": "census.m3.new_orders",
+                "cadence": "monthly",
+                "extras": {"country": "US", "targetUnit": "percent"},
+            }
+        ]
+    }
+    argv = _repo(tmp_path, [_row("bls.cps.unemployment_rate")], seed=seed)
+    assert bsc.main(argv) == 0
+    catalog = json.loads((tmp_path / "catalog.json").read_text())
+    row = next(r for r in catalog["series"] if r["status"] == "docket-only")
+    stale_uuid = row["uuid"]
+    row["uuid"] = "55555555-5555-4555-8555-555555555555"
+    (tmp_path / "catalog.json").write_text(
+        json.dumps(catalog, indent=2) + "\n", encoding="utf-8"
+    )
+    assert (
+        bsc.main(argv + ["--allow-remint", "--remint-note", "curated remint"])
+        == 0
+    )
+    # Regress the row to its pre-supersede UUID: a stale catalog.
+    catalog = json.loads((tmp_path / "catalog.json").read_text())
+    row = next(r for r in catalog["series"] if r["status"] == "docket-only")
+    row["uuid"] = stale_uuid
+    (tmp_path / "catalog.json").write_text(
+        json.dumps(catalog, indent=2) + "\n", encoding="utf-8"
+    )
+    catalog_before = (tmp_path / "catalog.json").read_bytes()
+    registry_before = (tmp_path / "registry.jsonl").read_bytes()
+    (tmp_path / "obs.jsonl").write_text(
+        "".join(
+            json.dumps(r) + "\n"
+            for r in [
+                _row("bls.cps.unemployment_rate"),
+                _row("census.m3.new_orders"),
+            ]
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(SystemExit, match="explicit ceremony"):
+        bsc.main(argv)
+    assert (tmp_path / "catalog.json").read_bytes() == catalog_before
+    assert (tmp_path / "registry.jsonl").read_bytes() == registry_before


### PR DESCRIPTION
## Why

Closes the two LOW residuals accepted in the [chronicle#145 merge disposition](https://github.com/PolicyEngine/chronicle/pull/145): the `_plan_enrichment` ownership guard that inferred rather than verified the live binding, and the reviewer-noted missing regression for a stale catalog UUID after its placeholder key was superseded. Diagnostic hardening only — staging replay already rejected the invalid plan before any write.

## What

- **`_plan_enrichment` now demands the live binding own `row_uuid`** (`registry.binding(prior_own_key) == row_uuid`), matching its stated contract. `uuid_owner` records FIRST ownership and never moves, so the old guard (historical owner + key liveness) accepted a stale catalog row still carrying a UUID its key had superseded away from, building a retire + succeeds plan that only died later in staging replay. The stale state now fails at plan time with the UUID-reuse ceremony diagnostic. Builder output for every valid state is unchanged.
- **Two regressions pin the previously untested state** (fifteenth-review follow-ups):
  - `test_stage_rejects_stale_uuid_retire_after_supersede` — the hand-forged retire(A/U1)+succeeds(B/U1) plan after A superseded U1→U2 dies in `UuidRegistry.stage()` replay ("must keep uuid") before any byte reaches disk.
  - `test_stale_catalog_uuid_after_supersede_fails_before_write` — end-to-end: mint, curated remint, regress the catalog row to its pre-supersede UUID, observe; the builder exits with the ceremony diagnostic and both artifacts are byte-untouched. Counterfactually verified: with the guard hunk reverted, this test fails (the SystemExit becomes the staging-replay "uuid registry invalid" instead of the plan-time diagnostic).
- **Backlog doc**: a "Builder polish" section in `docs/catalog-curation-backlog.md` records both residuals as closed, as the #145 disposition promised.

## Verification

- `uv run pytest tests/test_build_series_catalog.py -q` — 155 passed (153 base + 2 new)
- `uv run python scripts/build_series_catalog.py` — zero artifact diff (sha256-stable across repeated runs; artifact bytes unchanged by the guard)
- `uv run python scripts/build_series_catalog.py --check` — `catalog current: 209 series`
- `uv run ruff check` — clean
- Counterfactual: guard hunk reverted → builder-level regression fails for the designed reason; staging-level regression still passes (it pins the pre-existing deeper guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
