### PR TITLE
Regenerate series catalog to match same-commit observations

### DIFF
--- a/ledger/series_catalog.json
+++ b/ledger/series_catalog.json
@@ -1,9 +1,9 @@
 {
   "comment": "Canonical series catalog. One row per (concept, geography level/id/vintage, entity) identity. UUID authority is the append-only ledger/series_uuid_registry.jsonl (digest below): a uuid is minted once, inherited from the registry on every regeneration, and changes only through explicit, chained supersede/retire/revive/succeeds events recorded there (live bindings and rows stay in bijection). Consumers reference series by uuid or concept only. Regenerate with scripts/build_series_catalog.py; verify with --check. Aliases are curated identity statements (plus observed spellings of the same identity) and inherit only within one (geography, entity) slice; aliases listed in ambiguous_aliases match multiple rows and never drive inheritance. source_concepts are publisher labels — provenance, never identity. Cross-spelling and cross-vintage merges are manual curation: delete the absorbed row, alias its concept on the survivor, regenerate with --allow-remint.",
   "generator_version": 3,
-  "observations_sha256": "ee4b3cadfed4c9d2e968d03eb0aa13294895d5775d87ef4b966ff0a4ef01224c",
-  "observation_rows": 189,
-  "current_assertion_rows": 189,
+  "observations_sha256": "04ece7b939840112e65299df5afefca4a0c962136bb45828439221299010d0e1",
+  "observation_rows": 191,
+  "current_assertion_rows": 191,
   "docket_seed_sha256": "5914192517350e0166045afd9064a515ea312acbea1844d9cb594cc9f525dbb9",
   "uuid_registry_sha256": "b8c21e7822b45ced01a250879b585dde8593ee71ce3488617c22a0eb64e3120a",
   "suspect_segments": [],
@@ -203,6 +203,10 @@
       "us.dol.initial_claims.sa"
     ],
     "week_2026-08-01": [
+      "dol.eta.continued_claims.sa",
+      "us.dol.initial_claims.sa"
+    ],
+    "week_2026-08-08": [
       "us.dol.initial_claims.sa"
     ],
     "week_2026_06_13": [
@@ -2879,8 +2883,8 @@
         "dol.eta.continued_claims.sa.{P}.first_print"
       ],
       "first_observed_period": "2026-06-27",
-      "last_observed_period": "2026-07-25",
-      "observation_count": 5
+      "last_observed_period": "2026-08-01",
+      "observation_count": 6
     },
     {
       "uuid": "32b335ea-b2dd-4fba-8321-e9751df19318",
@@ -6702,8 +6706,8 @@
         "us.dol.initial_claims.sa.{P}"
       ],
       "first_observed_period": "2026-06-20",
-      "last_observed_period": "2026-08-01",
-      "observation_count": 6
+      "last_observed_period": "2026-08-08",
+      "observation_count": 7
     },
     {
       "uuid": "830e68bb-9ed6-493c-a8a4-440ba8e53f76",

--- a/tests/test_build_series_catalog.py
+++ b/tests/test_build_series_catalog.py
@@ -780,7 +780,8 @@ def test_committed_catalog_is_current_and_valid() -> None:
         "june_2026", "may_2026", "q1_2026", "week_2026-06-13",
         "week_2026-06-20", "week_2026-06-27", "week_2026-07-04",
         "week_2026-07-11", "week_2026-07-18", "week_2026-07-25",
-        "week_2026-08-01", "week_2026_06_13", "week_ending_2026_06_06",
+        "week_2026-08-01", "week_2026-08-08", "week_2026_06_13",
+        "week_ending_2026_06_06",
     ]
     assert committed["stripped_segments"]["after_mpc_june_2026"] == [
         "boe.bank_rate"


### PR DESCRIPTION
The witnessed append path appends observations without regenerating the catalog, so the 2026-08-14 and 2026-08-15 appends left `observations_sha256`/`observation_rows` at the 2026-08-13 state. Thesis's catalog-v3 pin requires same-commit coherence, so its resolve loop has failed daily since 8/14 (thesis #190/#193/#196/#197).

Pure regeneration via `scripts/build_series_catalog.py`: 191 rows, 219 series, minted=0, superseded=0. Per-series `last_observed_period`/`observation_count` advance for exactly the two appended DOL weekly-claims prints; `--check` passes on the result.

Thesis-side follow-up (appends regenerate the catalog in the same proposal commit, so coherence can't drift again) is being prepared separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)