### PR TITLE
Schedule daily OpenTimestamps anchoring of the witnessed journal

### DIFF
--- a/.github/workflows/ots-anchor.yml
+++ b/.github/workflows/ots-anchor.yml
@@ -1,0 +1,77 @@
+name: OTS anchor
+
+# Anchor the witnessed observation journal outside the operator's control.
+# The journal and its release manifests live on codex/thesis-ledger-facts;
+# scripts/ots_anchor.py there stamps every release manifest's exact bytes
+# through OpenTimestamps and upgrades pending proofs once the calendars'
+# aggregate Bitcoin transactions confirm. Scheduled workflows only run from
+# the default branch, so this definition lives on main and operates on a
+# checkout of the journal branch. See ots/README.md on that branch for what
+# the proofs establish and how to verify them.
+
+on:
+  schedule:
+    - cron: "23 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ots-anchor
+  cancel-in-progress: false
+
+jobs:
+  anchor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      JOURNAL_BRANCH: codex/thesis-ledger-facts
+    steps:
+      - name: Check out the journal branch
+        uses: actions/checkout@v4
+        with:
+          ref: codex/thesis-ledger-facts
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Stamp missing proofs and upgrade pending ones
+        id: anchor
+        run: |
+          set -euo pipefail
+          if [ ! -f scripts/ots_anchor.py ]; then
+            echo "scripts/ots_anchor.py is not on $JOURNAL_BRANCH yet; nothing to do"
+            exit 0
+          fi
+          python3 scripts/ots_anchor.py run \
+            --ots-bin "uvx --from opentimestamps-client==0.7.2 ots"
+
+      - name: Commit and push proof changes
+        run: |
+          set -euo pipefail
+          if [ -z "$(git status --porcelain -- ots)" ]; then
+            echo "no proof changes to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add ots
+          git commit -m "Update OpenTimestamps anchors for release manifests"
+          for attempt in 1 2 3; do
+            if git push origin "HEAD:$JOURNAL_BRANCH"; then
+              exit 0
+            fi
+            git pull --rebase origin "$JOURNAL_BRANCH"
+          done
+          git push origin "HEAD:$JOURNAL_BRANCH"
+
+      - name: Verify every proof binds to its manifest
+        run: |
+          set -euo pipefail
+          if [ ! -f scripts/ots_anchor.py ]; then
+            exit 0
+          fi
+          python3 scripts/ots_anchor.py verify \
+            --ots-bin "uvx --from opentimestamps-client==0.7.2 ots"


### PR DESCRIPTION
## What

A daily GitHub Actions cron (plus `workflow_dispatch`) that anchors the witnessed observation journal in Bitcoin via OpenTimestamps. Companion to PolicyEngine/chronicle#182, which adds the tool, the proofs for releases 0000–0014, and the docs on `codex/thesis-ledger-facts`.

Scheduled workflows only run from the default branch, so this definition lives on `main` and operates on a checkout of the journal branch:

1. `python3 scripts/ots_anchor.py run` — stamp any release manifest lacking a proof, upgrade pending proofs whose calendar attestations have confirmed into Bitcoin. Idempotent; the tool is stdlib-only and the `ots` client is pinned (`opentimestamps-client==0.7.2`).
2. Commit changed proofs under `ots/` back to the journal branch as `github-actions[bot]`, with a rebase-and-retry push loop (proof commits touch neither the data surface nor the gate surface, so they cannot collide with resolver append PRs).
3. `python3 scripts/ots_anchor.py verify` — fail the run if any proof stops binding to its manifest's exact bytes.

## Merge order

Safe to merge before or after #182: the job exits cleanly with a notice while `scripts/ots_anchor.py` is not yet on the journal branch. The first effective run needs #182 merged; `workflow_dispatch` can trigger it immediately after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
