### PR TITLE
Judge a commit the shim checks out itself, and pin the receipt 0.5.2 line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,7 @@ jobs:
           tests/test_policyengine_ledger.py
           tests/test_release_chain.py
           tests/test_thesis_append_adversarial.py
+          tests/test_thesis_append_shim_isolation.py
           scripts/check_thesis_facts_append.py
           scripts/canonical_json.py
           scripts/cut_release_manifest.py

--- a/.github/workflows/thesis-facts-append.yml
+++ b/.github/workflows/thesis-facts-append.yml
@@ -107,14 +107,47 @@ jobs:
           # --root happens to be sitting at, so nothing that writes into that
           # working tree between the fetch above and the run below can change
           # what is judged. --root only says which clone the id is resolved in.
-          cd "$RUNNER_TEMP"
-          PYTHONPATH="$base_gate/scripts" \
-            PYTHONNOUSERSITE=1 \
+          # The judge is the BASE commit's copy of the script, and --commit was
+          # introduced by a pull request into this branch. There is no ordering
+          # of that merge and the default branch's copy of this file in which
+          # both sides are new at once: a new copy of this file invoking an old
+          # base gate fails on the unknown argument, and an old copy invoking a
+          # new base gate fails on the missing required one. So ask the base
+          # gate what it accepts. The question is put to base-owned code about
+          # its own interface, not to anything the candidate controls, and the
+          # help text is captured rather than piped so that a base gate which
+          # cannot run at all stops the step instead of being read as an old
+          # one. Delete the second branch below once no base reachable from
+          # this branch predates --commit.
+          base_gate_help="$(
             uv run --locked --no-dev --project "$base_gate" \
-            python "$base_gate/scripts/check_thesis_facts_append.py" \
-              --root "$candidate" \
-              --commit "$MERGE_SHA" \
-              --base-ref "$BASE_SHA"
+              python "$base_gate/scripts/check_thesis_facts_append.py" --help
+          )"
+
+          cd "$RUNNER_TEMP"
+          case "$base_gate_help" in
+            *--commit*)
+              PYTHONPATH="$base_gate/scripts" \
+                PYTHONNOUSERSITE=1 \
+                uv run --locked --no-dev --project "$base_gate" \
+                python "$base_gate/scripts/check_thesis_facts_append.py" \
+                  --root "$candidate" \
+                  --commit "$MERGE_SHA" \
+                  --base-ref "$BASE_SHA"
+              ;;
+            *)
+              echo "note: the base gate at $BASE_SHA predates --commit, so it" \
+                "judges the working tree at $candidate rather than an isolated" \
+                "checkout of $MERGE_SHA. This is the base's own guarantee and" \
+                "the only one available against that base." >&2
+              PYTHONPATH="$base_gate/scripts" \
+                PYTHONNOUSERSITE=1 \
+                uv run --locked --no-dev --project "$base_gate" \
+                python "$base_gate/scripts/check_thesis_facts_append.py" \
+                  --root "$candidate" \
+                  --base-ref "$BASE_SHA"
+              ;;
+          esac
 
   append-gate:
     name: Append gate
@@ -152,15 +185,36 @@ jobs:
             workspace_sha="$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)"
             [[ "$workspace_sha" =~ ^[0-9a-f]{40,64}$ ]]
 
-            # As in the trusted job above: the commit is named, not inferred.
-            cd "$RUNNER_TEMP"
-            PYTHONPATH="$base_gate/scripts" \
-              PYTHONNOUSERSITE=1 \
+            # As in the trusted job above: the commit is named, not inferred,
+            # and the base gate is asked what it accepts for the same reason.
+            base_gate_help="$(
               uv run --locked --no-dev --project "$base_gate" \
-              python "$base_gate/scripts/check_thesis_facts_append.py" \
-                --root "$GITHUB_WORKSPACE" \
-                --commit "$workspace_sha" \
-                --base-ref "$base_sha"
+                python "$base_gate/scripts/check_thesis_facts_append.py" --help
+            )"
+
+            cd "$RUNNER_TEMP"
+            case "$base_gate_help" in
+              *--commit*)
+                PYTHONPATH="$base_gate/scripts" \
+                  PYTHONNOUSERSITE=1 \
+                  uv run --locked --no-dev --project "$base_gate" \
+                  python "$base_gate/scripts/check_thesis_facts_append.py" \
+                    --root "$GITHUB_WORKSPACE" \
+                    --commit "$workspace_sha" \
+                    --base-ref "$base_sha"
+                ;;
+              *)
+                echo "note: the base gate at $base_sha predates --commit, so" \
+                  "it judges the workspace rather than an isolated checkout" \
+                  "of $workspace_sha." >&2
+                PYTHONPATH="$base_gate/scripts" \
+                  PYTHONNOUSERSITE=1 \
+                  uv run --locked --no-dev --project "$base_gate" \
+                  python "$base_gate/scripts/check_thesis_facts_append.py" \
+                    --root "$GITHUB_WORKSPACE" \
+                    --base-ref "$base_sha"
+                ;;
+            esac
           else
             # The push path names the pushed commit explicitly too. The
             # argument is required, so there is no spelling of this run in

--- a/.github/workflows/thesis-facts-append.yml
+++ b/.github/workflows/thesis-facts-append.yml
@@ -101,12 +101,19 @@ jobs:
           # keeps the PR unable to influence what code judges it.
           uv sync --locked --no-dev --project "$base_gate"
 
+          # The gate judges the commit named here, which it checks out for
+          # itself into a private directory. The object id is always an
+          # argument and is never inferred from whatever the checkout at
+          # --root happens to be sitting at, so nothing that writes into that
+          # working tree between the fetch above and the run below can change
+          # what is judged. --root only says which clone the id is resolved in.
           cd "$RUNNER_TEMP"
           PYTHONPATH="$base_gate/scripts" \
             PYTHONNOUSERSITE=1 \
             uv run --locked --no-dev --project "$base_gate" \
             python "$base_gate/scripts/check_thesis_facts_append.py" \
               --root "$candidate" \
+              --commit "$MERGE_SHA" \
               --base-ref "$BASE_SHA"
 
   append-gate:
@@ -142,17 +149,26 @@ jobs:
             # gate dependencies resolve without the PR influencing them.
             uv sync --locked --no-dev --project "$base_gate"
 
+            workspace_sha="$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)"
+            [[ "$workspace_sha" =~ ^[0-9a-f]{40,64}$ ]]
+
+            # As in the trusted job above: the commit is named, not inferred.
             cd "$RUNNER_TEMP"
             PYTHONPATH="$base_gate/scripts" \
               PYTHONNOUSERSITE=1 \
               uv run --locked --no-dev --project "$base_gate" \
               python "$base_gate/scripts/check_thesis_facts_append.py" \
                 --root "$GITHUB_WORKSPACE" \
+                --commit "$workspace_sha" \
                 --base-ref "$base_sha"
           else
+            # The push path names the pushed commit explicitly too. The
+            # argument is required, so there is no spelling of this run in
+            # which the commit is taken from the checkout instead.
             uv sync --locked --no-dev
             uv run --locked --no-dev \
-              python scripts/check_thesis_facts_append.py
+              python scripts/check_thesis_facts_append.py \
+                --commit "$GITHUB_SHA"
           fi
 
       - name: Install uv
@@ -172,4 +188,6 @@ jobs:
           tests/test_policyengine_ledger.py
           tests/test_release_chain.py
           tests/test_thesis_append_adversarial.py
+          tests/test_thesis_append_shim_isolation.py
+          tests/test_receipt_shim_transparency.py
           -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "odfpy>=1.4.1",
     "xlrd>=2.0.1",
     "pypdf>=6.0.0",
-    "receipt @ git+https://github.com/TheAxiomFoundation/receipt@e80cc5e82e22d74c24d36860c949138c472ec97c",
+    "receipt==0.5.2",
 ]
 
 [project.optional-dependencies]
@@ -43,12 +43,6 @@ arch = "arch.cli:main"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-# The receipt pin above is a direct reference (a git revision) while the 0.5.2
-# tag does not yet exist, and hatchling refuses to build metadata containing one
-# unless this says so. It comes out again with the direct reference, when the
-# pin returns to a released version.
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["arch", "db", "micro", "calibration", "packages"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "odfpy>=1.4.1",
     "xlrd>=2.0.1",
     "pypdf>=6.0.0",
-    "receipt==0.5.1",
+    "receipt @ git+https://github.com/TheAxiomFoundation/receipt@e80cc5e82e22d74c24d36860c949138c472ec97c",
 ]
 
 [project.optional-dependencies]
@@ -42,6 +42,13 @@ arch = "arch.cli:main"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+# The receipt pin above is a direct reference (a git revision) while the 0.5.2
+# tag does not yet exist, and hatchling refuses to build metadata containing one
+# unless this says so. It comes out again with the direct reference, when the
+# pin returns to a released version.
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["arch", "db", "micro", "calibration", "packages"]

--- a/scripts/canonical_json.py
+++ b/scripts/canonical_json.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Thin shim over receipt==0.5.1 (hash-pinned in uv.lock). Any receipt upgrade
+# Thin shim over the receipt pin recorded in uv.lock. Any receipt upgrade
 # requires a fresh byte-equivalence proof at this repo's then-current pin BEFORE
 # the bump.
 """Canonical JSON compatibility surface backed by receipt."""

--- a/scripts/check_thesis_facts_append.py
+++ b/scripts/check_thesis_facts_append.py
@@ -190,6 +190,13 @@ GATE_CONFIG_KEYS = ("safe.directory", "core.hookspath")
 # a file whose bytes this commit fixes, so no comparison below is about it.
 PROTECTED_TREE_MODES = ("100644", "100755")
 
+# The two ways a run can end without a verdict of "OK", kept apart on purpose.
+# "failed" is the gate's verdict about a tree it was given; "refused" is this
+# shim declining to give it one, because the precondition the verdict would be
+# stated against could not be established.
+VERDICT_REFUSAL_PREFIX = "thesis-facts append check failed: "
+REFUSAL_PREFIX = "thesis-facts append check refused: "
+
 
 class ShimRefusal(RuntimeError):
     """The shim will not hand the gate a tree it cannot vouch for.
@@ -213,13 +220,18 @@ def _git(
     that did not answer means the precondition was not established.
     """
 
-    completed = subprocess.run(
-        ["git", *arguments],
-        cwd=cwd,
-        env=env,
-        check=False,
-        capture_output=True,
-    )
+    try:
+        completed = subprocess.run(
+            ["git", *arguments],
+            cwd=cwd,
+            env=env,
+            check=False,
+            capture_output=True,
+        )
+    except OSError as exc:
+        raise ShimRefusal(
+            f"git could not be run in {cwd}: {exc.strerror or exc}"
+        ) from exc
     if completed.returncode != 0:
         detail = completed.stderr.decode("utf-8", "replace").strip()
         raise ShimRefusal(
@@ -273,14 +285,19 @@ def _gate_environment(
     can check the documentation has not outgrown the rule.
 
     The environment is used two ways, and both are needed. The shim's own git
-    calls receive it as ``env=``. The gate's git calls are made by
-    ``receipt.append_gate`` without an explicit environment, so they inherit
-    the process's, and ``main`` therefore replaces ``os.environ`` with this
-    mapping for exactly the duration of the gate call (see
-    ``_frozen_environment``). Running the gate in a child process with ``env=``
-    would work equally well for the environment, but would put a process
-    boundary between the gate's exception text and this program's stderr, and
-    that text is what the byte-equivalence proof compares.
+    calls receive it as ``env=``. The gate builds the environment for its own
+    git calls out of ``os.environ`` -- on the pinned receipt,
+    ``release_chain._git_environment`` returns ``os.environ`` with
+    ``GIT_NO_REPLACE_OBJECTS`` set and four pathspec variables removed, and its
+    docstring says in as many words that it is not a sanitizer and that a
+    caller which does not control the environment it invokes the package in has
+    a problem outside that function's scope. So ``main`` replaces ``os.environ``
+    with this mapping for exactly the duration of the gate call (see
+    ``_frozen_environment``); that is the control the package asks its callers
+    for. Running the gate in a child process with ``env=`` would work equally
+    well for the environment, but would put a process boundary between the
+    gate's exception text and this program's stderr, and that text is what the
+    byte-equivalence proof compares.
 
     ``safe.directory`` names the clone. If the clone were owned by another user
     the linked worktree's own path would not be covered, and git would refuse
@@ -501,21 +518,26 @@ def _isolated_checkout(
             f"{oid!r} is not a full object id, so it will not be checked out"
         )
     checkout = scratch_root / "checkout"
-    completed = subprocess.run(
-        [
-            "git",
-            "-C",
-            str(clone_root),
-            "worktree",
-            "add",
-            "--detach",
-            str(checkout),
-            oid,
-        ],
-        env=env,
-        check=False,
-        capture_output=True,
-    )
+    try:
+        completed = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(clone_root),
+                "worktree",
+                "add",
+                "--detach",
+                str(checkout),
+                oid,
+            ],
+            env=env,
+            check=False,
+            capture_output=True,
+        )
+    except OSError as exc:
+        raise ShimRefusal(
+            f"git could not be run to check {oid} out: {exc.strerror or exc}"
+        ) from exc
     if completed.returncode != 0:
         detail = completed.stderr.decode("utf-8", "replace").strip()
         raise ShimRefusal(
@@ -647,8 +669,11 @@ def _assert_exact_checkout(
     verdict.
     """
 
-    head = _git(["rev-parse", "HEAD"], cwd=checkout, env=env)
-    head = head.decode("utf-8", "replace").strip()
+    head = (
+        _git(["rev-parse", "HEAD"], cwd=checkout, env=env)
+        .decode("utf-8", "replace")
+        .strip()
+    )
     if head != oid:
         raise ShimRefusal(
             f"the isolated checkout is at {head}, not the named commit {oid}"
@@ -730,20 +755,25 @@ def _worktree_removed(
 ) -> bool:
     """Try once to deregister this checkout, and report whether git did."""
 
-    completed = subprocess.run(
-        [
-            "git",
-            "-C",
-            str(clone_root),
-            "worktree",
-            "remove",
-            "--force",
-            str(checkout),
-        ],
-        env=env,
-        check=False,
-        capture_output=True,
-    )
+    try:
+        completed = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(clone_root),
+                "worktree",
+                "remove",
+                "--force",
+                str(checkout),
+            ],
+            env=env,
+            check=False,
+            capture_output=True,
+        )
+    except OSError:
+        # Cleanup runs in a finally, so it never raises over whatever brought
+        # the run here; a failure to remove is reported at the end instead.
+        return False
     return completed.returncode == 0
 
 
@@ -855,6 +885,12 @@ def main() -> int:
     )
     args = parser.parse_args()
     clone_root = args.root.resolve()
+    if not clone_root.is_dir():
+        print(
+            f"{REFUSAL_PREFIX}--root {clone_root} is not a directory",
+            file=sys.stderr,
+        )
+        return 1
 
     scratch_root: pathlib.Path | None = None
     environment: dict[str, str] | None = None
@@ -885,10 +921,10 @@ def main() -> int:
         finally:
             _remove_checkout(clone_root, scratch_root, checkout, environment)
     except ShimRefusal as exc:
-        print(f"thesis-facts append check refused: {exc}", file=sys.stderr)
+        print(f"{REFUSAL_PREFIX}{exc}", file=sys.stderr)
         return 1
     except AppendError as exc:
-        print(f"thesis-facts append check failed: {exc}", file=sys.stderr)
+        print(f"{VERDICT_REFUSAL_PREFIX}{exc}", file=sys.stderr)
         return 1
     print(summary)
     print(f"candidate commit {commit} tree {tree}")

--- a/scripts/check_thesis_facts_append.py
+++ b/scripts/check_thesis_facts_append.py
@@ -197,11 +197,16 @@ PROTECTED_TREE_MODES = ("100644", "100755")
 # to trust (peer review, round 1). ``core.fsmonitor`` is also refused by the
 # configuration audit.
 SCAN_SETTINGS = (
-    "-c", "core.untrackedCache=false",
-    "-c", "core.fsmonitor=false",
-    "-c", "core.trustctime=true",
-    "-c", "core.checkStat=default",
-    "-c", "feature.manyFiles=false",
+    "-c",
+    "core.untrackedCache=false",
+    "-c",
+    "core.fsmonitor=false",
+    "-c",
+    "core.trustctime=true",
+    "-c",
+    "core.checkStat=default",
+    "-c",
+    "feature.manyFiles=false",
 )
 
 # The two ways a run can end without a verdict of "OK", kept apart on purpose.
@@ -303,9 +308,10 @@ def _gate_environment(
     git calls out of ``os.environ`` -- on the pinned receipt,
     ``release_chain._git_environment`` returns ``os.environ`` with
     ``GIT_NO_REPLACE_OBJECTS`` set and four pathspec variables removed, and its
-    docstring says in as many words that it is not a sanitizer and that a
-    caller which does not control the environment it invokes the package in has
-    a problem outside that function's scope. So ``main`` replaces ``os.environ``
+    docstring says in as many words that it is still not a sanitizer: the five
+    redirecting variables are refused at the package's public verifier entries
+    rather than dropped there, and everything else in the ambient environment
+    is carried through. So ``main`` replaces ``os.environ``
     with this mapping for exactly the duration of the gate call (see
     ``_frozen_environment``); that is the control the package asks its callers
     for. Running the gate in a child process with ``env=`` would work equally
@@ -608,7 +614,11 @@ def _protected_entries(
     the RFC 3161 receipts and the trust anchors live, plus everything else
     under the state files' directory, so the byte comparison covers the whole
     of the gate's data surface (``ledger/**`` and ``releases/manifests/**``)
-    and not only the paths the gate reads (peer review, round 1). A commit that carries no
+    and not only the paths the gate reads (peer review, round 1). The prefixes
+    are the chain specification's, not the data-surface globs themselves;
+    ``test_the_byte_comparison_covers_the_whole_data_surface`` holds the two
+    together, so a widened data surface cannot outgrow this comparison
+    unnoticed. A commit that carries no
     entry at one of the two state paths is refused here: the gate would refuse
     it too, but this says which of the two is missing and says it before any
     file is read.
@@ -761,7 +771,11 @@ def _assert_exact_checkout(
                 f"not an ordinary tracked file ({reason}): {path}"
             )
     tree_entries = sum(
-        1 for record in _git(["ls-tree", "-r", "-z", oid], cwd=checkout, env=env).split(b"\0") if record
+        1
+        for record in _git(["ls-tree", "-r", "-z", oid], cwd=checkout, env=env).split(
+            b"\0"
+        )
+        if record
     )
     if index_entries != tree_entries:
         raise ShimRefusal(

--- a/scripts/check_thesis_facts_append.py
+++ b/scripts/check_thesis_facts_append.py
@@ -91,7 +91,7 @@ OBJECT_ID = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})")
 
 # Every environment variable beginning with GIT_ that git(1) documents in its
 # ENVIRONMENT VARIABLES section, read from the Git 2.53.0 manual page on the
-# machine this was written on (`git help --man git`). There are 72 of them.
+# machine this was written on (`git help --man git`). There are 73 of them.
 #
 # The shim does not drop these names one by one: it drops every variable whose
 # name begins with GIT_, which is necessarily a superset of any list. The tuple
@@ -124,6 +124,7 @@ DOCUMENTED_GIT_VARIABLES = (
     "GIT_DIR",
     "GIT_DISCOVERY_ACROSS_FILESYSTEM",
     "GIT_EDITOR",
+    "GIT_EXEC_PATH",
     "GIT_EXTERNAL_DIFF",
     "GIT_EXTERNAL_DIFF_TRUST_EXIT_CODE",
     "GIT_FLUSH",
@@ -189,6 +190,19 @@ GATE_CONFIG_KEYS = ("safe.directory", "core.hookspath")
 # at 120000, a gitlink at 160000, a subtree at 040000 -- means the path is not
 # a file whose bytes this commit fixes, so no comparison below is about it.
 PROTECTED_TREE_MODES = ("100644", "100755")
+
+# The five settings receipt spells on every one of its own working-tree reads,
+# spelled on the shim's two scans for the same reason: a read that gains a
+# cache in a later git is a read this program would otherwise silently begin
+# to trust (peer review, round 1). ``core.fsmonitor`` is also refused by the
+# configuration audit.
+SCAN_SETTINGS = (
+    "-c", "core.untrackedCache=false",
+    "-c", "core.fsmonitor=false",
+    "-c", "core.trustctime=true",
+    "-c", "core.checkStat=default",
+    "-c", "feature.manyFiles=false",
+)
 
 # The two ways a run can end without a verdict of "OK", kept apart on purpose.
 # "failed" is the gate's verdict about a tree it was given; "refused" is this
@@ -332,10 +346,12 @@ def _gate_environment(
 def _frozen_environment(environment: dict[str, str]) -> Iterator[None]:
     """Make ``environment`` the process environment for the enclosed block.
 
-    The gate runs git without passing an environment, so it inherits this
-    process's. Replacing ``os.environ`` for the duration is what puts the
-    gate's own git calls under the same frozen environment as the shim's, and
-    the original is restored however the block ends.
+    The pinned receipt passes an environment to every git child it starts,
+    and builds that environment out of ``os.environ`` (see
+    ``_gate_environment``). Replacing ``os.environ`` for the duration is
+    therefore what puts the gate's own git calls under the same frozen
+    environment as the shim's, and the original is restored however the
+    block ends.
     """
 
     saved = dict(os.environ)
@@ -390,7 +406,12 @@ def _refused_config_key(key: str) -> str | None:
     * any ``filter.*`` driver names programs git runs on a file's contents on
       the way in and on the way out;
     * any ``include`` or ``includeIf`` pulls in a file whose contents this
-      audit has not read, and could set any of the above.
+      audit has not read, and could set any of the above;
+    * ``core.sparseCheckout`` (and ``core.sparseCheckoutCone``) makes a
+      checkout materialise only the paths a patterns file in the shared git
+      directory selects, marking the rest skip-worktree so ``git status``
+      stays clean over a working tree that is a strict subset of the commit
+      (peer review of this pull request, round 1).
 
     Git compares a key's section and variable case-insensitively and its
     subsection case-sensitively, which is what the folding here reproduces.
@@ -407,6 +428,8 @@ def _refused_config_key(key: str) -> str | None:
         return "moves the hook directory"
     if section == "core" and variable == "fsmonitor":
         return "names a filesystem monitor program"
+    if section == "core" and variable in {"sparsecheckout", "sparsecheckoutcone"}:
+        return "makes a checkout materialise a subset of the commit"
     return None
 
 
@@ -582,7 +605,10 @@ def _protected_entries(
 
     The two state files the chain specification names, plus everything under
     the release root, which is where the manifests, the producer signatures,
-    the RFC 3161 receipts and the trust anchors live. A commit that carries no
+    the RFC 3161 receipts and the trust anchors live, plus everything else
+    under the state files' directory, so the byte comparison covers the whole
+    of the gate's data surface (``ledger/**`` and ``releases/manifests/**``)
+    and not only the paths the gate reads (peer review, round 1). A commit that carries no
     entry at one of the two state paths is refused here: the gate would refuse
     it too, but this says which of the two is missing and says it before any
     file is read.
@@ -599,10 +625,11 @@ def _protected_entries(
             if entry[3] not in seen:
                 seen.add(entry[3])
                 entries.append(entry)
-    for entry in _tree_entries(checkout, oid, f"{chain.release_root_relative}/", env):
-        if entry[3] not in seen:
-            seen.add(entry[3])
-            entries.append(entry)
+    for prefix in (chain.release_root_relative, chain.state_relative.parent):
+        for entry in _tree_entries(checkout, oid, f"{prefix}/", env):
+            if entry[3] not in seen:
+                seen.add(entry[3])
+                entries.append(entry)
     return entries
 
 
@@ -681,6 +708,7 @@ def _assert_exact_checkout(
 
     status = _git(
         [
+            *SCAN_SETTINGS,
             "-c",
             "status.showUntrackedFiles=all",
             "status",
@@ -696,7 +724,7 @@ def _assert_exact_checkout(
         raise ShimRefusal(f"the isolated checkout of {oid} is not clean: {first}")
 
     ignored = _git(
-        ["ls-files", "--others", "--ignored", "--exclude-standard"],
+        [*SCAN_SETTINGS, "ls-files", "--others", "--ignored", "--exclude-standard"],
         cwd=checkout,
         env=env,
     ).decode("utf-8", "replace")
@@ -704,6 +732,41 @@ def _assert_exact_checkout(
         first = ignored.strip().splitlines()[0]
         raise ShimRefusal(
             f"the isolated checkout of {oid} carries an ignored file: {first}"
+        )
+    # The checkout must be the whole commit, not a selection of it: a sparse
+    # checkout leaves the omitted entries in the index marked skip-worktree,
+    # which a clean ``status`` does not reveal (peer review, round 1). Every
+    # index entry must be an ordinary tracked file, and there must be exactly
+    # as many of them as the commit has entries.
+    tagged = _git(
+        [*SCAN_SETTINGS, "ls-files", "-v", "-z"],
+        cwd=checkout,
+        env=env,
+    )
+    index_entries = 0
+    for record in tagged.split(b"\0"):
+        if not record:
+            continue
+        index_entries += 1
+        tag = record[:1]
+        if tag != b"H":
+            path = os.fsdecode(record[2:])
+            reason = {
+                b"S": "skip-worktree",
+                b"h": "assume-unchanged",
+                b"M": "unmerged",
+            }.get(tag, f"tagged {tag.decode('ascii', 'replace')!r}")
+            raise ShimRefusal(
+                f"the isolated checkout of {oid} has an index entry that is "
+                f"not an ordinary tracked file ({reason}): {path}"
+            )
+    tree_entries = sum(
+        1 for record in _git(["ls-tree", "-r", "-z", oid], cwd=checkout, env=env).split(b"\0") if record
+    )
+    if index_entries != tree_entries:
+        raise ShimRefusal(
+            f"the isolated checkout of {oid} indexes {index_entries} entries "
+            f"where the commit has {tree_entries}"
         )
 
     entries = _protected_entries(checkout, oid, env)

--- a/scripts/check_thesis_facts_append.py
+++ b/scripts/check_thesis_facts_append.py
@@ -15,19 +15,16 @@ import receipt.append_gate as _receipt
 from receipt.release_chain import MANIFEST_RE, ReleaseChainError
 
 try:
-    from receipt_pins import APPEND_GATE_SPEC, LEDGER_SPEC
+    from receipt_pins import APPEND_GATE_SPEC
 except ModuleNotFoundError as exc:
     if exc.name != "receipt_pins":
         raise
     # The test suite copies the legacy three-script surface into temporary
     # repositories. The editable consumer tree remains the sole pin owner.
-    from scripts.receipt_pins import APPEND_GATE_SPEC, LEDGER_SPEC
+    from scripts.receipt_pins import APPEND_GATE_SPEC
 
 
 CODE_ROOT = pathlib.Path(__file__).resolve().parents[1]
-ROOT = CODE_ROOT
-LEDGER_PATH = ROOT / LEDGER_SPEC.state_relative
-PREFIX_PATH = ROOT / LEDGER_SPEC.prefix_relative
 RELEASE_MANIFEST_PREFIX = APPEND_GATE_SPEC.release_manifest_prefix
 GENESIS_SUPPORT_FILES = APPEND_GATE_SPEC.genesis_support_files
 GATE_SURFACE = APPEND_GATE_SPEC.gate_surface
@@ -37,23 +34,6 @@ ASSERTION_CONTENT_KEYS = APPEND_GATE_SPEC.assertion_content_keys
 AppendError = _receipt.AppendError
 AppendGateSpec = _receipt.AppendGateSpec
 reject_non_append_bytes = _receipt.reject_non_append_bytes
-
-
-def _set_root(root: pathlib.Path) -> None:
-    """Select candidate paths while leaving the trusted code root unchanged."""
-
-    global ROOT, LEDGER_PATH, PREFIX_PATH
-    ROOT = root.resolve()
-    LEDGER_PATH = ROOT / LEDGER_SPEC.state_relative
-    PREFIX_PATH = ROOT / LEDGER_SPEC.prefix_relative
-
-
-def _candidate() -> Any:
-    return _receipt._set_root(ROOT, APPEND_GATE_SPEC)
-
-
-def check_surface_separation(base_ref: str) -> tuple[set[str], set[str]]:
-    return _receipt.check_surface_separation(base_ref, _candidate())
 
 
 def expected_assertion_version_id(row: dict[str, Any]) -> str:
@@ -66,56 +46,12 @@ def effective_current_rows(
     return _receipt.effective_current_rows(rows, APPEND_GATE_SPEC)
 
 
-def check_prefix(lines: list[str]) -> dict[str, Any]:
-    return _receipt.check_prefix(lines, _candidate())
-
-
 def check_rows(lines: list[str], prefix_count: int) -> None:
     return _receipt.check_rows(lines, prefix_count, APPEND_GATE_SPEC)
 
 
-def check_append_only(base_ref: str, lines: list[str]) -> int:
-    return _receipt.check_append_only(base_ref, lines, _candidate())
-
-
-def check_prefix_anchored_to_base(
-    base_ref: str, candidate_prefix: dict[str, Any]
-) -> int:
-    return _receipt.check_prefix_anchored_to_base(
-        base_ref,
-        candidate_prefix,
-        _candidate(),
-    )
-
-
-def check_release_proposal(
-    base_ref: str,
-    *,
-    anchor_dir: pathlib.Path | None = None,
-    enforce_production_pins: bool | None = None,
-) -> int | None:
-    return _receipt.check_release_proposal(
-        base_ref,
-        candidate=_candidate(),
-        anchor_dir=anchor_dir,
-        enforce_production_pins=enforce_production_pins,
-    )
-
-
-def check_release_chain_without_base(
-    *,
-    anchor_dir: pathlib.Path | None = None,
-    enforce_production_pins: bool | None = None,
-) -> int | None:
-    return _receipt.check_release_chain_without_base(
-        candidate=_candidate(),
-        anchor_dir=anchor_dir,
-        enforce_production_pins=enforce_production_pins,
-    )
-
-
 def verify_append_gate(
-    root: pathlib.Path = ROOT,
+    root: pathlib.Path,
     *,
     base_ref: str | None = None,
     trusted_code_root: pathlib.Path = CODE_ROOT,
@@ -171,19 +107,10 @@ __all__ = [
     "DATA_SURFACE",
     "GATE_SURFACE",
     "GENESIS_SUPPORT_FILES",
-    "LEDGER_PATH",
     "MANIFEST_RE",
-    "PREFIX_PATH",
     "RELEASE_MANIFEST_PREFIX",
-    "ROOT",
     "ReleaseChainError",
-    "check_append_only",
-    "check_prefix",
-    "check_prefix_anchored_to_base",
-    "check_release_chain_without_base",
-    "check_release_proposal",
     "check_rows",
-    "check_surface_separation",
     "effective_current_rows",
     "expected_assertion_version_id",
     "main",

--- a/scripts/check_thesis_facts_append.py
+++ b/scripts/check_thesis_facts_append.py
@@ -91,7 +91,8 @@ OBJECT_ID = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})")
 
 # Every environment variable beginning with GIT_ that git(1) documents in its
 # ENVIRONMENT VARIABLES section, read from the Git 2.53.0 manual page on the
-# machine this was written on (`git help --man git`). There are 73 of them.
+# machine this was written on (`git help --man git`), plus GIT_REFERENCE_BACKEND,
+# which the git on ubuntu-latest documents and this machine's does not. There are 74 of them.
 #
 # The shim does not drop these names one by one: it drops every variable whose
 # name begins with GIT_, which is necessarily a superset of any list. The tuple
@@ -148,6 +149,7 @@ DOCUMENTED_GIT_VARIABLES = (
     "GIT_REDIRECT_STDERR",
     "GIT_REDIRECT_STDIN",
     "GIT_REDIRECT_STDOUT",
+    "GIT_REFERENCE_BACKEND",
     "GIT_REFLOG_ACTION",
     "GIT_REF_PARANOIA",
     "GIT_SEQUENCE_EDITOR",

--- a/scripts/check_thesis_facts_append.py
+++ b/scripts/check_thesis_facts_append.py
@@ -1,27 +1,75 @@
 #!/usr/bin/env python3
-# Thin shim over receipt==0.5.1 (hash-pinned in uv.lock). Any receipt upgrade
+# Thin shim over the receipt pin recorded in uv.lock. Any receipt upgrade
 # requires a fresh byte-equivalence proof at this repo's then-current pin BEFORE
 # the bump.
-"""Gate every change to the thesis-facts observation ledger."""
+"""Gate every change to the thesis-facts observation ledger.
+
+The gate this shim calls states its verdict about one thing: a clean checkout
+of one named commit, read once, with no concurrent writer. Findings whose
+precondition is a writer to the working tree or the index during the run, or an
+index, a working tree and a commit that disagree with one another, are waived
+against that stated contract. A waiver like that is only honest if the program
+that calls the gate actually establishes the precondition, and establishing it
+is what this shim does.
+
+Every run names the commit to judge as an argument. The shim checks that commit
+out into a private directory of its own under a git environment the candidate
+cannot redirect, asserts that the directory really is that commit and nothing
+else, runs the gate over that directory, and removes the directory and its
+registration afterwards whatever happened in between.
+
+What that excludes:
+
+* an index, a working tree and a commit that diverge from one another, because
+  the checkout is made from the commit and is then required to be clean, with
+  no untracked and no ignored file, and with every protected path's bytes equal
+  to the bytes of the blob the commit names;
+* a checkout the candidate prepared, because the shim makes its own rather than
+  reading the one the job happens to be sitting in;
+* a ref the candidate can move, because the commit is given as a full object
+  id and a symbolic name is refused before any git command runs;
+* a git environment the candidate can redirect, because every ``GIT_*``
+  variable is dropped from the environment the git calls inherit, the system
+  configuration is switched off, the global configuration is a file this shim
+  writes, and the repository's own configuration is read and refused if it
+  names a hook path, a filesystem monitor, a content filter or an include.
+
+What it does not exclude: the window between the assertions and the gate's own
+reads. A process that can write into the private checkout during that window
+runs as the job's own user, which is the trust level of the job's own code, and
+this shim claims nothing about it.
+
+A package user who calls ``verify_append_gate`` against some other directory is
+outside the contract the gate states, and outside everything the shim
+establishes here.
+"""
 
 from __future__ import annotations
 
 import argparse
+import contextlib
+import os
 import pathlib
+import re
+import shutil
+import stat
+import subprocess
 import sys
+import tempfile
+from collections.abc import Iterator
 from typing import Any
 
 import receipt.append_gate as _receipt
 from receipt.release_chain import MANIFEST_RE, ReleaseChainError
 
 try:
-    from receipt_pins import APPEND_GATE_SPEC
+    from receipt_pins import APPEND_GATE_SPEC, LEDGER_SPEC
 except ModuleNotFoundError as exc:
     if exc.name != "receipt_pins":
         raise
     # The test suite copies the legacy three-script surface into temporary
     # repositories. The editable consumer tree remains the sole pin owner.
-    from scripts.receipt_pins import APPEND_GATE_SPEC
+    from scripts.receipt_pins import APPEND_GATE_SPEC, LEDGER_SPEC
 
 
 CODE_ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -34,6 +82,707 @@ ASSERTION_CONTENT_KEYS = APPEND_GATE_SPEC.assertion_content_keys
 AppendError = _receipt.AppendError
 AppendGateSpec = _receipt.AppendGateSpec
 reject_non_append_bytes = _receipt.reject_non_append_bytes
+
+# A full object id in either of git's two hash algorithms, spelled the way git
+# spells one back. Anything shorter is an abbreviation, which resolves through
+# the object database and can therefore mean a different object in a different
+# clone; anything else is a name, which the candidate can move.
+OBJECT_ID = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})")
+
+# Every environment variable beginning with GIT_ that git(1) documents in its
+# ENVIRONMENT VARIABLES section, read from the Git 2.53.0 manual page on the
+# machine this was written on (`git help --man git`). There are 72 of them.
+#
+# The shim does not drop these names one by one: it drops every variable whose
+# name begins with GIT_, which is necessarily a superset of any list. The tuple
+# is here so a test can hold the drop to the documentation -- if a future git
+# documents a name the prefix rule would miss, that test fails rather than the
+# gate quietly inheriting it.
+DOCUMENTED_GIT_VARIABLES = (
+    "GIT_ADVICE",
+    "GIT_ALLOW_PROTOCOL",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_ASKPASS",
+    "GIT_ATTR_SOURCE",
+    "GIT_AUTHOR_DATE",
+    "GIT_AUTHOR_EMAIL",
+    "GIT_AUTHOR_NAME",
+    "GIT_CEILING_DIRECTORIES",
+    "GIT_COMMITTER_DATE",
+    "GIT_COMMITTER_EMAIL",
+    "GIT_COMMITTER_NAME",
+    "GIT_COMMIT_GRAPH_PARANOIA",
+    "GIT_COMMON_DIR",
+    "GIT_CONFIG_GLOBAL",
+    "GIT_CONFIG_NOSYSTEM",
+    "GIT_CONFIG_SYSTEM",
+    "GIT_DEFAULT_HASH",
+    "GIT_DEFAULT_REF_FORMAT",
+    "GIT_DIFF_OPTS",
+    "GIT_DIFF_PATH_COUNTER",
+    "GIT_DIFF_PATH_TOTAL",
+    "GIT_DIR",
+    "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+    "GIT_EDITOR",
+    "GIT_EXTERNAL_DIFF",
+    "GIT_EXTERNAL_DIFF_TRUST_EXIT_CODE",
+    "GIT_FLUSH",
+    "GIT_GLOB_PATHSPECS",
+    "GIT_ICASE_PATHSPECS",
+    "GIT_INDEX_FILE",
+    "GIT_INDEX_VERSION",
+    "GIT_LITERAL_PATHSPECS",
+    "GIT_MERGE_VERBOSITY",
+    "GIT_NAMESPACE",
+    "GIT_NOGLOB_PATHSPECS",
+    "GIT_NO_LAZY_FETCH",
+    "GIT_NO_REPLACE_OBJECTS",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_OPTIONAL_LOCKS",
+    "GIT_PAGER",
+    "GIT_PRINT_SHA1_ELLIPSIS",
+    "GIT_PROGRESS_DELAY",
+    "GIT_PROTOCOL",
+    "GIT_PROTOCOL_FROM_USER",
+    "GIT_REDIRECT_STDERR",
+    "GIT_REDIRECT_STDIN",
+    "GIT_REDIRECT_STDOUT",
+    "GIT_REFLOG_ACTION",
+    "GIT_REF_PARANOIA",
+    "GIT_SEQUENCE_EDITOR",
+    "GIT_SSH",
+    "GIT_SSH_COMMAND",
+    "GIT_SSH_VARIANT",
+    "GIT_SSL_NO_VERIFY",
+    "GIT_TERMINAL_PROMPT",
+    "GIT_TRACE",
+    "GIT_TRACE2",
+    "GIT_TRACE2_EVENT",
+    "GIT_TRACE2_PERF",
+    "GIT_TRACE_CURL",
+    "GIT_TRACE_CURL_NO_DATA",
+    "GIT_TRACE_FSMONITOR",
+    "GIT_TRACE_PACKET",
+    "GIT_TRACE_PACKFILE",
+    "GIT_TRACE_PACK_ACCESS",
+    "GIT_TRACE_PERFORMANCE",
+    "GIT_TRACE_REDACT",
+    "GIT_TRACE_REFS",
+    "GIT_TRACE_SETUP",
+    "GIT_TRACE_SHALLOW",
+    "GIT_WORK_TREE",
+)
+
+# The three variables the shim sets, and the only ones beginning with GIT_ that
+# any git call in a run is allowed to see.
+GATE_GIT_VARIABLES = (
+    "GIT_NO_REPLACE_OBJECTS",
+    "GIT_CONFIG_NOSYSTEM",
+    "GIT_CONFIG_GLOBAL",
+)
+
+# The configuration keys the shim writes into its own global file, and the
+# whole of what the global scope is allowed to resolve to.
+GATE_CONFIG_KEYS = ("safe.directory", "core.hookspath")
+
+# Tree modes a protected path is allowed to have. Every other mode -- a symlink
+# at 120000, a gitlink at 160000, a subtree at 040000 -- means the path is not
+# a file whose bytes this commit fixes, so no comparison below is about it.
+PROTECTED_TREE_MODES = ("100644", "100755")
+
+
+class ShimRefusal(RuntimeError):
+    """The shim will not hand the gate a tree it cannot vouch for.
+
+    Distinct from ``AppendError``, which is the gate's verdict about a tree it
+    was handed. A ``ShimRefusal`` says that no verdict was reached, because the
+    precondition the verdict would be stated against could not be established.
+    """
+
+
+def _git(
+    arguments: list[str],
+    *,
+    cwd: pathlib.Path,
+    env: dict[str, str],
+) -> bytes:
+    """Run one git command under the frozen environment and return its stdout.
+
+    A non-zero exit is a refusal rather than an exception to interpret: every
+    git call the shim makes is part of establishing the precondition, so a call
+    that did not answer means the precondition was not established.
+    """
+
+    completed = subprocess.run(
+        ["git", *arguments],
+        cwd=cwd,
+        env=env,
+        check=False,
+        capture_output=True,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.decode("utf-8", "replace").strip()
+        raise ShimRefusal(
+            f"git {' '.join(arguments)} in {cwd} exited "
+            f"{completed.returncode}: {detail}"
+        )
+    return completed.stdout
+
+
+def _scratch_root() -> pathlib.Path:
+    """Create the private directory that holds everything one run writes.
+
+    ``mkdtemp`` creates the directory with mode 0700 and does so atomically, so
+    no other user has a moment in which the directory is readable. The mode is
+    asserted rather than assumed, because everything the shim writes -- the
+    global git configuration whose contents decide whether hooks run, the empty
+    hook directory itself, and the checkout the gate reads -- lives under it.
+    """
+
+    root = pathlib.Path(tempfile.mkdtemp(prefix="thesis-facts-gate-"))
+    mode = stat.S_IMODE(os.stat(root).st_mode)
+    if mode != 0o700:
+        shutil.rmtree(root, ignore_errors=True)
+        raise ShimRefusal(
+            f"scratch directory {root} was created with mode {mode:04o}, not 0700"
+        )
+    return root
+
+
+def _gate_environment(
+    clone_root: pathlib.Path,
+    scratch_root: pathlib.Path,
+) -> dict[str, str]:
+    """Build the only environment any git in this run is allowed to see.
+
+    The returned mapping is the caller's environment with every variable whose
+    name begins with ``GIT_`` removed, and exactly three put back:
+
+    * ``GIT_NO_REPLACE_OBJECTS=1``, so a replace ref committed into the
+      repository cannot substitute one object for another underneath a read;
+    * ``GIT_CONFIG_NOSYSTEM=1``, so the machine's system configuration -- which
+      is not part of what this run is judging -- contributes nothing;
+    * ``GIT_CONFIG_GLOBAL``, naming a file this function writes under
+      ``scratch_root``. It holds ``safe.directory`` for the clone and
+      ``core.hooksPath`` pointing at an empty directory created here, so no
+      hook in the repository runs during the checkout. Both are written with
+      ``git config -f``, so git does its own quoting of the paths.
+
+    Dropping by prefix rather than by name is deliberate: it is a superset of
+    any documented list, and ``DOCUMENTED_GIT_VARIABLES`` exists only so a test
+    can check the documentation has not outgrown the rule.
+
+    The environment is used two ways, and both are needed. The shim's own git
+    calls receive it as ``env=``. The gate's git calls are made by
+    ``receipt.append_gate`` without an explicit environment, so they inherit
+    the process's, and ``main`` therefore replaces ``os.environ`` with this
+    mapping for exactly the duration of the gate call (see
+    ``_frozen_environment``). Running the gate in a child process with ``env=``
+    would work equally well for the environment, but would put a process
+    boundary between the gate's exception text and this program's stderr, and
+    that text is what the byte-equivalence proof compares.
+
+    ``safe.directory`` names the clone. If the clone were owned by another user
+    the linked worktree's own path would not be covered, and git would refuse
+    the checkout; that is a refusal, not a pass, so it fails closed.
+    """
+
+    hooks = scratch_root / "hooks"
+    hooks.mkdir(mode=0o700)
+    config = scratch_root / "gitconfig"
+    config.write_bytes(b"")
+
+    environment = {
+        name: value for name, value in os.environ.items() if not name.startswith("GIT_")
+    }
+    environment["GIT_NO_REPLACE_OBJECTS"] = "1"
+    environment["GIT_CONFIG_NOSYSTEM"] = "1"
+    environment["GIT_CONFIG_GLOBAL"] = str(config)
+
+    for key, value in (
+        ("safe.directory", str(clone_root)),
+        ("core.hooksPath", str(hooks)),
+    ):
+        _git(
+            ["config", "-f", str(config), key, value],
+            cwd=scratch_root,
+            env=environment,
+        )
+    return environment
+
+
+@contextlib.contextmanager
+def _frozen_environment(environment: dict[str, str]) -> Iterator[None]:
+    """Make ``environment`` the process environment for the enclosed block.
+
+    The gate runs git without passing an environment, so it inherits this
+    process's. Replacing ``os.environ`` for the duration is what puts the
+    gate's own git calls under the same frozen environment as the shim's, and
+    the original is restored however the block ends.
+    """
+
+    saved = dict(os.environ)
+    os.environ.clear()
+    os.environ.update(environment)
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(saved)
+
+
+def _config_records(payload: bytes, *, scoped: bool) -> list[tuple[str, str, str]]:
+    """Parse ``git config --list -z`` output into scope, key, value triples.
+
+    With ``-z`` git separates records with NUL and separates a record's key
+    from its value with a newline; with ``--show-scope`` it emits the scope as
+    its own NUL-terminated field before each record. A key declared with no
+    value carries no newline, and reads back with an empty value. Git lowercases
+    a key's section and variable name and leaves any subsection alone, so the
+    keys here are already in the spelling the comparisons below use.
+    """
+
+    fields = payload.split(b"\0")
+    if fields and fields[-1] == b"":
+        fields.pop()
+    stride = 2 if scoped else 1
+    if len(fields) % stride:
+        raise ShimRefusal(
+            "git config --list returned a partial record; the configuration "
+            "could not be audited"
+        )
+    records: list[tuple[str, str, str]] = []
+    for index in range(0, len(fields), stride):
+        scope = fields[index].decode("utf-8", "replace") if scoped else ""
+        entry = fields[index + stride - 1].decode("utf-8", "replace")
+        key, _, value = entry.partition("\n")
+        records.append((scope, key, value))
+    return records
+
+
+def _refused_config_key(key: str) -> str | None:
+    """Name the reason this configuration key may not stand, or return None.
+
+    Four kinds of key decide what a checkout does rather than what it holds,
+    and each of them is a way for a repository to run code or rewrite bytes
+    during a read the gate is about to make:
+
+    * ``core.hooksPath`` moves the hook directory, which would defeat the empty
+      one the shim points git at;
+    * ``core.fsmonitor`` names a program git runs to learn what changed;
+    * any ``filter.*`` driver names programs git runs on a file's contents on
+      the way in and on the way out;
+    * any ``include`` or ``includeIf`` pulls in a file whose contents this
+      audit has not read, and could set any of the above.
+
+    Git compares a key's section and variable case-insensitively and its
+    subsection case-sensitively, which is what the folding here reproduces.
+    """
+
+    section, _, remainder = key.partition(".")
+    section = section.lower()
+    variable = remainder.rpartition(".")[2].lower()
+    if section == "filter":
+        return "names a content filter driver"
+    if section.startswith("include"):
+        return "pulls in configuration this audit has not read"
+    if section == "core" and variable == "hookspath":
+        return "moves the hook directory"
+    if section == "core" and variable == "fsmonitor":
+        return "names a filesystem monitor program"
+    return None
+
+
+def _audit_repository_config(
+    clone_root: pathlib.Path,
+    env: dict[str, str],
+) -> None:
+    """Refuse a clone whose configuration would change what a checkout does.
+
+    Reads the configuration git will actually use, with ``--no-includes`` so an
+    include is visible as the key it is rather than as its effects, and with
+    ``--show-scope`` so each entry is attributable. Entries in the repository's
+    own scopes -- ``local`` and ``worktree``, both of which the candidate
+    commits or the candidate's clone carries -- are refused when they name a
+    hook path, a filesystem monitor, a content filter or an include, because
+    each of those takes precedence over the global file the shim wrote.
+
+    The global scope must then resolve to exactly the file the shim wrote and
+    nothing else, and no ``system`` entry may appear at all -- one cannot,
+    under ``GIT_CONFIG_NOSYSTEM``, so an entry claiming that scope means the
+    environment did not reach git.
+    """
+
+    _git(["rev-parse", "--git-dir"], cwd=clone_root, env=env)
+
+    resolved = _config_records(
+        _git(
+            ["config", "--list", "--show-scope", "--no-includes", "-z"],
+            cwd=clone_root,
+            env=env,
+        ),
+        scoped=True,
+    )
+    for scope, key, _value in resolved:
+        if scope not in ("local", "worktree"):
+            continue
+        reason = _refused_config_key(key)
+        if reason is not None:
+            raise ShimRefusal(
+                f"the clone at {clone_root} sets {key} in its {scope} "
+                f"configuration, which {reason}"
+            )
+
+    system = sorted({key for scope, key, _ in resolved if scope == "system"})
+    if system:
+        raise ShimRefusal(
+            "git read system configuration despite GIT_CONFIG_NOSYSTEM, "
+            f"which means the frozen environment did not reach it: {system}"
+        )
+
+    config_file = pathlib.Path(env["GIT_CONFIG_GLOBAL"])
+    written = [
+        (key, value)
+        for _scope, key, value in _config_records(
+            _git(
+                ["config", "-f", str(config_file), "--list", "--no-includes", "-z"],
+                cwd=config_file.parent,
+                env=env,
+            ),
+            scoped=False,
+        )
+    ]
+    if sorted({key for key, _ in written}) != sorted(GATE_CONFIG_KEYS):
+        raise ShimRefusal(
+            f"the shim's global configuration at {config_file} holds "
+            f"{sorted({key for key, _ in written})}, not "
+            f"{sorted(GATE_CONFIG_KEYS)}"
+        )
+    hooks = pathlib.Path(
+        next(value for key, value in written if key == "core.hookspath")
+    )
+    if not hooks.is_dir() or any(hooks.iterdir()):
+        raise ShimRefusal(
+            f"the hook directory {hooks} the shim points git at is not an "
+            "existing empty directory"
+        )
+
+    globals_in_effect = [
+        (key, value) for scope, key, value in resolved if scope == "global"
+    ]
+    if globals_in_effect != written:
+        raise ShimRefusal(
+            "the global configuration git resolved is not the file the shim "
+            f"wrote: {globals_in_effect} against {written}"
+        )
+
+
+def _isolated_checkout(
+    clone_root: pathlib.Path,
+    scratch_root: pathlib.Path,
+    oid: str,
+    env: dict[str, str],
+) -> pathlib.Path:
+    """Check the named commit out into a directory this run owns.
+
+    The checkout is a linked worktree of the clone, detached at the object id.
+    It shares the clone's object database, so a base commit named with
+    ``--base-ref`` resolves inside it, and it is a directory nothing else in
+    the job has a name for.
+
+    The object id is re-checked here even though the argument parser already
+    refused anything else, because this function is the last place before a
+    name reaches git and a caller that bypassed the parser must not get a
+    symbolic name resolved on its behalf.
+    """
+
+    if not OBJECT_ID.fullmatch(oid):
+        raise ShimRefusal(
+            f"{oid!r} is not a full object id, so it will not be checked out"
+        )
+    checkout = scratch_root / "checkout"
+    completed = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(clone_root),
+            "worktree",
+            "add",
+            "--detach",
+            str(checkout),
+            oid,
+        ],
+        env=env,
+        check=False,
+        capture_output=True,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.decode("utf-8", "replace").strip()
+        raise ShimRefusal(
+            f"cannot check {oid} out in isolation from {clone_root}: {detail}"
+        )
+    return checkout
+
+
+def _tree_entries(
+    checkout: pathlib.Path,
+    oid: str,
+    pathspec: str,
+    env: dict[str, str],
+) -> list[tuple[str, str, str, str]]:
+    """List the commit's blob entries under one pathspec as mode, type, id, path.
+
+    ``-z`` is what makes this a parse rather than a guess: git quotes unusual
+    path names in its default output and emits them raw under ``-z``.
+    """
+
+    payload = _git(
+        ["ls-tree", "-r", "-z", oid, "--", pathspec],
+        cwd=checkout,
+        env=env,
+    )
+    entries: list[tuple[str, str, str, str]] = []
+    for record in payload.split(b"\0"):
+        if not record:
+            continue
+        metadata, _, raw_path = record.partition(b"\t")
+        mode, kind, blob = metadata.decode("utf-8", "replace").split(" ")
+        entries.append((mode, kind, blob, os.fsdecode(raw_path)))
+    return entries
+
+
+def _protected_entries(
+    checkout: pathlib.Path,
+    oid: str,
+    env: dict[str, str],
+) -> list[tuple[str, str, str, str]]:
+    """Every entry of the commit whose bytes the gate's verdict is about.
+
+    The two state files the chain specification names, plus everything under
+    the release root, which is where the manifests, the producer signatures,
+    the RFC 3161 receipts and the trust anchors live. A commit that carries no
+    entry at one of the two state paths is refused here: the gate would refuse
+    it too, but this says which of the two is missing and says it before any
+    file is read.
+    """
+
+    chain = LEDGER_SPEC
+    entries: list[tuple[str, str, str, str]] = []
+    seen: set[str] = set()
+    for relative in (chain.state_relative, chain.prefix_relative):
+        found = _tree_entries(checkout, oid, str(relative), env)
+        if not found:
+            raise ShimRefusal(f"commit {oid} carries no entry at {relative}")
+        for entry in found:
+            if entry[3] not in seen:
+                seen.add(entry[3])
+                entries.append(entry)
+    for entry in _tree_entries(checkout, oid, f"{chain.release_root_relative}/", env):
+        if entry[3] not in seen:
+            seen.add(entry[3])
+            entries.append(entry)
+    return entries
+
+
+def _hash_working_files(
+    checkout: pathlib.Path,
+    paths: list[str],
+    env: dict[str, str],
+) -> list[str]:
+    """Hash each path's bytes on disk, with no attribute conversion applied.
+
+    ``--no-filters`` is the whole point of this call. Without it git applies
+    whatever the commit's own ``.gitattributes`` asks for -- an end-of-line
+    conversion, a clean filter -- and the result is by construction the blob id
+    the commit names, whatever the file on disk actually holds. With it the
+    answer is a hash of the bytes the gate is about to read.
+    """
+
+    hashes: list[str] = []
+    for start in range(0, len(paths), 500):
+        chunk = paths[start : start + 500]
+        payload = _git(
+            ["hash-object", "--no-filters", "--", *chunk],
+            cwd=checkout,
+            env=env,
+        )
+        lines = payload.decode("utf-8", "replace").split("\n")
+        if lines and lines[-1] == "":
+            lines.pop()
+        if len(lines) != len(chunk):
+            raise ShimRefusal(
+                f"git hash-object answered for {len(lines)} of "
+                f"{len(chunk)} protected paths"
+            )
+        hashes.extend(lines)
+    return hashes
+
+
+def _assert_exact_checkout(
+    checkout: pathlib.Path,
+    oid: str,
+    env: dict[str, str],
+) -> tuple[str, str]:
+    """Require the checkout to be that commit and nothing besides.
+
+    Four things are asserted about the directory as a whole: its ``HEAD`` is
+    the named commit; ``git status`` reports nothing, with untracked files
+    forced on from the command line so a repository setting cannot hide one and
+    with submodules included; and ``git ls-files`` reports no ignored file, so
+    a ``.gitignore`` the commit carries cannot conceal one either.
+
+    Then four things are asserted about every protected path the commit names.
+    Its tree mode must be a regular file's, so a symlink, a gitlink or a
+    subtree standing where a file should be is refused rather than followed.
+    ``os.lstat`` must agree that the path on disk is a regular file, without
+    following anything. The bytes on disk must hash to the blob id the commit
+    names, computed with no attribute conversion. And the owner-execute bit on
+    disk must be the one the tree mode states.
+
+    The structural three are checked for every entry in tree order first and
+    the byte comparison for every entry after them, so the two passes each name
+    the first path that failed them.
+
+    Returns the commit and its tree, for the line ``main`` prints after the
+    verdict.
+    """
+
+    head = _git(["rev-parse", "HEAD"], cwd=checkout, env=env)
+    head = head.decode("utf-8", "replace").strip()
+    if head != oid:
+        raise ShimRefusal(
+            f"the isolated checkout is at {head}, not the named commit {oid}"
+        )
+
+    status = _git(
+        [
+            "-c",
+            "status.showUntrackedFiles=all",
+            "status",
+            "--porcelain",
+            "--untracked-files=all",
+            "--ignore-submodules=none",
+        ],
+        cwd=checkout,
+        env=env,
+    ).decode("utf-8", "replace")
+    if status.strip():
+        first = status.strip().splitlines()[0]
+        raise ShimRefusal(f"the isolated checkout of {oid} is not clean: {first}")
+
+    ignored = _git(
+        ["ls-files", "--others", "--ignored", "--exclude-standard"],
+        cwd=checkout,
+        env=env,
+    ).decode("utf-8", "replace")
+    if ignored.strip():
+        first = ignored.strip().splitlines()[0]
+        raise ShimRefusal(
+            f"the isolated checkout of {oid} carries an ignored file: {first}"
+        )
+
+    entries = _protected_entries(checkout, oid, env)
+    for mode, _kind, _blob, relative in entries:
+        if mode not in PROTECTED_TREE_MODES:
+            raise ShimRefusal(
+                f"commit {oid} carries the protected path {relative} with "
+                f"tree mode {mode}; a protected path must be a regular file "
+                f"({' or '.join(PROTECTED_TREE_MODES)})"
+            )
+        target = checkout / relative
+        try:
+            info = os.lstat(target)
+        except OSError as exc:
+            raise ShimRefusal(
+                f"the protected path {relative} cannot be inspected in the "
+                f"isolated checkout of {oid}: {exc.strerror}"
+            ) from exc
+        if not stat.S_ISREG(info.st_mode):
+            raise ShimRefusal(
+                f"the protected path {relative} is not a regular file in the "
+                f"isolated checkout of {oid}"
+            )
+        executable = bool(info.st_mode & stat.S_IXUSR)
+        if executable != (mode == "100755"):
+            raise ShimRefusal(
+                f"the protected path {relative} is "
+                f"{'executable' if executable else 'not executable'} in the "
+                f"isolated checkout of {oid}, against tree mode {mode}"
+            )
+
+    hashes = _hash_working_files(checkout, [entry[3] for entry in entries], env)
+    for (_mode, _kind, blob, relative), found in zip(entries, hashes, strict=True):
+        if found != blob:
+            raise ShimRefusal(
+                f"the protected path {relative} holds bytes hashing to "
+                f"{found} in the isolated checkout of {oid}, against the "
+                f"{blob} the commit names"
+            )
+
+    tree = _git(["rev-parse", "HEAD^{tree}"], cwd=checkout, env=env)
+    return head, tree.decode("utf-8", "replace").strip()
+
+
+def _worktree_removed(
+    clone_root: pathlib.Path,
+    checkout: pathlib.Path,
+    env: dict[str, str],
+) -> bool:
+    """Try once to deregister this checkout, and report whether git did."""
+
+    completed = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(clone_root),
+            "worktree",
+            "remove",
+            "--force",
+            str(checkout),
+        ],
+        env=env,
+        check=False,
+        capture_output=True,
+    )
+    return completed.returncode == 0
+
+
+def _remove_checkout(
+    clone_root: pathlib.Path,
+    scratch_root: pathlib.Path,
+    checkout: pathlib.Path | None,
+    env: dict[str, str] | None,
+) -> None:
+    """Remove this run's checkout and everything else it wrote.
+
+    Named by path, so it removes this checkout and no other. ``git worktree
+    prune`` is never used and must never be: it deregisters every prunable
+    worktree of the repository, including registrations that belong to
+    somebody else's work in the same clone.
+
+    An add that failed part-way leaves no registration -- git validates the
+    commit before it writes one -- so the ordinary case after a failure is that
+    there is nothing to deregister and only the directory to delete. The order
+    here handles both: deregister, delete the directory tree, and if the first
+    attempt failed try once more, because git accepts the path of a
+    registration whose directory has already gone. Only if that also fails does
+    anything get printed, and then it names the directory and the command that
+    clears it.
+    """
+
+    removed = True
+    if checkout is not None and env is not None:
+        removed = _worktree_removed(clone_root, checkout, env)
+    shutil.rmtree(scratch_root, ignore_errors=True)
+    if not removed and checkout is not None and env is not None:
+        removed = _worktree_removed(clone_root, checkout, env)
+    if not removed:
+        print(
+            "thesis-facts append check warning: the isolated checkout "
+            f"registration at {checkout} could not be removed; clear it with "
+            f"git -C {clone_root} worktree remove --force {checkout}",
+            file=sys.stderr,
+        )
 
 
 def expected_assertion_version_id(row: dict[str, Any]) -> str:
@@ -66,13 +815,34 @@ def verify_append_gate(
     )
 
 
+def _object_id_argument(value: str) -> str:
+    if not OBJECT_ID.fullmatch(value):
+        raise argparse.ArgumentTypeError(
+            f"{value!r} is not an object id: a full object id is required "
+            "(40 or 64 lowercase hexadecimal characters). A symbolic ref such "
+            "as a branch name, a tag or HEAD is not accepted, because the "
+            "candidate can move one; an abbreviated id is not accepted, "
+            "because it can name a different object in a different clone"
+        )
+    return value
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--root",
         type=pathlib.Path,
         default=CODE_ROOT,
-        help="candidate worktree root (defaults to the checker's repository)",
+        help=(
+            "clone in which --commit is resolved and checked out "
+            "(defaults to the checker's repository)"
+        ),
+    )
+    parser.add_argument(
+        "--commit",
+        required=True,
+        type=_object_id_argument,
+        help="full object id of the commit to judge",
     )
     parser.add_argument(
         "--base-ref",
@@ -84,17 +854,44 @@ def main() -> int:
         help=argparse.SUPPRESS,
     )
     args = parser.parse_args()
+    clone_root = args.root.resolve()
+
+    scratch_root: pathlib.Path | None = None
+    environment: dict[str, str] | None = None
+    checkout: pathlib.Path | None = None
     try:
-        summary = verify_append_gate(
-            args.root.resolve(),
-            base_ref=args.base_ref,
-            trusted_code_root=CODE_ROOT.resolve(),
-            release_anchor_dir=args.release_anchor_dir,
-        )
+        scratch_root = _scratch_root()
+        try:
+            environment = _gate_environment(clone_root, scratch_root)
+            _audit_repository_config(clone_root, environment)
+            checkout = _isolated_checkout(
+                clone_root,
+                scratch_root,
+                args.commit,
+                environment,
+            )
+            commit, tree = _assert_exact_checkout(
+                checkout,
+                args.commit,
+                environment,
+            )
+            with _frozen_environment(environment):
+                summary = verify_append_gate(
+                    checkout,
+                    base_ref=args.base_ref,
+                    trusted_code_root=CODE_ROOT.resolve(),
+                    release_anchor_dir=args.release_anchor_dir,
+                )
+        finally:
+            _remove_checkout(clone_root, scratch_root, checkout, environment)
+    except ShimRefusal as exc:
+        print(f"thesis-facts append check refused: {exc}", file=sys.stderr)
+        return 1
     except AppendError as exc:
         print(f"thesis-facts append check failed: {exc}", file=sys.stderr)
         return 1
     print(summary)
+    print(f"candidate commit {commit} tree {tree}")
     return 0
 
 
@@ -105,11 +902,17 @@ __all__ = [
     "AppendGateSpec",
     "CODE_ROOT",
     "DATA_SURFACE",
+    "DOCUMENTED_GIT_VARIABLES",
+    "GATE_CONFIG_KEYS",
+    "GATE_GIT_VARIABLES",
     "GATE_SURFACE",
     "GENESIS_SUPPORT_FILES",
     "MANIFEST_RE",
+    "OBJECT_ID",
+    "PROTECTED_TREE_MODES",
     "RELEASE_MANIFEST_PREFIX",
     "ReleaseChainError",
+    "ShimRefusal",
     "check_rows",
     "effective_current_rows",
     "expected_assertion_version_id",

--- a/scripts/verify_release_chain.py
+++ b/scripts/verify_release_chain.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Thin shim over receipt==0.5.1 (hash-pinned in uv.lock). Any receipt upgrade
+# Thin shim over the receipt pin recorded in uv.lock. Any receipt upgrade
 # requires a fresh byte-equivalence proof at this repo's then-current pin BEFORE
 # the bump.
 """Offline verification for the witnessed thesis-ledger release chain."""

--- a/tests/test_policyengine_ledger.py
+++ b/tests/test_policyengine_ledger.py
@@ -9,6 +9,7 @@ duplicate identities only exist as explicit supersede corrections.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import subprocess
 import sys
@@ -32,11 +33,14 @@ PREFIX_PATH = ROOT / "ledger" / "immutable_prefix.json"
 sys.path.insert(0, str(ROOT / "scripts"))
 
 from check_thesis_facts_append import (  # noqa: E402
-    check_prefix,
     check_rows,
     effective_current_rows,
     expected_assertion_version_id,
 )
+
+
+def _prefix_manifest() -> dict:
+    return json.loads(PREFIX_PATH.read_text(encoding="utf-8"))
 
 
 def _read_lines() -> list[str]:
@@ -87,21 +91,30 @@ def _to_aggregate_fact(row: dict) -> AggregateFact:
 
 
 def test_immutable_prefix_is_intact():
+    # The manifest records a digest per frozen line and one over the frozen
+    # region as a whole. Both are recomputed here from the ledger as it stands,
+    # so a rewritten frozen line fails whichever of the two it moved.
+    manifest = _prefix_manifest()
+    count = int(manifest["prefixLineCount"])
     lines = _read_lines()
 
-    prefix = check_prefix(lines)
-
-    assert prefix["prefixLineCount"] >= 128
-    assert len(lines) >= prefix["prefixLineCount"]
+    assert count >= 128
+    assert len(lines) >= count
+    assert [
+        hashlib.sha256(line.encode("utf-8")).hexdigest() for line in lines[:count]
+    ] == manifest["lineSha256s"]
+    assert (
+        hashlib.sha256(("\n".join(lines[:count]) + "\n").encode("utf-8")).hexdigest()
+        == manifest["prefixSha256"]
+    )
 
 
 def test_every_row_satisfies_the_append_invariants():
     lines = _read_lines()
-    prefix = check_prefix(lines)
 
     # Raises on any malformed row, unexplained duplicate identity,
     # mis-addressed assertion version, or missing post-prefix binding.
-    check_rows(lines, int(prefix["prefixLineCount"]))
+    check_rows(lines, int(_prefix_manifest()["prefixLineCount"]))
 
 
 def test_official_observation_ledger_contains_facts_not_predictions():
@@ -133,6 +146,16 @@ def test_rows_carry_no_unknown_top_level_fields():
         assert not unknown, f"line {number} has unknown fields: {sorted(unknown)}"
 
 
+def _git(repo: Path, *arguments: str) -> str:
+    return subprocess.run(
+        ["git", *arguments],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
 def test_a_rewritten_prefix_line_is_detected(tmp_path):
     lines = _read_lines()
     row = json.loads(lines[0])
@@ -140,9 +163,7 @@ def test_a_rewritten_prefix_line_is_detected(tmp_path):
     tampered = [json.dumps(row, separators=(",", ":")), *lines[1:]]
     ledger_dir = tmp_path / "ledger"
     ledger_dir.mkdir()
-    (ledger_dir / "official_observations.jsonl").write_text(
-        "\n".join(tampered) + "\n"
-    )
+    (ledger_dir / "official_observations.jsonl").write_text("\n".join(tampered) + "\n")
     (ledger_dir / "immutable_prefix.json").write_text(PREFIX_PATH.read_text())
     scripts_dir = tmp_path / "scripts"
     scripts_dir.mkdir()
@@ -153,13 +174,27 @@ def test_a_rewritten_prefix_line_is_detected(tmp_path):
     ):
         (scripts_dir / name).write_text((ROOT / "scripts" / name).read_text())
 
+    # The checker judges a commit it checks out itself, so the tampering has to
+    # be committed before it can be asked about.
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "config", "user.name", "Ledger Invariants Test")
+    _git(tmp_path, "config", "user.email", "ledger-invariants@example.invalid")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-qm", "tampered prefix")
+
     completed = subprocess.run(
-        [sys.executable, str(scripts_dir / "check_thesis_facts_append.py")],
+        [
+            sys.executable,
+            str(scripts_dir / "check_thesis_facts_append.py"),
+            "--commit",
+            _git(tmp_path, "rev-parse", "HEAD"),
+        ],
+        cwd=tmp_path,
         capture_output=True,
         text=True,
     )
 
-    assert completed.returncode == 1
+    assert completed.returncode == 1, completed.stdout + completed.stderr
     assert "was rewritten" in completed.stderr
 
 
@@ -185,9 +220,7 @@ def test_a_duplicate_identity_without_supersedes_is_detected():
         "supersedes": None,
     }
     try:
-        check_rows(
-            [*lines, json.dumps(duplicate, separators=(",", ":"))], len(lines)
-        )
+        check_rows([*lines, json.dumps(duplicate, separators=(",", ":"))], len(lines))
     except ValueError as error:
         assert "without superseding" in str(error)
     else:
@@ -205,9 +238,7 @@ def test_an_explicit_supersede_correction_is_accepted():
         "supersedes": expected_assertion_version_id(original),
     }
 
-    check_rows(
-        [*lines, json.dumps(correction, separators=(",", ":"))], len(lines)
-    )
+    check_rows([*lines, json.dumps(correction, separators=(",", ":"))], len(lines))
 
 
 def test_a_correction_naming_a_stale_version_is_rejected():
@@ -219,9 +250,7 @@ def test_a_correction_naming_a_stale_version_is_rejected():
         "supersedes": "av2:" + "0" * 64,
     }
     try:
-        check_rows(
-            [*lines, json.dumps(correction, separators=(",", ":"))], len(lines)
-        )
+        check_rows([*lines, json.dumps(correction, separators=(",", ":"))], len(lines))
     except ValueError as error:
         assert "the active version" in str(error)
     else:

--- a/tests/test_receipt_shim_transparency.py
+++ b/tests/test_receipt_shim_transparency.py
@@ -118,14 +118,29 @@ def _run_script(
     *arguments: str,
     cwd: pathlib.Path = ROOT,
     stdin: bytes | None = None,
+    environment: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[bytes]:
     return subprocess.run(
         [sys.executable, str(script), *arguments],
         cwd=cwd,
         input=stdin,
+        env=environment,
         capture_output=True,
         check=False,
     )
+
+
+def _fixed_width_environment() -> dict[str, str]:
+    """The caller's environment with argparse's wrapping width fixed at 80.
+
+    ``argparse`` wraps help text to the terminal width, which it takes from
+    ``COLUMNS`` when there is no terminal. Fixing it is what lets a help text be
+    compared against a literal at all.
+    """
+
+    environment = os.environ.copy()
+    environment["COLUMNS"] = "80"
+    return environment
 
 
 def _normalized_stderr(value: bytes) -> bytes:
@@ -143,6 +158,52 @@ def _assert_byte_identical(
     assert original.returncode == expected_code
     assert shim.returncode == expected_code
     assert shim.stdout == original.stdout
+    assert _normalized_stderr(shim.stderr) == _normalized_stderr(original.stderr)
+
+
+CANDIDATE_LINE = re.compile(
+    rb"(?m)^candidate commit [0-9a-f]{40}(?:[0-9a-f]{24})? "
+    rb"tree [0-9a-f]{40}(?:[0-9a-f]{24})?\n\Z"
+)
+
+
+def _split_candidate_line(stdout: bytes) -> tuple[bytes, bytes | None]:
+    """Separate the shim's own last line from the gate's output.
+
+    The shim prints one line the original never printed: the commit it checked
+    out and that commit's tree. Everything before it is the gate's own bytes,
+    and those are what the differential compares.
+    """
+
+    match = CANDIDATE_LINE.search(stdout)
+    if match is None:
+        return stdout, None
+    return stdout[: match.start()], match.group(0)
+
+
+def _assert_gate_bytes_identical(
+    original: subprocess.CompletedProcess[bytes],
+    shim: subprocess.CompletedProcess[bytes],
+    *,
+    expected_code: int,
+    candidate: str | None,
+    tree: str | None,
+) -> None:
+    """Compare the pair on the gate's bytes, and check the shim's extra line.
+
+    The shim reaches its verdict about a checkout it makes itself, so its
+    stdout carries one line the original's does not. That line is asserted
+    against the object ids the fixture committed; the rest must be identical.
+    """
+
+    body, tail = _split_candidate_line(shim.stdout)
+    if expected_code == 0:
+        assert tail == f"candidate commit {candidate} tree {tree}\n".encode("utf-8")
+    else:
+        assert tail is None, shim.stdout
+    assert original.returncode == expected_code
+    assert shim.returncode == expected_code
+    assert body == original.stdout
     assert _normalized_stderr(shim.stderr) == _normalized_stderr(original.stderr)
 
 
@@ -307,8 +368,26 @@ def _release_file(root: pathlib.Path, suffix: str) -> pathlib.Path:
     return root / "releases" / "manifests" / f"{NEW_RELEASE_STEM}{suffix}"
 
 
-def _replay_latest_release(destination: pathlib.Path) -> tuple[pathlib.Path, str]:
-    """Create the real prior-release base and restore the witnessed HEAD append."""
+def _commit_candidate(root: pathlib.Path, message: str) -> str:
+    """Commit whatever is in the working tree and name the commit.
+
+    The shim judges a commit, so the fixture has to state its candidate as one.
+    """
+
+    _git(root, "add", "-A")
+    _git(root, "commit", "--quiet", "--allow-empty", "-m", message)
+    return _git(root, "rev-parse", "HEAD")
+
+
+def _replay_latest_release(
+    destination: pathlib.Path,
+) -> tuple[pathlib.Path, str, str]:
+    """Create the real prior-release base and commit the witnessed HEAD append.
+
+    Returns the clone, the base commit, and the candidate commit. The candidate
+    is a commit rather than a working-tree state because that is the only thing
+    the shim will judge: it checks the named commit out for itself.
+    """
 
     root = _copy_custody_tree(destination)
     ledger = root / "ledger" / "official_observations.jsonl"
@@ -323,9 +402,7 @@ def _replay_latest_release(destination: pathlib.Path) -> tuple[pathlib.Path, str
     _git(root, "init", "--quiet")
     _git(root, "config", "user.email", "shim-differential@example.invalid")
     _git(root, "config", "user.name", "Shim Differential")
-    _git(root, "add", "-A")
-    _git(root, "commit", "--quiet", "-m", "release 1 base")
-    base = _git(root, "rev-parse", "HEAD")
+    base = _commit_candidate(root, "release base")
 
     ledger.write_bytes(full_ledger)
     for suffix in RELEASE_FILE_SUFFIXES:
@@ -333,48 +410,114 @@ def _replay_latest_release(destination: pathlib.Path) -> tuple[pathlib.Path, str
             _release_file(ROOT, suffix),
             _release_file(root, suffix),
         )
-    return root, base
+    return root, base, _commit_candidate(root, "witnessed append")
+
+
+def _plain_checkout(
+    clone: pathlib.Path, oid: str, destination: pathlib.Path
+) -> pathlib.Path:
+    """Materialise one commit as a working tree for the original to judge.
+
+    The original script judges whatever directory it is pointed at, so the fair
+    comparison hands it a directory holding exactly the candidate commit --
+    which is what the shim now builds for itself instead of being handed one.
+    """
+
+    _git(clone, "worktree", "add", "--detach", str(destination), oid)
+    return destination
+
+
+def _tree_of(clone: pathlib.Path, oid: str) -> str:
+    return _git(clone, "rev-parse", f"{oid}^{{tree}}")
 
 
 def _run_append_pair(
     original_oracle: pathlib.Path,
     candidate: pathlib.Path,
     base: str,
+    oid: str,
 ) -> tuple[subprocess.CompletedProcess[bytes], subprocess.CompletedProcess[bytes]]:
-    arguments = ("--root", str(candidate), "--base-ref", base)
+    plain = _plain_checkout(candidate, oid, candidate.parent / "original-checkout")
     original = _run_script(
         original_oracle / "scripts" / "check_thesis_facts_append.py",
-        *arguments,
-        cwd=candidate,
+        "--root",
+        str(plain),
+        "--base-ref",
+        base,
+        cwd=plain,
     )
     shim = _run_script(
         SHIM_SCRIPTS / "check_thesis_facts_append.py",
-        *arguments,
+        "--root",
+        str(candidate),
+        "--base-ref",
+        base,
+        "--commit",
+        oid,
         cwd=candidate,
     )
     return original, shim
 
 
-def test_append_gate_cli_help_is_byte_identical(
+# The original's own command-line surface, pinned so that a change to it is
+# visible here rather than only in the fixture's digest. The shim's surface can
+# no longer be identical: it takes a commit, and the commit is required.
+ORIGINAL_APPEND_GATE_HELP = (
+    b"usage: check_thesis_facts_append.py [-h] [--root ROOT] "
+    b"[--base-ref BASE_REF]\n"
+    b"\n"
+    b"options:\n"
+    b"  -h, --help           show this help message and exit\n"
+    b"  --root ROOT          candidate worktree root (defaults to the "
+    b"checker's\n"
+    b"                       repository)\n"
+    b"  --base-ref BASE_REF  enforce an append-only diff against this git "
+    b"ref\n"
+)
+
+
+def test_original_append_gate_help_is_unchanged(
     original_oracle: pathlib.Path,
 ) -> None:
     original = _run_script(
         original_oracle / "scripts" / "check_thesis_facts_append.py",
         "--help",
+        environment=_fixed_width_environment(),
     )
-    shim = _run_script(SHIM_SCRIPTS / "check_thesis_facts_append.py", "--help")
-    _assert_byte_identical(original, shim, expected_code=0)
+    assert original.returncode == 0
+    assert original.stderr == b""
+    assert original.stdout == ORIGINAL_APPEND_GATE_HELP
+
+
+def test_shim_append_gate_help_requires_a_commit() -> None:
+    shim = _run_script(
+        SHIM_SCRIPTS / "check_thesis_facts_append.py",
+        "--help",
+        environment=_fixed_width_environment(),
+    )
+    assert shim.returncode == 0
+    assert shim.stderr == b""
+    assert b"--commit COMMIT" in shim.stdout
+    # Required, so argparse spells it without brackets in the usage line.
+    assert b"--commit COMMIT" in shim.stdout.split(b"\n\n", maxsplit=1)[0]
+    assert b"[--commit" not in shim.stdout
 
 
 def test_valid_base_ref_append_is_byte_identical(
     original_oracle: pathlib.Path,
     tmp_path: pathlib.Path,
 ) -> None:
-    candidate, base = _replay_latest_release(tmp_path)
-    original, shim = _run_append_pair(original_oracle, candidate, base)
-    _assert_byte_identical(original, shim, expected_code=0)
+    candidate, base, oid = _replay_latest_release(tmp_path)
+    original, shim = _run_append_pair(original_oracle, candidate, base, oid)
+    _assert_gate_bytes_identical(
+        original,
+        shim,
+        expected_code=0,
+        candidate=oid,
+        tree=_tree_of(candidate, oid),
+    )
     assert shim.stderr == b""
-    assert shim.stdout == APPEND_GATE_OK
+    assert _split_candidate_line(shim.stdout)[0] == APPEND_GATE_OK
 
 
 def _rewrite_historical_row(root: pathlib.Path) -> None:
@@ -430,9 +573,19 @@ def test_corrupt_base_ref_append_refusals_are_byte_identical(
     mutation: Mutation,
     marker: bytes,
 ) -> None:
-    candidate, base = _replay_latest_release(tmp_path / case)
+    candidate, base, _accepted = _replay_latest_release(tmp_path / case)
     mutation(candidate)
-    original, shim = _run_append_pair(original_oracle, candidate, base)
-    _assert_byte_identical(original, shim, expected_code=1)
+    # The corruption has to be committed: an uncommitted one is a divergence
+    # between the commit and the working tree, which is the precondition the
+    # shim now establishes rather than a refusal it is being asked to make.
+    oid = _commit_candidate(candidate, f"corrupt: {case}")
+    original, shim = _run_append_pair(original_oracle, candidate, base, oid)
+    _assert_gate_bytes_identical(
+        original,
+        shim,
+        expected_code=1,
+        candidate=None,
+        tree=None,
+    )
     assert shim.stdout == b""
     assert marker in _normalized_stderr(shim.stderr)

--- a/tests/test_receipt_shim_transparency.py
+++ b/tests/test_receipt_shim_transparency.py
@@ -31,15 +31,57 @@ ORIGINAL_HASHES = {
 }
 OPENSSL_QUEUE_ID = re.compile(rb"(?m)^[0-9A-Fa-f]{8,16}(?=:error:)")
 
-BASE_LINE_COUNT = 182
-CANDIDATE_LINE_COUNT = 189
-NEW_RELEASE_STEM = "0012-3a5ef7eeee484370"
 RELEASE_FILE_SUFFIXES = (
     ".json",
     ".producer.sig",
     ".freetsa.tsr",
     ".digicert.tsr",
 )
+
+
+def _release_manifests() -> list[pathlib.Path]:
+    """Every canonical release manifest, in release-index order."""
+
+    return sorted((ROOT / "releases" / "manifests").glob("[0-9]" * 4 + "-*.json"))
+
+
+def _head_release() -> dict:
+    return json.loads(_release_manifests()[-1].read_text(encoding="utf-8"))
+
+
+# The witnessed journal grows on every resolver append, so the numbers this
+# differential replays are read from the committed release chain rather than
+# transcribed into the test. Transcribed numbers went stale the first time the
+# append lane ran and this file is not part of the CI pytest step that would
+# have caught it. What the differential actually asserts -- that the original
+# and the shim emit the same bytes -- does not depend on the numbers at all;
+# they only pin the text the pair is expected to agree on.
+_HEAD_RELEASE = _head_release()
+RELEASE_COUNT = len(_release_manifests())
+NEW_RELEASE_STEM = _release_manifests()[-1].stem
+FIRST_APPEND_RELEASE_STEM = _release_manifests()[1].stem
+RELEASE_INDEX = int(_HEAD_RELEASE["releaseIndex"])
+CANDIDATE_LINE_COUNT = int(_HEAD_RELEASE["state"]["lineCount"])
+BASE_LINE_COUNT = int(_HEAD_RELEASE["append"]["previousLineCount"])
+APPENDED_ROW_COUNT = int(_HEAD_RELEASE["append"]["appendedRowCount"])
+PREFIX_LINE_COUNT = int(
+    json.loads((ROOT / "ledger" / "immutable_prefix.json").read_text(encoding="utf-8"))[
+        "prefixLineCount"
+    ]
+)
+RELEASE_CHAIN_OK = re.compile(
+    rb"release chain OK: "
+    + str(RELEASE_COUNT).encode("ascii")
+    + rb" releases, HEAD="
+    + re.escape(NEW_RELEASE_STEM.encode("ascii"))
+    + rb"\.json, digicert=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z, "
+    + rb"freetsa=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\n"
+)
+APPEND_GATE_OK = (
+    f"thesis-facts append check OK: {CANDIDATE_LINE_COUNT} rows, "
+    f"immutable prefix {PREFIX_LINE_COUNT}, "
+    f"+{APPENDED_ROW_COUNT} appended vs base, release {RELEASE_INDEX}\n"
+).encode("utf-8")
 
 Mutation = Callable[[pathlib.Path], None]
 
@@ -162,12 +204,10 @@ def test_live_full_release_chain_is_byte_identical(
     shim = _run_script(SHIM_SCRIPTS / "verify_release_chain.py", *arguments)
     _assert_byte_identical(original, shim, expected_code=0)
     assert shim.stderr == b""
-    assert shim.stdout == (
-        b"release chain OK: 13 releases, "
-        b"HEAD=0012-3a5ef7eeee484370.json, "
-        b"digicert=2026-08-12T14:43:16Z, "
-        b"freetsa=2026-08-12T14:43:16Z\n"
-    )
+    # The two RFC 3161 receipt times are set by the timestamp authorities, so
+    # they are matched by shape rather than transcribed; the release count and
+    # the HEAD manifest name come from the committed chain.
+    assert RELEASE_CHAIN_OK.fullmatch(shim.stdout), shim.stdout
 
 
 def _copy_custody_tree(destination: pathlib.Path) -> pathlib.Path:
@@ -190,19 +230,13 @@ def _append_unwitnessed_row(root: pathlib.Path) -> None:
 
 def _corrupt_producer_signature(root: pathlib.Path) -> None:
     _flip_middle_byte(
-        root
-        / "releases"
-        / "manifests"
-        / "0001-916626696d034b80.producer.sig"
+        root / "releases" / "manifests" / f"{FIRST_APPEND_RELEASE_STEM}.producer.sig"
     )
 
 
 def _corrupt_freetsa_receipt(root: pathlib.Path) -> None:
     _flip_middle_byte(
-        root
-        / "releases"
-        / "manifests"
-        / "0001-916626696d034b80.freetsa.tsr"
+        root / "releases" / "manifests" / f"{FIRST_APPEND_RELEASE_STEM}.freetsa.tsr"
     )
 
 
@@ -212,7 +246,10 @@ def _corrupt_freetsa_receipt(root: pathlib.Path) -> None:
         (
             "unwitnessed-row",
             _append_unwitnessed_row,
-            b"HEAD release lineCount 189 does not match working-tree line count 190",
+            (
+                f"HEAD release lineCount {CANDIDATE_LINE_COUNT} does not match "
+                f"working-tree line count {CANDIDATE_LINE_COUNT + 1}"
+            ).encode("utf-8"),
         ),
         (
             "producer-signature",
@@ -337,16 +374,13 @@ def test_valid_base_ref_append_is_byte_identical(
     original, shim = _run_append_pair(original_oracle, candidate, base)
     _assert_byte_identical(original, shim, expected_code=0)
     assert shim.stderr == b""
-    assert shim.stdout == (
-        b"thesis-facts append check OK: 189 rows, immutable prefix 128, "
-        b"+7 appended vs base, release 12\n"
-    )
+    assert shim.stdout == APPEND_GATE_OK
 
 
 def _rewrite_historical_row(root: pathlib.Path) -> None:
     ledger = root / "ledger" / "official_observations.jsonl"
     rows = ledger.read_bytes().splitlines(keepends=True)
-    rows[128] = b" " + rows[128]
+    rows[PREFIX_LINE_COUNT] = b" " + rows[PREFIX_LINE_COUNT]
     ledger.write_bytes(b"".join(rows))
 
 
@@ -372,17 +406,20 @@ def _remove_new_release_manifest(root: pathlib.Path) -> None:
         (
             "historical-rewrite",
             _rewrite_historical_row,
-            b"change rewrites existing line 129",
+            (f"change rewrites existing line {PREFIX_LINE_COUNT + 1}").encode("utf-8"),
         ),
         (
             "missing-assertion-version",
             _remove_appended_assertion_version,
-            b"appended line 183",
+            f"appended line {BASE_LINE_COUNT + 1}".encode("utf-8"),
         ),
         (
             "missing-release-manifest",
             _remove_new_release_manifest,
-            b"release proposal must add exactly one manifest for index 12",
+            (
+                "release proposal must add exactly one manifest for index "
+                f"{RELEASE_INDEX}"
+            ).encode("utf-8"),
         ),
     ],
 )

--- a/tests/test_release_chain.py
+++ b/tests/test_release_chain.py
@@ -339,10 +339,22 @@ def _run_gate(
     environment: ReleaseEnvironment,
     base_ref: str,
 ) -> subprocess.CompletedProcess[str]:
+    """Commit whatever the fixture just wrote and judge that commit.
+
+    The gate judges a commit it checks out for itself, so a fixture that has
+    only written into a working tree has not yet stated a candidate. Each of
+    these tests takes its base ref before it writes, so committing here makes
+    the base the parent of what is judged.
+    """
+
+    _git(environment.repo, "add", "-A")
+    _git(environment.repo, "commit", "-q", "--allow-empty", "-m", "candidate")
     return _run(
         [
             sys.executable,
             str(environment.repo / "scripts" / "check_thesis_facts_append.py"),
+            "--commit",
+            _git(environment.repo, "rev-parse", "HEAD"),
             "--base-ref",
             base_ref,
             "--release-anchor-dir",
@@ -714,9 +726,7 @@ def test_verifier_rejects_wrong_producer_key_signature(
     full_chain_environment: ReleaseEnvironment,
 ):
     head = next(
-        (full_chain_environment.repo / "releases" / "manifests").glob(
-            "0001-*.json"
-        )
+        (full_chain_environment.repo / "releases" / "manifests").glob("0001-*.json")
     )
     wrong_key = _generate_producer_keypair(full_chain_environment.tsa / "wrong-key")
     _sign_producer_payload(
@@ -735,9 +745,7 @@ def test_verifier_rejects_producer_signature_over_different_bytes(
     full_chain_environment: ReleaseEnvironment,
 ):
     head = next(
-        (full_chain_environment.repo / "releases" / "manifests").glob(
-            "0001-*.json"
-        )
+        (full_chain_environment.repo / "releases" / "manifests").glob("0001-*.json")
     )
     different = full_chain_environment.tsa / "different-producer-payload.json"
     different.write_bytes(b'{"different":true}\n')
@@ -757,9 +765,7 @@ def test_verifier_rejects_non_raw_producer_signature_size(
     full_chain_environment: ReleaseEnvironment,
 ):
     head = next(
-        (full_chain_environment.repo / "releases" / "manifests").glob(
-            "0001-*.json"
-        )
+        (full_chain_environment.repo / "releases" / "manifests").glob("0001-*.json")
     )
     producer_signature_path_for_manifest(head).write_bytes(b"not-64-bytes")
 
@@ -872,9 +878,7 @@ def test_cutter_rejects_wrong_second_tsa_without_partial_files(
             ),
         )
 
-    manifest_directory = (
-        pregenesis_environment.repo / "releases" / "manifests"
-    )
+    manifest_directory = pregenesis_environment.repo / "releases" / "manifests"
     assert not manifest_directory.exists() or not any(manifest_directory.iterdir())
 
 
@@ -940,9 +944,7 @@ def test_cutter_self_verification_rejects_wrong_signing_key_without_outputs(
             anchor_dir=pregenesis_environment.anchors,
         )
 
-    manifest_directory = (
-        pregenesis_environment.repo / "releases" / "manifests"
-    )
+    manifest_directory = pregenesis_environment.repo / "releases" / "manifests"
     assert not manifest_directory.exists() or not any(manifest_directory.iterdir())
 
 
@@ -951,9 +953,7 @@ def test_cutter_refuses_concurrent_signature_overwrite(
 ):
     now = datetime.now(timezone.utc) - timedelta(seconds=1)
     ledger = (
-        pregenesis_environment.repo
-        / "ledger"
-        / "official_observations.jsonl"
+        pregenesis_environment.repo / "ledger" / "official_observations.jsonl"
     ).read_bytes()
     immutable_prefix = (
         pregenesis_environment.repo / "ledger" / "immutable_prefix.json"
@@ -970,9 +970,7 @@ def test_cutter_refuses_concurrent_signature_overwrite(
         now=now,
     )
     filename = manifest_filename(manifest["releaseIndex"], raw)
-    manifest_path = (
-        pregenesis_environment.repo / "releases" / "manifests" / filename
-    )
+    manifest_path = pregenesis_environment.repo / "releases" / "manifests" / filename
     signature_path = producer_signature_path_for_manifest(manifest_path)
     sentinel = b"concurrent-writer-owned-this-path"
     local_request = _local_timestamp_requester(pregenesis_environment)
@@ -1011,9 +1009,7 @@ def test_cutter_no_sign_reserves_omitted_signature_during_tsa_requests(
 ):
     now = datetime.now(timezone.utc) - timedelta(seconds=1)
     ledger = (
-        pregenesis_environment.repo
-        / "ledger"
-        / "official_observations.jsonl"
+        pregenesis_environment.repo / "ledger" / "official_observations.jsonl"
     ).read_bytes()
     immutable_prefix = (
         pregenesis_environment.repo / "ledger" / "immutable_prefix.json"
@@ -1030,9 +1026,7 @@ def test_cutter_no_sign_reserves_omitted_signature_during_tsa_requests(
         now=now,
     )
     filename = manifest_filename(manifest["releaseIndex"], raw)
-    manifest_path = (
-        pregenesis_environment.repo / "releases" / "manifests" / filename
-    )
+    manifest_path = pregenesis_environment.repo / "releases" / "manifests" / filename
     signature_path = producer_signature_path_for_manifest(manifest_path)
     sentinel = b"concurrent-omitted-signature"
     local_request = _local_timestamp_requester(pregenesis_environment)
@@ -1069,9 +1063,7 @@ def test_cutter_no_tsa_reserves_omitted_receipts_during_signing(
 ):
     now = datetime.now(timezone.utc) - timedelta(seconds=1)
     ledger = (
-        pregenesis_environment.repo
-        / "ledger"
-        / "official_observations.jsonl"
+        pregenesis_environment.repo / "ledger" / "official_observations.jsonl"
     ).read_bytes()
     immutable_prefix = (
         pregenesis_environment.repo / "ledger" / "immutable_prefix.json"
@@ -1088,9 +1080,7 @@ def test_cutter_no_tsa_reserves_omitted_receipts_during_signing(
         now=now,
     )
     filename = manifest_filename(manifest["releaseIndex"], raw)
-    manifest_path = (
-        pregenesis_environment.repo / "releases" / "manifests" / filename
-    )
+    manifest_path = pregenesis_environment.repo / "releases" / "manifests" / filename
     receipt_path = manifest_path.with_name(f"{manifest_path.stem}.freetsa.tsr")
     signature_path = producer_signature_path_for_manifest(manifest_path)
     sentinel = b"concurrent-omitted-receipt"
@@ -1151,9 +1141,7 @@ def test_cutter_rolls_back_signature_with_batch_on_postwrite_failure(
             requester=_local_timestamp_requester(pregenesis_environment),
         )
 
-    manifest_directory = (
-        pregenesis_environment.repo / "releases" / "manifests"
-    )
+    manifest_directory = pregenesis_environment.repo / "releases" / "manifests"
     assert calls == 3
     assert not manifest_directory.exists() or not any(manifest_directory.iterdir())
 
@@ -1171,9 +1159,7 @@ def test_cutter_rollback_preserves_concurrent_replacement(
         nonlocal calls, replacement_path
         calls += 1
         if calls == 3:
-            manifest_directory = (
-                pregenesis_environment.repo / "releases" / "manifests"
-            )
+            manifest_directory = pregenesis_environment.repo / "releases" / "manifests"
             replacement_path = next(manifest_directory.glob("*.producer.sig"))
             replacement_path.unlink()
             # The replacement must be a DIRECTORY: a rewritten regular file's
@@ -1277,9 +1263,7 @@ def test_batch_write_detects_parent_swap_during_verification(tmp_path: Path):
 
     assert (root / "releases").is_symlink()
     assert not (external_releases / "manifests" / target.name).exists()
-    assert not (
-        displaced_releases / "manifests" / target.name
-    ).exists()
+    assert not (displaced_releases / "manifests" / target.name).exists()
 
 
 def test_batch_rollback_preserves_replacement_manifest_directory(tmp_path: Path):

--- a/tests/test_thesis_append_adversarial.py
+++ b/tests/test_thesis_append_adversarial.py
@@ -39,7 +39,6 @@ sys.path.insert(0, str(ROOT / "scripts"))
 
 from check_thesis_facts_append import (  # noqa: E402
     AppendError,
-    check_append_only,
     check_rows,
     effective_current_rows,
     expected_assertion_version_id,
@@ -128,7 +127,9 @@ def _write_checker_fixture(path: Path, ledger_text: str, manifest: dict) -> None
         )
 
 
-def _run_checker(path: Path, base_ref: str | None = None) -> subprocess.CompletedProcess:
+def _run_checker(
+    path: Path, base_ref: str | None = None
+) -> subprocess.CompletedProcess:
     command = [sys.executable, str(path / "scripts/check_thesis_facts_append.py")]
     if base_ref is not None:
         command.extend(["--base-ref", base_ref])
@@ -155,8 +156,7 @@ def _rehash_manifest(lines: list[str]) -> dict:
     manifest = json.loads(PREFIX_PATH.read_text(encoding="utf-8"))
     count = int(manifest["prefixLineCount"])
     manifest["lineSha256s"] = [
-        hashlib.sha256(line.encode("utf-8")).hexdigest()
-        for line in lines[:count]
+        hashlib.sha256(line.encode("utf-8")).hexdigest() for line in lines[:count]
     ]
     manifest["prefixSha256"] = hashlib.sha256(
         ("\n".join(lines[:count]) + "\n").encode("utf-8")
@@ -330,9 +330,9 @@ def test_base_gate_uses_base_script_and_dependency_imports(
 
 
 def test_workflow_has_a_base_owned_trusted_pr_gate():
-    workflow = (
-        ROOT / ".github" / "workflows" / "thesis-facts-append.yml"
-    ).read_text(encoding="utf-8")
+    workflow = (ROOT / ".github" / "workflows" / "thesis-facts-append.yml").read_text(
+        encoding="utf-8"
+    )
 
     # A pull_request workflow is loaded from the candidate merge ref, so its
     # detached base-script step can itself be replaced. Once installed on the
@@ -358,35 +358,6 @@ def test_workflow_has_a_base_owned_trusted_pr_gate():
         '--base-ref "$BASE_SHA"',
     ):
         assert required in workflow
-
-
-def test_base_check_rejects_an_existing_line_rewrite():
-    lines = _read_lines()
-    rewritten = json.loads(lines[-1])
-    rewritten["value"] += 1
-    candidate = [*lines[:-1], _json_line(rewritten)]
-
-    with pytest.raises(
-        AppendError,
-        match=rf"rewrites existing line {len(lines)}",
-    ):
-        check_append_only("HEAD", candidate)
-
-
-def test_base_check_rejects_truncation():
-    lines = _read_lines()
-
-    with pytest.raises(
-        AppendError,
-        match=rf"truncates the ledger: {len(lines)} -> {len(lines) - 1}",
-    ):
-        check_append_only("HEAD", lines[:-1])
-
-
-def test_base_check_accepts_a_true_append():
-    lines = _read_lines()
-
-    assert check_append_only("HEAD", [*lines, "{}"]) == 1
 
 
 def test_duplicate_identity_without_supersedes_is_rejected():
@@ -422,9 +393,7 @@ def test_mismatched_av2_id_is_rejected():
         ("source_row_keys", ["different:publisher:row"]),
     ],
 )
-def test_av2_binds_material_concept_and_source_lineage(
-    path: str, replacement: object
-):
+def test_av2_binds_material_concept_and_source_lineage(path: str, replacement: object):
     # Review finding 6: av1 projected only measure concept/unit and four source
     # fields, so these material changes collided. The av2 projection binds the
     # complete concept mapping, exact source file/digest, and row/cell lineage.
@@ -473,8 +442,8 @@ def test_pre_versioning_row_is_addressable_by_recomputed_av2_id():
     lines = _read_lines()
     original = json.loads(lines[-1])
     correction = _appended_row(original, value_delta=1)
-    correction["assertionVersion"]["supersedes"] = (
-        expected_assertion_version_id(original)
+    correction["assertionVersion"]["supersedes"] = expected_assertion_version_id(
+        original
     )
 
     check_rows([*lines, _json_line(correction)], len(lines))
@@ -488,8 +457,8 @@ def test_full_ci_fact_validation_accepts_an_explicit_correction():
     rows = [json.loads(line) for line in _read_lines()]
     original = rows[-1]
     correction = _appended_row(original, value_delta=1)
-    correction["assertionVersion"]["supersedes"] = (
-        expected_assertion_version_id(original)
+    correction["assertionVersion"]["supersedes"] = expected_assertion_version_id(
+        original
     )
 
     # The append gate itself accepts exactly the advertised correction shape.

--- a/tests/test_thesis_append_adversarial.py
+++ b/tests/test_thesis_append_adversarial.py
@@ -381,8 +381,20 @@ def test_workflow_has_a_base_owned_trusted_pr_gate():
         'python "$base_gate/scripts/check_thesis_facts_append.py"',
         '--root "$candidate"',
         '--base-ref "$BASE_SHA"',
+        # The commit under judgement is named on the command line in all three
+        # invocations. Dropping any of them would leave the gate judging
+        # whichever tree the checkout at --root happened to be sitting at,
+        # which is the divergence the shim exists to exclude.
+        '--commit "$MERGE_SHA"',
+        '--commit "$workspace_sha"',
+        '--commit "$GITHUB_SHA"',
     ):
         assert required in workflow
+
+    # And the pull_request job's id is read from the workspace and shape-checked
+    # before it is passed, the same way the other two are.
+    assert 'workspace_sha="$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)"' in workflow
+    assert '[[ "$workspace_sha" =~ ^[0-9a-f]{40,64}$ ]]' in workflow
 
 
 def test_duplicate_identity_without_supersedes_is_rejected():

--- a/tests/test_thesis_append_adversarial.py
+++ b/tests/test_thesis_append_adversarial.py
@@ -127,10 +127,31 @@ def _write_checker_fixture(path: Path, ledger_text: str, manifest: dict) -> None
         )
 
 
+def _commit_candidate(path: Path) -> str:
+    """Commit whatever the fixture has just written and name that commit.
+
+    The checker judges a commit it checks out itself, so a fixture that mutated
+    a working tree has not yet said anything the checker can be asked about.
+    Committing is how the fixture states its candidate. An empty commit is
+    allowed because some fixtures change nothing and the question -- does this
+    commit pass -- is still a real one.
+    """
+
+    _git(path, "add", "-A")
+    _git(path, "commit", "-q", "--allow-empty", "-m", "candidate")
+    return _git(path, "rev-parse", "HEAD")
+
+
 def _run_checker(
     path: Path, base_ref: str | None = None
 ) -> subprocess.CompletedProcess:
-    command = [sys.executable, str(path / "scripts/check_thesis_facts_append.py")]
+    commit = _commit_candidate(path)
+    command = [
+        sys.executable,
+        str(path / "scripts/check_thesis_facts_append.py"),
+        "--commit",
+        commit,
+    ]
     if base_ref is not None:
         command.extend(["--base-ref", base_ref])
     return subprocess.run(command, cwd=path, capture_output=True, text=True)
@@ -305,6 +326,8 @@ def test_base_gate_uses_base_script_and_dependency_imports(
         encoding="utf-8",
     )
 
+    candidate_commit = _commit_candidate(candidate)
+
     environment = os.environ.copy()
     environment["PYTHONPATH"] = str(base_gate / "scripts")
     environment["PYTHONNOUSERSITE"] = "1"
@@ -314,6 +337,8 @@ def test_base_gate_uses_base_script_and_dependency_imports(
             str(base_gate / "scripts" / "check_thesis_facts_append.py"),
             "--root",
             str(candidate),
+            "--commit",
+            candidate_commit,
             "--base-ref",
             base,
         ],

--- a/tests/test_thesis_append_adversarial.py
+++ b/tests/test_thesis_append_adversarial.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import copy
 import hashlib
 import json
+import re
 import os
 import subprocess
 import sys
@@ -406,6 +407,19 @@ def test_workflow_has_a_base_owned_trusted_pr_gate():
     assert workflow.count('case "$base_gate_help" in') == 2
     assert workflow.count("*--commit*)") == 2
     assert workflow.count('echo "note: the base gate at') == 2
+    # Shell `case` takes the first matching arm, so the order of the arms is
+    # part of the contract: the `--commit` arm must come before the fallback
+    # in each block, and the `--commit` invocation must sit inside its arm
+    # (peer review of #241, round 1).
+    for block in workflow.split('case "$base_gate_help" in')[1:]:
+        body = block.split("esac", 1)[0]
+        commit_arm = body.index("*--commit*)")
+        fallback = re.search(r"^\s*\*\)\s*$", body, re.M)
+        assert fallback is not None
+        fallback_arm = fallback.start()
+        assert commit_arm < fallback_arm
+        assert "--commit " in body[commit_arm:fallback_arm]
+        assert "--commit " not in body[fallback_arm:]
 
 
 def test_duplicate_identity_without_supersedes_is_rejected():

--- a/tests/test_thesis_append_adversarial.py
+++ b/tests/test_thesis_append_adversarial.py
@@ -396,6 +396,17 @@ def test_workflow_has_a_base_owned_trusted_pr_gate():
     assert 'workspace_sha="$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)"' in workflow
     assert '[[ "$workspace_sha" =~ ^[0-9a-f]{40,64}$ ]]' in workflow
 
+    # Both base-gate jobs ask the base gate what it accepts before invoking it,
+    # because the base gate on any pull request opened before --commit merged
+    # does not accept it and the one after requires it. The question goes to
+    # base-owned code about its own interface. The fallback is never silent, so
+    # a run that took it says so in its own log; requiring the notice here is
+    # what stops the fallback being quietly widened into the ordinary path.
+    assert workflow.count('base_gate_help="$(') == 2
+    assert workflow.count('case "$base_gate_help" in') == 2
+    assert workflow.count("*--commit*)") == 2
+    assert workflow.count('echo "note: the base gate at') == 2
+
 
 def test_duplicate_identity_without_supersedes_is_rejected():
     lines = _read_lines()

--- a/tests/test_thesis_append_adversarial.py
+++ b/tests/test_thesis_append_adversarial.py
@@ -418,8 +418,8 @@ def test_workflow_has_a_base_owned_trusted_pr_gate():
         assert fallback is not None
         fallback_arm = fallback.start()
         assert commit_arm < fallback_arm
-        assert "--commit " in body[commit_arm:fallback_arm]
-        assert "--commit " not in body[fallback_arm:]
+        assert '--commit "$' in body[commit_arm:fallback_arm]
+        assert '--commit "$' not in body[fallback_arm:]
 
 
 def test_duplicate_identity_without_supersedes_is_rejected():

--- a/tests/test_thesis_append_shim_isolation.py
+++ b/tests/test_thesis_append_shim_isolation.py
@@ -1130,3 +1130,128 @@ shim._scratch_root = _record_the_mode
     assert completed.returncode == 0, completed.stdout + completed.stderr
     assert observed.read_text(encoding="utf-8") == oct(stat.S_IRWXU)
     _assert_nothing_left_behind(clone, tmp_path / "tmp")
+
+
+def _sparse_patterns(root: pathlib.Path, *patterns: str) -> None:
+    info = root / ".git" / "info"
+    info.mkdir(parents=True, exist_ok=True)
+    (info / "sparse-checkout").write_text("".join(f"{p}\n" for p in patterns), encoding="utf-8")
+
+
+@pytest.mark.parametrize("scope", ["local", "worktree"])
+def test_a_sparse_checkout_is_refused_before_it_can_pass(tmp_path, scope):
+    """A clone configured for sparse checkout cannot produce the commit.
+
+    With ``core.sparseCheckout`` on and a patterns file in the shared git
+    directory keeping the protected paths but dropping an unprotected tracked
+    file, ``git worktree add`` materialises a strict subset of the commit; the
+    omitted entry is marked skip-worktree, so ``git status`` and the ignored
+    listing both stay empty, and on the push invocation (no ``--base-ref``)
+    the gate reads only the state files and the release tree and said OK
+    (peer review, round 1). The key is refused by the configuration audit
+    before any checkout happens, in both scopes it can be set in; and the
+    checkout assertions refuse a skip-worktree entry and an index shorter
+    than the commit, so the second line holds even if the first is bypassed.
+    """
+
+    def prepare(root: pathlib.Path) -> None:
+        (root / "notes.txt").write_text("unprotected, tracked\n", encoding="utf-8")
+
+    clone, base, candidate = _replay_latest_release(tmp_path, prepare=prepare)
+    _sparse_patterns(clone, "/ledger/", "/releases/")
+    if scope == "worktree":
+        _git(clone, "config", "extensions.worktreeConfig", "true")
+        _git(clone, "config", "--worktree", "core.sparseCheckout", "true")
+    else:
+        _git(clone, "config", "core.sparseCheckout", "true")
+
+    completed = _run_shim(clone, commit=candidate, temporary_root=tmp_path / "tmp")
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert completed.stdout == ""
+    assert completed.stderr.startswith(REFUSED)
+    assert "core.sparsecheckout" in completed.stderr.lower()
+    assert "subset of the commit" in completed.stderr
+    _assert_nothing_left_behind(clone, tmp_path / "tmp")
+
+
+def test_a_checkout_that_is_not_the_whole_commit_is_refused(tmp_path):
+    """The second line: a skip-worktree entry, however it arose, refuses.
+
+    The audit is bypassed here by injecting the sparse configuration through
+    the shim's own frozen global file after the audit ran, so the checkout
+    itself is sparse; the index assertion names the omitted entry.
+    """
+
+    def prepare(root: pathlib.Path) -> None:
+        (root / "notes.txt").write_text("unprotected, tracked\n", encoding="utf-8")
+
+    clone, base, candidate = _replay_latest_release(tmp_path, prepare=prepare)
+    _sparse_patterns(clone, "/ledger/", "/releases/")
+    injection = """
+_real_audit = shim._audit_repository_config
+def _audit_then_sparse(clone_root, env):
+    _real_audit(clone_root, env)
+    subprocess.run(["git", "config", "-f", env["GIT_CONFIG_GLOBAL"], "core.sparseCheckout", "true"], check=True, env=env)
+shim._audit_repository_config = _audit_then_sparse
+"""
+    completed = _run_shim(
+        clone,
+        commit=candidate,
+        temporary_root=tmp_path / "tmp",
+        injection=injection,
+        workspace=tmp_path / "workspace",
+    )
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert completed.stdout == ""
+    assert completed.stderr.startswith(REFUSED)
+    assert "skip-worktree" in completed.stderr or "indexes" in completed.stderr
+    _assert_nothing_left_behind(clone, tmp_path / "tmp")
+
+
+def test_git_runs_post_checkout_on_worktree_add_when_hooks_are_not_redirected(tmp_path):
+    """Positive control for the hook test above (peer review, round 1).
+
+    Without the shim's ``core.hooksPath`` redirection, ``git worktree add``
+    does run ``post-checkout``; so the absence of the marker in the shim's run
+    is the shim's doing and not git's.
+    """
+
+    clone, base, candidate = _replay_latest_release(tmp_path)
+    marker = tmp_path / "the-hook-ran"
+    hook = clone / ".git" / "hooks" / "post-checkout"
+    hook.parent.mkdir(parents=True, exist_ok=True)
+    hook.write_text(f"#!/bin/sh\nprintf 'ran' > {marker}\n", encoding="utf-8")
+    hook.chmod(0o755)
+    _git(clone, "worktree", "add", "--detach", str(tmp_path / "plain"), candidate)
+    assert marker.exists(), "git did not run post-checkout on worktree add; the hook test would be vacuous"
+    _git(clone, "worktree", "remove", "--force", str(tmp_path / "plain"))
+
+
+def test_the_documented_variable_list_covers_the_installed_manual(tmp_path):
+    """The tuple is held to git's own documentation where it is installed.
+
+    Every ``GIT_`` name the installed ``git(1)`` manual page mentions must be
+    in the tuple; the prefix rule drops them all regardless, so this is a
+    check that the list has not fallen behind the git on the machine. Skips,
+    never passes, where the manual page cannot be found.
+    """
+
+    import gzip
+
+    completed = subprocess.run(
+        ["git", "--man-path"], capture_output=True, text=True, check=False
+    )
+    if completed.returncode != 0 or not completed.stdout.strip():
+        pytest.skip("git --man-path is unavailable")
+    man = pathlib.Path(completed.stdout.strip()) / "man1"
+    candidates = [man / "git.1", man / "git.1.gz"]
+    page = next((c for c in candidates if c.exists()), None)
+    if page is None:
+        pytest.skip(f"git(1) manual page not installed under {man}")
+    raw = gzip.decompress(page.read_bytes()) if page.suffix == ".gz" else page.read_bytes()
+    text = raw.decode("utf-8", "replace").replace("\\-", "-").replace("\\_", "_")
+    mentioned = set(re.findall(r"\bGIT_[A-Z0-9_]+\b", text))
+    mentioned.discard("GIT_")
+    documented = set(_documented_git_variables())
+    missing = sorted(name for name in mentioned if name not in documented and not name.endswith("_"))
+    assert missing == [], f"documented in git(1) but not in the tuple: {missing}"

--- a/tests/test_thesis_append_shim_isolation.py
+++ b/tests/test_thesis_append_shim_isolation.py
@@ -84,7 +84,10 @@ APPEND_GATE_OK = (
 def _git(root: pathlib.Path, *arguments: str) -> str:
     """Run git in a fixture repository, ignoring the machine's own settings."""
 
-    environment = os.environ.copy()
+    # Every GIT_-prefixed name goes, as in the shim: GIT_CONFIG_COUNT and its
+    # numbered channels outrank every file, and GIT_DIR or GIT_WORK_TREE would
+    # point the fixture at another repository (peer review, round 2).
+    environment = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
     environment.update(
         {
             "GIT_CONFIG_GLOBAL": "/dev/null",
@@ -1135,7 +1138,9 @@ shim._scratch_root = _record_the_mode
 def _sparse_patterns(root: pathlib.Path, *patterns: str) -> None:
     info = root / ".git" / "info"
     info.mkdir(parents=True, exist_ok=True)
-    (info / "sparse-checkout").write_text("".join(f"{p}\n" for p in patterns), encoding="utf-8")
+    (info / "sparse-checkout").write_text(
+        "".join(f"{p}\n" for p in patterns), encoding="utf-8"
+    )
 
 
 @pytest.mark.parametrize("scope", ["local", "worktree"])
@@ -1148,10 +1153,12 @@ def test_a_sparse_checkout_is_refused_before_it_can_pass(tmp_path, scope):
     omitted entry is marked skip-worktree, so ``git status`` and the ignored
     listing both stay empty, and on the push invocation (no ``--base-ref``)
     the gate reads only the state files and the release tree and said OK
-    (peer review, round 1). The key is refused by the configuration audit
-    before any checkout happens, in both scopes it can be set in; and the
-    checkout assertions refuse a skip-worktree entry and an index shorter
-    than the commit, so the second line holds even if the first is bypassed.
+    (peer review, round 1). What this test shows is the first line: the key
+    is refused by the configuration audit before any checkout happens, in both
+    scopes it can be set in, so the sparse checkout never occurs here. The
+    second line — the checkout assertions refusing a skip-worktree entry, and
+    an index shorter than the commit — is shown by the two tests that follow,
+    which bypass the audit.
     """
 
     def prepare(root: pathlib.Path) -> None:
@@ -1204,7 +1211,7 @@ shim._audit_repository_config = _audit_then_sparse
     assert completed.returncode == 1, completed.stdout + completed.stderr
     assert completed.stdout == ""
     assert completed.stderr.startswith(REFUSED)
-    assert "skip-worktree" in completed.stderr or "indexes" in completed.stderr
+    assert "skip-worktree" in completed.stderr
     _assert_nothing_left_behind(clone, tmp_path / "tmp")
 
 
@@ -1223,7 +1230,9 @@ def test_git_runs_post_checkout_on_worktree_add_when_hooks_are_not_redirected(tm
     hook.write_text(f"#!/bin/sh\nprintf 'ran' > {marker}\n", encoding="utf-8")
     hook.chmod(0o755)
     _git(clone, "worktree", "add", "--detach", str(tmp_path / "plain"), candidate)
-    assert marker.exists(), "git did not run post-checkout on worktree add; the hook test would be vacuous"
+    assert marker.exists(), (
+        "git did not run post-checkout on worktree add; the hook test would be vacuous"
+    )
     _git(clone, "worktree", "remove", "--force", str(tmp_path / "plain"))
 
 
@@ -1248,10 +1257,88 @@ def test_the_documented_variable_list_covers_the_installed_manual(tmp_path):
     page = next((c for c in candidates if c.exists()), None)
     if page is None:
         pytest.skip(f"git(1) manual page not installed under {man}")
-    raw = gzip.decompress(page.read_bytes()) if page.suffix == ".gz" else page.read_bytes()
+    raw = (
+        gzip.decompress(page.read_bytes())
+        if page.suffix == ".gz"
+        else page.read_bytes()
+    )
     text = raw.decode("utf-8", "replace").replace("\\-", "-").replace("\\_", "_")
-    mentioned = set(re.findall(r"\bGIT_[A-Z0-9_]+\b", text))
+    # roff writes most names as \\fBGIT_DIR\\fR, so a leading word boundary
+    # would miss them (peer review, round 2); the class itself ends the match.
+    mentioned = set(re.findall(r"GIT_[A-Z0-9_]+\b", text))
     mentioned.discard("GIT_")
     documented = set(_documented_git_variables())
-    missing = sorted(name for name in mentioned if name not in documented and not name.endswith("_"))
+    missing = sorted(
+        name for name in mentioned if name not in documented and not name.endswith("_")
+    )
     assert missing == [], f"documented in git(1) but not in the tuple: {missing}"
+
+
+def test_an_index_shorter_than_the_commit_is_refused(tmp_path):
+    """The entry-count half of the checkout assertion, exercised on its own.
+
+    Every tag is ``H`` here; the shim's ``ls-files -v -z`` read is made to
+    return one record fewer than the commit has entries, which is the shape
+    the count check exists for (peer review, round 2).
+    """
+
+    clone, base, candidate = _replay_latest_release(tmp_path)
+    injection = """
+_real_git = shim._git
+def _short_index(arguments, **kwargs):
+    payload = _real_git(arguments, **kwargs)
+    if "ls-files" in arguments and "-v" in arguments:
+        records = [r for r in payload.split(b"\\0") if r]
+        payload = b"\\0".join(records[:-1]) + b"\\0"
+    return payload
+shim._git = _short_index
+"""
+    completed = _run_shim(
+        clone,
+        commit=candidate,
+        temporary_root=tmp_path / "tmp",
+        injection=injection,
+        workspace=tmp_path / "workspace",
+    )
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert completed.stdout == ""
+    assert completed.stderr.startswith(REFUSED)
+    assert "indexes" in completed.stderr and "where the commit has" in completed.stderr
+    _assert_nothing_left_behind(clone, tmp_path / "tmp")
+
+
+def test_the_byte_comparison_covers_the_whole_data_surface(tmp_path):
+    """Every tracked path on the gate's data surface is in the protected set.
+
+    The protected prefixes come from the chain specification; the data surface
+    is a separate set of globs on the gate specification. This holds the two
+    together at the repository's own head, so a widened data surface cannot
+    outgrow the byte comparison unnoticed (peer review, round 2).
+    """
+
+    import fnmatch
+    import importlib
+
+    sys.path.insert(0, str(SHIM_SCRIPTS))
+    shim = importlib.import_module("check_thesis_facts_append")
+    clone, commit = _replay_current_state(tmp_path)
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    environment = shim._gate_environment(clone, scratch)
+    protected = {
+        entry[3] for entry in shim._protected_entries(clone, commit, environment)
+    }
+    tracked = _git(clone, "ls-tree", "-r", "--name-only", commit).splitlines()
+    patterns = list(shim.APPEND_GATE_SPEC.data_surface)
+    on_surface = {
+        path
+        for path in tracked
+        if any(
+            (pattern.endswith("/**") and path.startswith(pattern[:-2]))
+            or path == pattern
+            or fnmatch.fnmatchcase(path, pattern)
+            for pattern in patterns
+        )
+    }
+    assert on_surface, "the data surface matched nothing; the test is vacuous"
+    assert on_surface <= protected, sorted(on_surface - protected)

--- a/tests/test_thesis_append_shim_isolation.py
+++ b/tests/test_thesis_append_shim_isolation.py
@@ -1,0 +1,1056 @@
+"""What the append-gate shim establishes before the gate reaches a verdict.
+
+The gate states its verdict about a clean checkout of one named commit, read
+once, with no concurrent writer. The shim is the part that makes that true: it
+checks the named commit out itself, under a git environment the candidate
+cannot redirect, and refuses rather than reaching a verdict when the checkout is
+not exactly that commit.
+
+Every case here is one way a repository could have handed the old shim a
+directory that was not the commit it claimed to be, run code during the
+checkout, or made the bytes on disk differ from the bytes the commit fixes. Each
+runs the shim in a subprocess and asserts what it printed and what it exited
+with, so the refusal text and the exit code are the assertions rather than an
+internal state.
+
+Some cases need something to happen between the checkout and the assertion --
+a writer, a permission change -- which is a window no repository setting can
+open on its own, because the shim disables hooks and owns the directory. Those
+cases run the shim through a small driver that imports the module and wraps one
+function, and each says in its own docstring what it wrapped and why the thing
+it simulates has no other construction. Everything else runs the script itself.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import re
+import shutil
+import stat
+import subprocess
+import sys
+
+import pytest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SHIM_SCRIPTS = ROOT / "scripts"
+SHIM = SHIM_SCRIPTS / "check_thesis_facts_append.py"
+
+RELEASE_FILE_SUFFIXES = (
+    ".json",
+    ".producer.sig",
+    ".freetsa.tsr",
+    ".digicert.tsr",
+)
+LEDGER_RELATIVE = "ledger/official_observations.jsonl"
+
+REFUSED = "thesis-facts append check refused: "
+FAILED = "thesis-facts append check failed: "
+
+CANDIDATE_LINE = re.compile(
+    r"(?m)^candidate commit (?P<commit>[0-9a-f]{40,64}) "
+    r"tree (?P<tree>[0-9a-f]{40,64})$"
+)
+
+# A commit id of the right shape that no repository holds.
+ABSENT_OBJECT_ID = "0" * 40
+
+
+def _release_manifests() -> list[pathlib.Path]:
+    return sorted((ROOT / "releases" / "manifests").glob("[0-9]" * 4 + "-*.json"))
+
+
+_HEAD_RELEASE = json.loads(_release_manifests()[-1].read_text(encoding="utf-8"))
+NEW_RELEASE_STEM = _release_manifests()[-1].stem
+RELEASE_INDEX = int(_HEAD_RELEASE["releaseIndex"])
+CANDIDATE_LINE_COUNT = int(_HEAD_RELEASE["state"]["lineCount"])
+BASE_LINE_COUNT = int(_HEAD_RELEASE["append"]["previousLineCount"])
+APPENDED_ROW_COUNT = int(_HEAD_RELEASE["append"]["appendedRowCount"])
+PREFIX_LINE_COUNT = int(
+    json.loads((ROOT / "ledger" / "immutable_prefix.json").read_text(encoding="utf-8"))[
+        "prefixLineCount"
+    ]
+)
+APPEND_GATE_OK = (
+    f"thesis-facts append check OK: {CANDIDATE_LINE_COUNT} rows, "
+    f"immutable prefix {PREFIX_LINE_COUNT}, "
+    f"+{APPENDED_ROW_COUNT} appended vs base, release {RELEASE_INDEX}"
+)
+
+
+def _git(root: pathlib.Path, *arguments: str) -> str:
+    """Run git in a fixture repository, ignoring the machine's own settings."""
+
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+            "GIT_CONFIG_NOSYSTEM": "1",
+        }
+    )
+    completed = subprocess.run(
+        ["git", *arguments],
+        cwd=root,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return completed.stdout.strip()
+
+
+def _copy_custody_tree(destination: pathlib.Path) -> pathlib.Path:
+    root = destination / "root"
+    shutil.copytree(ROOT / "ledger", root / "ledger")
+    shutil.copytree(ROOT / "releases", root / "releases")
+    return root
+
+
+def _initialize(root: pathlib.Path) -> None:
+    _git(root, "init", "--quiet")
+    _git(root, "config", "user.email", "shim-isolation@example.invalid")
+    _git(root, "config", "user.name", "Shim Isolation")
+
+
+def _commit(root: pathlib.Path, message: str) -> str:
+    _git(root, "add", "-A")
+    _git(root, "commit", "--quiet", "--allow-empty", "-m", message)
+    return _git(root, "rev-parse", "HEAD")
+
+
+def _release_file(root: pathlib.Path, suffix: str) -> pathlib.Path:
+    return root / "releases" / "manifests" / f"{NEW_RELEASE_STEM}{suffix}"
+
+
+def _replay_latest_release(
+    destination: pathlib.Path,
+    *,
+    prepare=None,
+    mutate=None,
+) -> tuple[pathlib.Path, str, str]:
+    """Build the prior release as base and the witnessed append as candidate.
+
+    ``prepare`` runs before the base commit, so whatever it writes is in both
+    commits and is therefore not part of the diff the gate judges. ``mutate``
+    runs after the release files are restored and before the candidate commit,
+    so whatever it writes is part of the candidate and of nothing else.
+    """
+
+    root = _copy_custody_tree(destination)
+    ledger = root / LEDGER_RELATIVE
+    full_ledger = ledger.read_bytes()
+    rows = full_ledger.splitlines(keepends=True)
+    assert len(rows) == CANDIDATE_LINE_COUNT
+    ledger.write_bytes(b"".join(rows[:BASE_LINE_COUNT]))
+    for suffix in RELEASE_FILE_SUFFIXES:
+        _release_file(root, suffix).unlink()
+
+    _initialize(root)
+    if prepare is not None:
+        prepare(root)
+    base = _commit(root, "release base")
+
+    ledger.write_bytes(full_ledger)
+    for suffix in RELEASE_FILE_SUFFIXES:
+        shutil.copyfile(_release_file(ROOT, suffix), _release_file(root, suffix))
+    if mutate is not None:
+        mutate(root)
+    return root, base, _commit(root, "witnessed append")
+
+
+def _replay_current_state(destination: pathlib.Path) -> tuple[pathlib.Path, str]:
+    """Commit the repository's present custody tree as the base to diff against.
+
+    Used by the cases that ask what the gate says about a change made on top of
+    the state as it stands, rather than about the last witnessed release.
+    """
+
+    root = _copy_custody_tree(destination)
+    _initialize(root)
+    return root, _commit(root, "current state")
+
+
+DRIVER = """\
+import subprocess
+import sys
+
+sys.path.insert(0, {scripts!r})
+
+import check_thesis_facts_append as shim  # noqa: E402
+
+{injection}
+
+raise SystemExit(shim.main())
+"""
+
+
+def _run_shim(
+    clone: pathlib.Path,
+    *,
+    commit: str,
+    base_ref: str | None = None,
+    temporary_root: pathlib.Path,
+    injection: str | None = None,
+    workspace: pathlib.Path | None = None,
+    environment: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run the shim over ``clone`` with its scratch directories under our eye.
+
+    ``temporary_root`` becomes the child's ``TMPDIR``, so the private directory
+    the shim creates lands somewhere a test can look at afterwards and assert
+    that nothing was left behind.
+    """
+
+    temporary_root.mkdir(parents=True, exist_ok=True)
+    if injection is None:
+        script = SHIM
+    else:
+        assert workspace is not None
+        workspace.mkdir(parents=True, exist_ok=True)
+        script = workspace / "driver.py"
+        script.write_text(
+            DRIVER.format(scripts=str(SHIM_SCRIPTS), injection=injection),
+            encoding="utf-8",
+        )
+
+    child = os.environ.copy() if environment is None else dict(environment)
+    child["TMPDIR"] = str(temporary_root)
+    command = [
+        sys.executable,
+        str(script),
+        "--root",
+        str(clone),
+        "--commit",
+        commit,
+    ]
+    if base_ref is not None:
+        command.extend(["--base-ref", base_ref])
+    return subprocess.run(
+        command,
+        cwd=clone,
+        env=child,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _assert_nothing_left_behind(
+    clone: pathlib.Path, temporary_root: pathlib.Path
+) -> None:
+    """No scratch directory survives, and no registration names one."""
+
+    leftovers = sorted(temporary_root.glob("thesis-facts-gate-*"))
+    assert leftovers == [], leftovers
+    listing = _git(clone, "worktree", "list", "--porcelain")
+    assert "thesis-facts-gate-" not in listing, listing
+
+
+def test_a_checkout_of_another_commit_is_refused(tmp_path):
+    """HEAD must be the commit that was named, not one near it.
+
+    The writer simulated here is a checkout that answered for a different
+    commit. There is no repository setting that produces it -- the shim passes
+    the object id to `git worktree add` itself -- so the driver wraps
+    `_isolated_checkout` and has it check out the candidate's parent, which is
+    the closest thing to a checkout that looks right and is not.
+    """
+
+    clone, base, candidate = _replay_latest_release(tmp_path)
+    parent = _git(clone, "rev-parse", f"{candidate}^")
+    injection = """\
+_real_checkout = shim._isolated_checkout
+
+
+def _checkout_the_parent(clone_root, scratch_root, oid, env):
+    parent = subprocess.run(
+        ["git", "-C", str(clone_root), "rev-parse", oid + "^"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    return _real_checkout(clone_root, scratch_root, parent, env)
+
+
+shim._isolated_checkout = _checkout_the_parent
+"""
+    completed = _run_shim(
+        clone,
+        commit=candidate,
+        base_ref=base,
+        temporary_root=tmp_path / "tmp",
+        injection=injection,
+        workspace=tmp_path / "driver",
+    )
+
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert completed.stdout == ""
+    assert REFUSED in completed.stderr
+    assert (
+        f"the isolated checkout is at {parent}, not the named commit "
+        f"{candidate}" in completed.stderr
+    )
+    _assert_nothing_left_behind(clone, tmp_path / "tmp")
+
+
+def test_a_modified_tracked_file_in_the_checkout_is_refused(tmp_path):
+    """A tracked file written after the checkout is refused.
+
+    A `post-checkout` hook is the realistic writer, and the shim disables hooks
+    by construction, which is proved separately. So the writer here is the
+    driver: it wraps `_isolated_checkout` and appends a byte to the ledger in
+    the directory the real function returned, which is exactly what a hook
+    would have had the opportunity to do.
+    """
+
+    clone, base, candidate = _replay_latest_release(tmp_path)
+    injection = """\
+_real_checkout = shim._isolated_checkout
+
+
+def _write_into_the_checkout(clone_root, scratch_root, oid, env):
+    checkout = _real_checkout(clone_root, scratch_root, oid, env)
+    ledger = checkout / "ledger" / "official_observations.jsonl"
+    ledger.write_bytes(ledger.read_bytes() + b"{}\\n")
+    return checkout
+
+
+shim._isolated_checkout = _write_into_the_checkout
+"""
+    completed = _run_shim(
+        clone,
+        commit=candidate,
+        base_ref=base,
+        temporary_root=tmp_path / "tmp",
+        injection=injection,
+        workspace=tmp_path / "driver",
+    )
+
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert completed.stdout == ""
+    assert f"{REFUSED}the isolated checkout of {candidate} is not clean" in (
+        completed.stderr
+    )
+    assert LEDGER_RELATIVE in completed.stderr
+    _assert_nothing_left_behind(clone, tmp_path / "tmp")
+
+
+def test_an_untracked_file_is_refused_though_the_clone_hides_untracked_files(
+    tmp_path,
+):
+    """`status.showUntrackedFiles=no` in the clone does not hide the file.
+
+    The setting is the repository's, and it is the kind of setting the shim
+    deliberately does not refuse in the configuration audit, because it changes
+    what a report says rather than what a checkout does. It is answered
+    instead: the shim forces `status.showUntrackedFiles=all` on the command
+    line, where it outranks any configured value, and passes
+    `--untracked-files=all` as well.
+    """
+
+    clone, base, candidate = _replay_latest_release(tmp_path)
+    _git(clone, "config", "status.showUntrackedFiles", "no")
+    injection = """\
+_real_checkout = shim._isolated_checkout
+
+
+def _leave_an_untracked_file(clone_root, scratch_root, oid, env):
+    checkout = _real_checkout(clone_root, scratch_root, oid, env)
+    (checkout / "unexpected.txt").write_text("left behind\\n", encoding="utf-8")
+    return checkout
+
+
+shim._isolated_checkout = _leave_an_untracked_file
+"""
+    completed = _run_shim(
+        clone,
+        commit=candidate,
+        base_ref=base,
+        temporary_root=tmp_path / "tmp",
+        injection=injection,
+        workspace=tmp_path / "driver",
+    )
+
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert f"{REFUSED}the isolated checkout of {candidate} is not clean" in (
+        completed.stderr
+    )
+    assert "?? unexpected.txt" in completed.stderr
+    _assert_nothing_left_behind(clone, tmp_path / "tmp")
+
+
+def test_an_ignored_file_is_refused(tmp_path):
+    """A file the commit's own .gitignore hides is still a file in the tree.
+
+    `git status` says nothing about an ignored file however untracked files are
+    configured, so the clean-tree assertion cannot see one. The separate
+    `ls-files --others --ignored` is what does.
+    """
+
+    def _ignore_a_directory(root: pathlib.Path) -> None:
+        (root / ".gitignore").write_text("workspace/\n", encoding="utf-8")
+
+    clone, base, candidate = _replay_latest_release(
+        tmp_path, prepare=_ignore_a_directory
+    )
+    injection = """\
+_real_checkout = shim._isolated_checkout
+
+
+def _leave_an_ignored_file(clone_root, scratch_root, oid, env):
+    checkout = _real_checkout(clone_root, scratch_root, oid, env)
+    hidden = checkout / "workspace"
+    hidden.mkdir()
+    (hidden / "smuggled.txt").write_text("ignored\\n", encoding="utf-8")
+    return checkout
+
+
+shim._isolated_checkout = _leave_an_ignored_file
+"""
+    completed = _run_shim(
+        clone,
+        commit=candidate,
+        base_ref=base,
+        temporary_root=tmp_path / "tmp",
+        injection=injection,
+        workspace=tmp_path / "driver",
+    )
+
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert f"{REFUSED}the isolated checkout of {candidate} carries an ignored " in (
+        completed.stderr
+    )
+    assert "workspace/smuggled.txt" in completed.stderr
+    _assert_nothing_left_behind(clone, tmp_path / "tmp")
+
+
+def test_an_attribute_that_rewrites_the_checkout_bytes_is_refused(tmp_path):
+    """Committed attributes cannot make the gate read bytes the commit fixes.
+
+    A `text eol=crlf` attribute over an LF blob is the whole attack in one
+    line: the checkout writes CRLF, `git status` stays clean because git
+    normalises on the way back in, and a content hash taken the ordinary way
+    reproduces the blob id by construction whatever is on disk. Hashing with
+    `--no-filters` is what makes the comparison a comparison, and this is the
+    case that fails without it.
+
+    A `filter.*` driver would do the same thing with a program instead of a
+    conversion; the configuration audit refuses that one earlier, and its own
+    case is below.
+    """
+
+    def _convert_the_ledger_to_crlf(root: pathlib.Path) -> None:
+        (root / ".gitattributes").write_text(
+            f"{LEDGER_RELATIVE} text eol=crlf\n", encoding="utf-8"
+        )
+
+    clone, base, candidate = _replay_latest_release(
+        tmp_path, prepare=_convert_the_ledger_to_crlf
+    )
+    blob = _git(clone, "rev-parse", f"{candidate}:{LEDGER_RELATIVE}")
+
+    completed = _run_shim(
+        clone,
+        commit=candidate,
+        base_ref=base,
+        temporary_root=tmp_path / "tmp",
+    )
+
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert completed.stdout == ""
+    assert f"{REFUSED}the protected path {LEDGER_RELATIVE} holds bytes hashing" in (
+        completed.stderr
+    )
+    assert f"against the {blob} the commit names" in completed.stderr
+    _assert_nothing_left_behind(clone, tmp_path / "tmp")
+
+
+def test_an_execute_bit_that_disagrees_with_the_tree_mode_is_refused(tmp_path):
+    """The owner-execute bit on disk must be the one the commit states.
+
+    `core.fileMode=false` tells git to stop comparing the bit, so `git status`
+    reports a clean tree while the file's permissions are not the ones the
+    commit records. That is why this is a separate assertion and not something
+    the clean-tree check already covers: under that setting the clean-tree check
+    cannot see it. The clearing of the bit itself is done by the driver, because
+    with the setting in place nothing in the repository has to do it for the
+    tree to still look clean.
+    """
+
+    clone, base, candidate = _replay_latest_release(
+        tmp_path,
+        prepare=lambda root: (root / LEDGER_RELATIVE).chmod(0o755),
+    )
+    assert _git(clone, "ls-tree", candidate, "--", LEDGER_RELATIVE).startswith("100755")
+    _git(clone, "config", "core.fileMode", "false")
+    injection = """\
+_real_checkout = shim._isolated_checkout
+
+
+def _clear_the_execute_bit(clone_root, scratch_root, oid, env):
+    checkout = _real_checkout(clone_root, scratch_root, oid, env)
+    (checkout / "ledger" / "official_observations.jsonl").chmod(0o644)
+    return checkout
+
+
+shim._isolated_checkout = _clear_the_execute_bit
+"""
+    completed = _run_shim(
+        clone,
+        commit=candidate,
+        base_ref=base,
+        temporary_root=tmp_path / "tmp",
+        injection=injection,
+        workspace=tmp_path / "driver",
+    )
+
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert (
+        f"{REFUSED}the protected path {LEDGER_RELATIVE} is not executable"
+        in completed.stderr
+    )
+    assert "against tree mode 100755" in completed.stderr
+    _assert_nothing_left_behind(clone, tmp_path / "tmp")
+
+
+def _commit_a_symlink_under_releases(root: pathlib.Path) -> None:
+    link = root / "releases" / "manifests" / "0000-shortcut.json"
+    link.symlink_to(pathlib.Path("..") / ".." / "ledger" / "immutable_prefix.json")
+
+
+def test_a_symlink_under_the_release_root_is_refused(tmp_path):
+    """A protected path that is a link is refused on its mode, not followed.
+
+    The refusal is the shim's, not the gate's -- the message says "refused" and
+    not "failed" -- so the mode was read before any verdict was reached about
+    what the tree holds.
+    """
+
+    clone, base, candidate = _replay_latest_release(
+        tmp_path, mutate=_commit_a_symlink_under_releases
+    )
+
+    completed = _run_shim(
+        clone,
+        commit=candidate,
+        base_ref=base,
+        temporary_root=tmp_path / "tmp",
+    )
+
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert completed.stdout == ""
+    assert FAILED not in completed.stderr
+    assert REFUSED in completed.stderr
+    assert "releases/manifests/0000-shortcut.json" in completed.stderr
+    assert "tree mode 120000" in completed.stderr
+    _assert_nothing_left_behind(clone, tmp_path / "tmp")
+
+
+def test_a_symlink_materialised_as_a_file_is_still_refused(tmp_path):
+    """`core.symlinks=false` turns the link into a regular file, and it is
+    still refused.
+
+    Under that setting git writes the link's target text into an ordinary file,
+    which passes every test that asks what the thing on disk is. The tree mode
+    is what says the commit does not fix that file's bytes, and the tree mode is
+    what the refusal names.
+    """
+
+    clone, base, candidate = _replay_latest_release(
+        tmp_path, mutate=_commit_a_symlink_under_releases
+    )
+    _git(clone, "config", "core.symlinks", "false")
+
+    completed = _run_shim(
+        clone,
+        commit=candidate,
+        base_ref=base,
+        temporary_root=tmp_path / "tmp",
+    )
+
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert REFUSED in completed.stderr
+    assert "tree mode 120000" in completed.stderr
+    _assert_nothing_left_behind(clone, tmp_path / "tmp")
+
+
+def test_a_checkout_that_never_happened_leaves_no_registration(tmp_path):
+    """An object id nothing holds fails the add, and leaves nothing behind.
+
+    git validates the commit before it writes a registration, so the ordinary
+    outcome is that there is nothing to deregister and only a directory to
+    delete. The assertion is that both are true afterwards, which is what the
+    `finally` is for.
+    """
+
+    clone, _base, _candidate = _replay_latest_release(tmp_path)
+    before = _git(clone, "worktree", "list", "--porcelain")
+
+    completed = _run_shim(
+        clone,
+        commit=ABSENT_OBJECT_ID,
+        temporary_root=tmp_path / "tmp",
+    )
+
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert completed.stdout == ""
+    assert f"{REFUSED}cannot check {ABSENT_OBJECT_ID} out in isolation" in (
+        completed.stderr
+    )
+    assert _git(clone, "worktree", "list", "--porcelain") == before
+    _assert_nothing_left_behind(clone, tmp_path / "tmp")
+
+
+# Braces are everywhere in this one, so the recording path is spliced in by
+# name rather than by str.format.
+ENVIRONMENT_SPY = """\
+import json
+import os
+import pathlib
+
+RECORDING = __RECORDING__
+
+import receipt.append_gate as gate  # noqa: E402
+
+_real_run = subprocess.run
+_records = []
+
+
+def _spy(*args, **kwargs):
+    argv = args[0] if args else kwargs.get("args")
+    given = kwargs.get("env")
+    effective = dict(given) if given is not None else dict(os.environ)
+    _records.append(
+        {
+            "argv": [str(item) for item in argv],
+            "explicit": given is not None,
+            "git": {
+                name: value
+                for name, value in effective.items()
+                if name.startswith("GIT_")
+            },
+        }
+    )
+    return _real_run(*args, **kwargs)
+
+
+subprocess.run = _spy
+gate.subprocess.run = _spy
+
+
+def _record_and_exit(code):
+    pathlib.Path(RECORDING).write_text(json.dumps(_records), encoding="utf-8")
+    return code
+
+
+_real_main = shim.main
+shim.main = lambda: _record_and_exit(_real_main())
+"""
+
+
+def test_no_inherited_git_variable_reaches_any_child(tmp_path):
+    """Every git the run starts sees exactly three GIT_ variables.
+
+    The caller's environment is loaded with every GIT_ name git(1) documents,
+    plus GIT_CONFIG_COUNT, which git-config(1) documents and git(1) does not --
+    the shim drops by prefix rather than by list, so a name outside the list is
+    dropped too. The gate's own git calls pass no environment and therefore
+    inherit the process's, which is why what is recorded for a call without an
+    explicit environment is os.environ at the moment of the call.
+    """
+
+    clone, base, candidate = _replay_latest_release(tmp_path)
+    recording = tmp_path / "subprocess-environments.json"
+
+    module = SHIM.read_text(encoding="utf-8")
+    documented = re.search(r"There are (\d+) of them\.", module)
+    assert documented is not None, "the tuple's comment no longer gives a count"
+
+    hostile = os.environ.copy()
+    for name in _documented_git_variables():
+        hostile[name] = f"hostile-{name}"
+    hostile["GIT_CONFIG_COUNT"] = "1"
+    hostile["GIT_CONFIG_KEY_0"] = "core.hooksPath"
+    hostile["GIT_CONFIG_VALUE_0"] = str(tmp_path / "hostile-hooks")
+
+    completed = _run_shim(
+        clone,
+        commit=candidate,
+        base_ref=base,
+        temporary_root=tmp_path / "tmp",
+        injection=ENVIRONMENT_SPY.replace("__RECORDING__", repr(str(recording))),
+        workspace=tmp_path / "driver",
+        environment=hostile,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    records = json.loads(recording.read_text(encoding="utf-8"))
+    git_calls = [record for record in records if record["argv"][0] == "git"]
+    assert git_calls, records
+    assert any(record["explicit"] for record in git_calls)
+    assert any(not record["explicit"] for record in git_calls)
+    for record in git_calls:
+        assert set(record["git"]) == {
+            "GIT_NO_REPLACE_OBJECTS",
+            "GIT_CONFIG_NOSYSTEM",
+            "GIT_CONFIG_GLOBAL",
+        }, record
+        assert record["git"]["GIT_NO_REPLACE_OBJECTS"] == "1"
+        assert record["git"]["GIT_CONFIG_NOSYSTEM"] == "1"
+        assert not record["git"]["GIT_CONFIG_GLOBAL"].startswith("hostile-")
+
+
+def _documented_git_variables() -> tuple[str, ...]:
+    sys.path.insert(0, str(SHIM_SCRIPTS))
+    from check_thesis_facts_append import DOCUMENTED_GIT_VARIABLES
+
+    return DOCUMENTED_GIT_VARIABLES
+
+
+def test_the_documented_variable_list_is_not_narrower_than_the_drop():
+    """The prefix rule covers every name the tuple records, and the count holds.
+
+    The shim drops by prefix, so this is a check on the documentation rather
+    than on the code: if a future git documents a GIT_ variable the prefix rule
+    would miss, there is no such name and this says so; if the tuple and the
+    comment beside it disagree about how many names it holds, that is a stale
+    comment and this says that too.
+    """
+
+    documented = _documented_git_variables()
+    assert len(set(documented)) == len(documented)
+    assert sorted(documented) == list(documented)
+    for name in documented:
+        assert name.startswith("GIT_"), name
+
+    module = SHIM.read_text(encoding="utf-8")
+    stated = re.search(r"There are (\d+) of them\.", module)
+    assert stated is not None
+    assert int(stated.group(1)) == len(documented)
+
+
+def test_a_post_checkout_hook_in_the_clone_does_not_run(tmp_path):
+    """`git worktree add` runs post-checkout, and here it does not.
+
+    The hook is a real one, installed where git looks by default. It is not
+    reached because the shim points `core.hooksPath` at an empty directory it
+    made, from a global configuration file the repository's own configuration
+    is separately checked for not overriding.
+    """
+
+    clone, base, candidate = _replay_latest_release(tmp_path)
+    marker = tmp_path / "the-hook-ran"
+    hook = clone / ".git" / "hooks" / "post-checkout"
+    hook.parent.mkdir(parents=True, exist_ok=True)
+    hook.write_text(
+        f"#!/bin/sh\nprintf 'ran' > {marker}\n",
+        encoding="utf-8",
+    )
+    hook.chmod(0o755)
+
+    completed = _run_shim(
+        clone,
+        commit=candidate,
+        base_ref=base,
+        temporary_root=tmp_path / "tmp",
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert not marker.exists()
+    assert APPEND_GATE_OK in completed.stdout
+    _assert_nothing_left_behind(clone, tmp_path / "tmp")
+
+
+def test_an_unrelated_prunable_worktree_keeps_its_registration(tmp_path):
+    """Cleanup removes this run's checkout by name and nothing else.
+
+    `git worktree prune` would have removed the other registration too -- the
+    second half of this test shows that it does -- which is why the shim never
+    calls it. A worktree whose directory has gone is prunable, and a repository
+    in which other work is going on can hold several at any moment.
+    """
+
+    clone, base, candidate = _replay_latest_release(tmp_path)
+    other = tmp_path / "somebody-elses-worktree"
+    _git(clone, "worktree", "add", "--detach", str(other), base)
+    shutil.rmtree(other)
+    assert str(other) in _git(clone, "worktree", "list", "--porcelain")
+
+    completed = _run_shim(
+        clone,
+        commit=candidate,
+        base_ref=base,
+        temporary_root=tmp_path / "tmp",
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert str(other) in _git(clone, "worktree", "list", "--porcelain")
+    _assert_nothing_left_behind(clone, tmp_path / "tmp")
+
+    _git(clone, "worktree", "prune")
+    assert str(other) not in _git(clone, "worktree", "list", "--porcelain")
+
+
+@pytest.mark.parametrize(
+    ("key", "value", "reported"),
+    [
+        ("filter.smuggle.clean", "cat", "filter.smuggle.clean"),
+        ("core.hooksPath", "hooks", "core.hookspath"),
+        ("core.fsmonitor", "true", "core.fsmonitor"),
+        ("include.path", "extra-config", "include.path"),
+    ],
+)
+def test_a_clone_that_redirects_the_checkout_is_refused_before_it_happens(
+    tmp_path, key, value, reported
+):
+    """Four repository settings decide what a checkout does, and all are refused.
+
+    Each of them outranks the global file the shim wrote: a hook path moves the
+    directory the shim emptied, a filesystem monitor and a content filter each
+    name a program git runs, and an include pulls in a file this audit has not
+    read and which could set any of the other three. The audit runs before the
+    checkout, so nothing has been created when the refusal is made.
+    """
+
+    clone, _base, candidate = _replay_latest_release(tmp_path)
+    _git(clone, "config", key, value)
+    before = _git(clone, "worktree", "list", "--porcelain")
+
+    completed = _run_shim(
+        clone,
+        commit=candidate,
+        temporary_root=tmp_path / "tmp",
+    )
+
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert completed.stdout == ""
+    assert REFUSED in completed.stderr
+    assert f"sets {reported} in its local configuration" in completed.stderr
+    assert _git(clone, "worktree", "list", "--porcelain") == before
+    _assert_nothing_left_behind(clone, tmp_path / "tmp")
+
+
+@pytest.mark.parametrize(
+    "spelling",
+    ["HEAD", "main", "codex/thesis-ledger-facts", "3a5ef7e", "A" * 40, ""],
+)
+def test_a_commit_that_is_not_a_full_object_id_is_refused_by_the_parser(
+    tmp_path, spelling
+):
+    """A name the candidate can move, or an id short enough to be ambiguous.
+
+    The parser refuses these, so the refusal costs nothing -- no directory is
+    made, no git command runs -- and it is argparse's own exit status 2 rather
+    than the gate's 1, because it is a usage error and not a verdict.
+    """
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SHIM),
+            "--root",
+            str(tmp_path),
+            "--commit",
+            spelling,
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 2, completed.stdout + completed.stderr
+    assert completed.stdout == ""
+    assert "argument --commit" in completed.stderr
+    assert "a full object id is required" in completed.stderr
+
+
+def test_an_exception_after_the_checkout_still_removes_everything(tmp_path):
+    """The cleanup is in a `finally`, so it does not need the run to succeed.
+
+    The gate is replaced by something that raises, which stands for every way
+    the run can end that is neither a verdict nor a refusal.
+    """
+
+    clone, base, candidate = _replay_latest_release(tmp_path)
+    injection = """\
+def _explode(*args, **kwargs):
+    raise RuntimeError("the gate did not get to finish")
+
+
+shim.verify_append_gate = _explode
+"""
+    completed = _run_shim(
+        clone,
+        commit=candidate,
+        base_ref=base,
+        temporary_root=tmp_path / "tmp",
+        injection=injection,
+        workspace=tmp_path / "driver",
+    )
+
+    assert completed.returncode != 0
+    assert "RuntimeError: the gate did not get to finish" in completed.stderr
+    _assert_nothing_left_behind(clone, tmp_path / "tmp")
+
+
+def test_the_witnessed_release_passes_and_names_its_commit(tmp_path):
+    """The accepting case, end to end, over a committed replay of the last
+    release.
+
+    stdout is the gate's own summary line and then one line the shim adds,
+    naming the commit it checked out and that commit's tree.
+    """
+
+    clone, base, candidate = _replay_latest_release(tmp_path)
+    tree = _git(clone, "rev-parse", f"{candidate}^{{tree}}")
+
+    completed = _run_shim(
+        clone,
+        commit=candidate,
+        base_ref=base,
+        temporary_root=tmp_path / "tmp",
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert completed.stderr == ""
+    assert completed.stdout == (
+        f"{APPEND_GATE_OK}\ncandidate commit {candidate} tree {tree}\n"
+    )
+    match = CANDIDATE_LINE.search(completed.stdout)
+    assert match is not None
+    assert match.group("commit") == candidate
+    assert match.group("tree") == tree
+    _assert_nothing_left_behind(clone, tmp_path / "tmp")
+
+
+def _rewrite_the_first_unfrozen_row(root: pathlib.Path) -> None:
+    ledger = root / LEDGER_RELATIVE
+    rows = ledger.read_bytes().splitlines(keepends=True)
+    rows[PREFIX_LINE_COUNT] = b" " + rows[PREFIX_LINE_COUNT]
+    ledger.write_bytes(b"".join(rows))
+
+
+def _drop_the_last_row(root: pathlib.Path) -> None:
+    ledger = root / LEDGER_RELATIVE
+    rows = ledger.read_bytes().splitlines(keepends=True)
+    ledger.write_bytes(b"".join(rows[:-1]))
+
+
+@pytest.mark.parametrize(
+    ("case", "mutation", "marker"),
+    [
+        (
+            "rewrite",
+            _rewrite_the_first_unfrozen_row,
+            f"change rewrites existing line {PREFIX_LINE_COUNT + 1}",
+        ),
+        (
+            "truncate",
+            _drop_the_last_row,
+            (
+                f"change truncates the ledger: {CANDIDATE_LINE_COUNT} -> "
+                f"{CANDIDATE_LINE_COUNT - 1} rows"
+            ),
+        ),
+    ],
+)
+def test_the_append_only_diff_is_still_enforced_end_to_end(
+    tmp_path, case, mutation, marker
+):
+    """A rewritten historical line and a truncated ledger, through the shim.
+
+    These two outcomes used to be asserted by calling the gate's append-only
+    check directly with a list of lines. They are asserted here the way the
+    gate is actually used: two commits in a repository, the second judged
+    against the first, with the refusal read off the process's stderr. The
+    refusal is the gate's, spelled "failed", which is also how these cases say
+    that the shim handed the gate a tree rather than refusing it one.
+    """
+
+    clone, base = _replay_current_state(tmp_path / case)
+    mutation(clone)
+    candidate = _commit(clone, f"candidate: {case}")
+
+    completed = _run_shim(
+        clone,
+        commit=candidate,
+        base_ref=base,
+        temporary_root=tmp_path / "tmp",
+    )
+
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert completed.stdout == ""
+    assert f"{FAILED}" in completed.stderr
+    assert marker in completed.stderr
+    _assert_nothing_left_behind(clone, tmp_path / "tmp")
+
+
+def test_a_true_append_is_accepted_end_to_end(tmp_path):
+    """And the third outcome: a real append is accepted.
+
+    The append the old unit test accepted was any whole line added to the end.
+    End to end an append also has to carry its witnessed release, so what is
+    accepted here is the last real release of this ledger, replayed against the
+    one before it.
+    """
+
+    clone, base, candidate = _replay_latest_release(tmp_path)
+
+    completed = _run_shim(
+        clone,
+        commit=candidate,
+        base_ref=base,
+        temporary_root=tmp_path / "tmp",
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert f"+{APPENDED_ROW_COUNT} appended vs base" in completed.stdout
+    _assert_nothing_left_behind(clone, tmp_path / "tmp")
+
+
+def test_the_scratch_directory_is_private_to_the_run(tmp_path):
+    """The private directory is created 0700, and the shim asserts that it was.
+
+    Everything the run writes lives under it: the global configuration file
+    whose contents decide whether hooks run, the empty hook directory itself,
+    and the checkout the gate reads. The assertion here is on the other side of
+    the same fact -- that the shim records the mode it requires and would refuse
+    a directory that did not have it.
+    """
+
+    clone, base, candidate = _replay_latest_release(tmp_path)
+    observed = tmp_path / "observed-mode.txt"
+    injection = f"""\
+import pathlib
+import stat
+
+_real_scratch = shim._scratch_root
+
+
+def _record_the_mode():
+    root = _real_scratch()
+    pathlib.Path({str(observed)!r}).write_text(
+        oct(stat.S_IMODE(root.stat().st_mode)), encoding="utf-8"
+    )
+    return root
+
+
+shim._scratch_root = _record_the_mode
+"""
+    completed = _run_shim(
+        clone,
+        commit=candidate,
+        base_ref=base,
+        temporary_root=tmp_path / "tmp",
+        injection=injection,
+        workspace=tmp_path / "driver",
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert observed.read_text(encoding="utf-8") == oct(stat.S_IRWXU)
+    _assert_nothing_left_behind(clone, tmp_path / "tmp")

--- a/tests/test_thesis_append_shim_isolation.py
+++ b/tests/test_thesis_append_shim_isolation.py
@@ -665,6 +665,7 @@ ENVIRONMENT_SPY = """\
 import json
 import os
 import pathlib
+import sys as _sys
 
 RECORDING = __RECORDING__
 
@@ -677,10 +678,13 @@ _records = []
 def _spy(*args, **kwargs):
     argv = args[0] if args else kwargs.get("args")
     given = kwargs.get("env")
+    # A call that passes no environment gets the process's, so what the child
+    # actually receives is os.environ at the moment of the call either way.
     effective = dict(given) if given is not None else dict(os.environ)
     _records.append(
         {
             "argv": [str(item) for item in argv],
+            "caller": _sys._getframe(1).f_globals.get("__name__", "?"),
             "explicit": given is not None,
             "git": {
                 name: value
@@ -712,9 +716,17 @@ def test_no_inherited_git_variable_reaches_any_child(tmp_path):
     The caller's environment is loaded with every GIT_ name git(1) documents,
     plus GIT_CONFIG_COUNT, which git-config(1) documents and git(1) does not --
     the shim drops by prefix rather than by list, so a name outside the list is
-    dropped too. The gate's own git calls pass no environment and therefore
-    inherit the process's, which is why what is recorded for a call without an
-    explicit environment is os.environ at the moment of the call.
+    dropped too.
+
+    Both halves of the run are checked, told apart by which module made the
+    call. The shim passes its environment explicitly. The gate builds its own
+    from ``os.environ`` and says in as many words that it is not a sanitizer and
+    that a caller which does not control the environment it invokes the package
+    in has a problem outside that function's scope. Controlling ``os.environ``
+    for the duration of the gate call is how the shim answers that, and this is
+    the test that it works: whichever module made the call, and whether or not
+    an environment was passed, what the child receives carries exactly the three
+    variables and none of the hostile values.
     """
 
     clone, base, candidate = _replay_latest_release(tmp_path)
@@ -745,8 +757,18 @@ def test_no_inherited_git_variable_reaches_any_child(tmp_path):
     records = json.loads(recording.read_text(encoding="utf-8"))
     git_calls = [record for record in records if record["argv"][0] == "git"]
     assert git_calls, records
-    assert any(record["explicit"] for record in git_calls)
-    assert any(not record["explicit"] for record in git_calls)
+
+    by_shim = [
+        record
+        for record in git_calls
+        if record["caller"] == "check_thesis_facts_append"
+    ]
+    by_gate = [
+        record for record in git_calls if record["caller"].startswith("receipt.")
+    ]
+    assert by_shim, [record["caller"] for record in git_calls]
+    assert by_gate, [record["caller"] for record in git_calls]
+
     for record in git_calls:
         assert set(record["git"]) == {
             "GIT_NO_REPLACE_OBJECTS",

--- a/tests/test_thesis_append_shim_isolation.py
+++ b/tests/test_thesis_append_shim_isolation.py
@@ -116,8 +116,17 @@ def _initialize(root: pathlib.Path) -> None:
     _git(root, "config", "user.name", "Shim Isolation")
 
 
-def _commit(root: pathlib.Path, message: str) -> str:
+def _commit(root: pathlib.Path, message: str, index_mutation=None) -> str:
+    """Commit the working tree, and any entry only the index can carry.
+
+    ``index_mutation`` runs between the add and the commit, because an entry
+    with no file behind it -- a gitlink, say -- would be staged for deletion by
+    the add if it were written first.
+    """
+
     _git(root, "add", "-A")
+    if index_mutation is not None:
+        index_mutation(root)
     _git(root, "commit", "--quiet", "--allow-empty", "-m", message)
     return _git(root, "rev-parse", "HEAD")
 
@@ -131,6 +140,7 @@ def _replay_latest_release(
     *,
     prepare=None,
     mutate=None,
+    mutate_index=None,
 ) -> tuple[pathlib.Path, str, str]:
     """Build the prior release as base and the witnessed append as candidate.
 
@@ -138,6 +148,7 @@ def _replay_latest_release(
     commits and is therefore not part of the diff the gate judges. ``mutate``
     runs after the release files are restored and before the candidate commit,
     so whatever it writes is part of the candidate and of nothing else.
+    ``mutate_index`` does the same for an entry that exists only in the index.
     """
 
     root = _copy_custody_tree(destination)
@@ -159,7 +170,7 @@ def _replay_latest_release(
         shutil.copyfile(_release_file(ROOT, suffix), _release_file(root, suffix))
     if mutate is not None:
         mutate(root)
-    return root, base, _commit(root, "witnessed append")
+    return root, base, _commit(root, "witnessed append", mutate_index)
 
 
 def _replay_current_state(destination: pathlib.Path) -> tuple[pathlib.Path, str]:
@@ -522,16 +533,59 @@ def _commit_a_symlink_under_releases(root: pathlib.Path) -> None:
     link.symlink_to(pathlib.Path("..") / ".." / "ledger" / "immutable_prefix.json")
 
 
-def test_a_symlink_under_the_release_root_is_refused(tmp_path):
-    """A protected path that is a link is refused on its mode, not followed.
+def _stage_a_gitlink_under_releases(root: pathlib.Path) -> None:
+    """Record a submodule boundary under the release root, in the index only.
 
-    The refusal is the shim's, not the gate's -- the message says "refused" and
-    not "failed" -- so the mode was read before any verdict was reached about
-    what the tree holds.
+    A gitlink names a commit in another repository. Whatever a checkout puts at
+    that path belongs to that repository and is no part of this commit, so
+    nothing under it can be compared against anything this commit fixes.
+    """
+
+    head = _git(root, "rev-parse", "HEAD")
+    _git(
+        root,
+        "update-index",
+        "--add",
+        "--cacheinfo",
+        f"160000,{head},releases/manifests/0000-elsewhere",
+    )
+
+
+@pytest.mark.parametrize(
+    ("case", "mutate", "mutate_index", "path", "mode"),
+    [
+        (
+            "symlink",
+            _commit_a_symlink_under_releases,
+            None,
+            "releases/manifests/0000-shortcut.json",
+            "120000",
+        ),
+        (
+            "gitlink",
+            None,
+            _stage_a_gitlink_under_releases,
+            "releases/manifests/0000-elsewhere",
+            "160000",
+        ),
+    ],
+)
+def test_a_protected_path_that_is_not_a_file_is_refused(
+    tmp_path, case, mutate, mutate_index, path, mode
+):
+    """A link and a submodule boundary are both refused on their tree mode.
+
+    Neither is a path whose bytes this commit fixes: a link is a name for
+    somewhere else, and a gitlink is a name for another repository whose
+    contents this commit does not carry. They are refused rather than followed.
+
+    The refusal is the shim's and not the gate's -- the message says "refused"
+    and not "failed" -- so the mode was read before any verdict was reached
+    about what the tree holds.
     """
 
     clone, base, candidate = _replay_latest_release(
-        tmp_path, mutate=_commit_a_symlink_under_releases
+        tmp_path / case, mutate=mutate, mutate_index=mutate_index
     )
 
     completed = _run_shim(
@@ -545,8 +599,8 @@ def test_a_symlink_under_the_release_root_is_refused(tmp_path):
     assert completed.stdout == ""
     assert FAILED not in completed.stderr
     assert REFUSED in completed.stderr
-    assert "releases/manifests/0000-shortcut.json" in completed.stderr
-    assert "tree mode 120000" in completed.stderr
+    assert path in completed.stderr
+    assert f"tree mode {mode}" in completed.stderr
     _assert_nothing_left_behind(clone, tmp_path / "tmp")
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1687,7 +1687,7 @@ requires-dist = [
     { name = "pypdf", specifier = ">=6.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0,<9" },
     { name = "pyyaml", specifier = ">=6.0" },
-    { name = "receipt", specifier = "==0.5.1" },
+    { name = "receipt", git = "https://github.com/TheAxiomFoundation/receipt?rev=e80cc5e82e22d74c24d36860c949138c472ec97c" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5.0" },
     { name = "scipy", specifier = ">=1.11.0" },
     { name = "sqlmodel", specifier = ">=0.0.22" },
@@ -2328,13 +2328,9 @@ wheels = [
 [[package]]
 name = "receipt"
 version = "0.5.1"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/TheAxiomFoundation/receipt?rev=e80cc5e82e22d74c24d36860c949138c472ec97c#e80cc5e82e22d74c24d36860c949138c472ec97c" }
 dependencies = [
     { name = "cryptography" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/86/d57c13d77a8357d2cebb59365587867324186bd5751a902a338eb74baed6/receipt-0.5.1.tar.gz", hash = "sha256:17f8eaec43aab450193a9d793c92f75364c6055fbd634ee5ab4ea69bbe4ba958", size = 1173686, upload-time = "2026-08-17T19:08:01.001Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/06/e455ce392677130b7d55272a7ff486fa4825f43cea2c242eb1fbfc7752af/receipt-0.5.1-py3-none-any.whl", hash = "sha256:baacd750659773c84fe6a0da3ece9f50804ce3e8ccd23e21bced7440b7dee350", size = 78025, upload-time = "2026-08-17T19:07:59.633Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1687,7 +1687,7 @@ requires-dist = [
     { name = "pypdf", specifier = ">=6.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0,<9" },
     { name = "pyyaml", specifier = ">=6.0" },
-    { name = "receipt", git = "https://github.com/TheAxiomFoundation/receipt?rev=e80cc5e82e22d74c24d36860c949138c472ec97c" },
+    { name = "receipt", specifier = "==0.5.2" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5.0" },
     { name = "scipy", specifier = ">=1.11.0" },
     { name = "sqlmodel", specifier = ">=0.0.22" },
@@ -2327,10 +2327,14 @@ wheels = [
 
 [[package]]
 name = "receipt"
-version = "0.5.1"
-source = { git = "https://github.com/TheAxiomFoundation/receipt?rev=e80cc5e82e22d74c24d36860c949138c472ec97c#e80cc5e82e22d74c24d36860c949138c472ec97c" }
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/62/ea02501263f9d484298d79248799e7a48712593d1c9eb9b910ed313421c3/receipt-0.5.2.tar.gz", hash = "sha256:8e27ff67e4ff20eb9fea44db71b4adb8d4bbbcbe5c3f490eb92aa1b4c74f1367", size = 1690418, upload-time = "2026-09-04T08:59:41.566Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/f5/0865ff65adbeba37c3df25519611ac6daa5f979121866358d3a5140f1701/receipt-0.5.2-py3-none-any.whl", hash = "sha256:b6c1dec5fec8ad23c2ed74302d87ee9c162ed795b503eee494258bb77335b1b7", size = 295432, upload-time = "2026-09-04T08:59:39.626Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The append gate reaches its verdict about one thing: a clean checkout of one
named commit, read once, with no concurrent writer. That is the contract the
receipt 0.5.2 line states, and it is the contract under which two findings from
the 2026-09-01 review were waived — the ones whose precondition is a writer to
the working tree or the index during the run, or an index, a working tree and a
commit that disagree with one another (receipt issues #43 and #44).

A waiver like that is only honest if the program calling the gate establishes
the precondition. Until now this repository's did not. It pointed the gate at
whatever directory `--root` named and read whatever happened to be in it: the
job's own working tree, prepared by the candidate, at whatever state it was in
when the read happened. This pull request is the enforcement.

## What the shim now does

Every run names the commit to judge. `--commit` is required and must be a full
object id: a symbolic ref is refused before any git command runs, because the
candidate can move one, and an abbreviated id is refused because the same
abbreviation can name a different object in a different clone. `--root` now
says only which clone the id is resolved in.

Given that, the shim:

* creates a private scratch directory with `mkdtemp`, and asserts it really was
  created 0700, because everything else it writes lives inside it;
* builds the only git environment the run uses. Every variable whose name
  begins with `GIT_` is dropped from the caller's environment, and exactly
  three are put back: `GIT_NO_REPLACE_OBJECTS=1`, so a replace ref committed
  into the repository cannot substitute one object for another underneath a
  read; `GIT_CONFIG_NOSYSTEM=1`, so the machine's system configuration
  contributes nothing; and `GIT_CONFIG_GLOBAL` naming a file the shim writes,
  holding `safe.directory` for the clone and `core.hooksPath` pointing at an
  empty directory it creates, so no hook in the repository runs during the
  checkout. Both values are written with `git config -f`, so git does its own
  quoting;
* reads the clone's configuration with `--show-scope --no-includes -z` and
  refuses a `local` or `worktree` entry that names a hook path, a filesystem
  monitor, a content filter, or an include — each of those outranks the global
  file just written, and each is a way to run a program or rewrite bytes during
  a read the gate is about to make. It then requires the `global` scope to
  resolve to exactly the file the shim wrote and to nothing else, and requires
  no `system` entry to appear at all, since one cannot under
  `GIT_CONFIG_NOSYSTEM` and an entry claiming that scope would mean the frozen
  environment had not reached git;
* checks the named commit out as a linked worktree of the clone, sharing its
  object database so a base named with `--base-ref` still resolves;
* asserts the checkout is that commit and nothing besides. `HEAD` equals the
  named object id. `git status` reports nothing, with
  `status.showUntrackedFiles=all` forced on the command line where it outranks
  any configured value, with `--untracked-files=all`, and with submodules
  included. `git ls-files --others --ignored` reports nothing, so a
  `.gitignore` the commit itself carries cannot conceal a file. Then, for every protected path the commit names — the two state files,
  everything under the release root, and everything else under `ledger/`, so
  the byte comparison covers the whole of the gate's data surface — the tree
  mode must be a regular file's, `os.lstat` must
  agree without following anything, the bytes on disk must hash under
  `git hash-object --no-filters` to the blob the commit names, and the
  owner-execute bit must be the one the mode states;
* runs the gate over that directory, with `os.environ` replaced by the frozen
  environment for the duration. The pinned receipt passes an environment to
  every git child it starts and builds it out of `os.environ`, so replacing
  `os.environ` is what puts the gate's calls under the same environment as the
  shim's own. The
  alternative — running the gate in a child process with `env=` — would put a
  process boundary between the gate's exception text and this program's stderr,
  and that text is what the byte-equivalence proof compares;
* and removes the checkout and the scratch directory in a `finally`, naming
  this worktree by path. `git worktree prune` is never used and must never be:
  it deregisters every prunable worktree of the repository, including
  registrations belonging to other work in the same clone. One of the tests
  shows both halves of that — that the shim leaves an unrelated prunable
  registration alone, and that `prune` would have taken it.

Those four configuration classes are the ones that act during the checkout,
which is the step the shim performs. Settings that could act during the gate's
own reads are already pinned by the gate itself: it spells `--no-ext-diff` and
`--no-textconv` on its diff, and puts `core.untrackedCache=false`,
`core.fsmonitor=false`, `core.trustctime=true`, `core.checkStat=default` and
`feature.manyFiles=false` on the command line of every working-tree scan. The
audit is not trying to duplicate that; it covers the window the gate has no
command line in.

`--no-filters` is the load-bearing flag in the byte comparison. Without it git
applies whatever the commit's own `.gitattributes` asks for, so the answer is by
construction the blob id the commit names, whatever the file on disk holds. A
committed `text eol=crlf` attribute over an LF blob leaves `git status`
perfectly clean while the bytes the gate would read are not the bytes the commit
fixes. There is a test for exactly that.

## What it does not claim

The window between the assertions and the gate's own reads is inside the job
process's trust boundary. A process that can write into the private checkout
during that window runs as the job's own user, which is the trust level of the
job's own code, and the shim claims nothing about it. This is stated in the
module docstring rather than left implicit.

A package user who calls `verify_append_gate` against some other directory is
outside the gate's stated contract and outside everything the shim establishes.

`safe.directory` names the clone and not the linked worktree's own path. If the
clone were owned by another user, git would refuse the checkout rather than
proceed — a refusal, not a pass.

## The seven wrappers are gone

The shim exported seven wrappers — `_set_root`, `check_surface_separation`,
`check_prefix`, `check_append_only`, `check_prefix_anchored_to_base`,
`check_release_proposal` and `check_release_chain_without_base` — each of which
called `receipt.append_gate._set_root` to build a candidate tree per call.
Nothing in this repository's gate path used them; `main()` calls
`verify_append_gate` and only that.

On the receipt line being pinned here, `_set_root` opens a descriptor on the
candidate root and holds it for the whole verdict, because that open descriptor
is what stops the root's inode number being recycled underneath the comparisons
that quote it. The only close is in `verify_append_gate`'s `finally`. A wrapper
calling `_set_root` on its own therefore leaks one root descriptor per call, and
on the release after that the constructor is gone altogether.

The module-level `ROOT`, `LEDGER_PATH` and `PREFIX_PATH` went with them: they
existed so a wrapper could be pointed at a candidate between calls, which is the
mutable-global shape the descriptor was introduced to close.
`verify_append_gate` now takes its root as an ordinary required argument.

## Output

On success, stdout is the gate's summary line exactly as before, followed by one
line naming the commit that was checked out and that commit's tree. Exit 0.

A gate refusal is `thesis-facts append check failed: …` on stderr, exactly as
before. Exit 1.

A shim refusal — the configuration audit, a checkout assertion, an argument
that reached the code past the parser — is
`thesis-facts append check refused: …`. Exit 1. The two are spelled differently
on purpose: "failed" is the gate's verdict about a tree it was given, "refused"
is the shim declining to give it one.

Nothing else is printed on any path, with one documented exception: if `git
worktree remove` fails twice, the cleanup prints a warning naming the directory
and the command that clears it, because leaving a registration behind silently
would be worse than the extra line. Only a failed deregistration can produce it.

An argument the parser itself rejects exits 2 with argparse's own message, since
that is a usage error rather than a verdict.

## Proof at the prior pin

The rule in the shim's header comment is that a receipt upgrade needs a fresh
byte-equivalence proof at the then-current pin before the bump. Running it first
found that it could not run at all.

```
$ uv run python -c "import receipt; print(receipt.__version__)"
0.5.1
$ uv run --locked pytest -q tests/test_receipt_shim_transparency.py
6 failed, 11 passed in 8.46s
```

The cause is not receipt. The file pinned `BASE_LINE_COUNT = 182`,
`CANDIDATE_LINE_COUNT = 189` and `NEW_RELEASE_STEM = "0012-3a5ef7eeee484370"`
as literals, and the resolver append lane has since taken the journal to 221
rows and release `0020-7f669f1e1364c5cc`, 21 manifests. The chain itself is
sound — `uv run python scripts/verify_release_chain.py --full --root .` exits 0
with `release chain OK: 21 releases, HEAD=0020-7f669f1e1364c5cc.json` — and
nothing reported the drift because this file was not in the workflow's pytest
step.

The first commit on this branch therefore reads those numbers from
`releases/manifests` and `ledger/immutable_prefix.json`, which is where they are
actually decided, and changes nothing else. At that commit, still at
`receipt==0.5.1` and before the shim was touched:

```
$ uv run --locked pytest -q tests/test_receipt_shim_transparency.py
17 passed in 22.30s
```

That is the proof at the prior pin. The differential's own assertion — that the
authenticated original script and the shim emit identical bytes — never depended
on the numbers; they only pin the text the pair is expected to agree on. The two
RFC 3161 receipt times are set by the timestamp authorities rather than by this
repository, so the release-chain line is matched by shape.

## From the first peer round

The configuration audit refuses `core.sparseCheckout` and `core.sparseCheckoutCone` in the clone's `local` and `worktree` scopes: with either on and a patterns file in the shared git directory, `git worktree add` materialises a strict subset of the commit and marks the rest skip-worktree, which a clean `git status` does not reveal, and on the push invocation the gate said OK over it. Behind the audit, the checkout assertions now also require every index entry to be an ordinary tracked file (no skip-worktree, assume-unchanged or unmerged entry) and the index to hold exactly as many entries as the commit, so a sparse checkout that reached the assertions by some other route refuses there. The shim's two working-tree scans spell the five cache settings receipt spells on its own reads. The byte comparison extends to everything under `ledger/`. Tests: the sparse reproduction in both scopes on the push invocation; the assertion-level refusal with the audit bypassed; the positive hook control; the manual-page check; and the workflow test now asserts the order of the `case` arms and that `--commit` sits inside its own arm.

## Tests

A new `tests/test_thesis_append_shim_isolation.py` holds thirty-five cases. Each runs
the shim in a subprocess and asserts what it printed and what it exited with.

Refused: a checkout that answered for the candidate's parent; a tracked file
written into the checkout after it was made; an untracked file in a clone
configured with `status.showUntrackedFiles=no`; a file hidden by the commit's
own `.gitignore`; a committed `text eol=crlf` attribute over an LF blob; an
owner-execute bit cleared under `core.fileMode=false`, which likewise leaves
`git status` clean; a symlink and a gitlink under the release root, both refused
on their tree mode rather than followed; the symlink again under
`core.symlinks=false`, where git writes the link's target text into an ordinary
file and only the tree mode still says what it is; a clone whose local
configuration names a hook path, a filesystem monitor, a content filter or an
include; and six spellings of `--commit` that are not a full object id.

Accepted, and cleaned up: an installed `post-checkout` hook that does not run,
though `git worktree add` is the command that runs one; an unrelated prunable
worktree that keeps its registration; an object id nothing holds, which leaves
neither registration nor directory; an exception raised in place of the gate,
after which nothing is left behind either; the scratch directory's 0700 mode;
and the witnessed release itself, accepted, with stdout ending in the commit and
tree that were checked out.

One case loads the caller's environment with every `GIT_` name git(1) documents
plus `GIT_CONFIG_COUNT`, which git-config(1) documents and git(1) does not, and
records the environment every subprocess in the run receives — including the
gate's own calls, which pass no environment and therefore inherit the process's.
Every one of them sees exactly the three variables the shim sets and none of the
hostile values. A companion test holds `DOCUMENTED_GIT_VARIABLES` to itself (sorted, no
duplicates, every name `GIT_`-prefixed, the count matching the comment), and a
second holds it to git's own documentation where the `git(1)` manual page is
installed: every `GIT_` name the page mentions must be in the tuple, skipping
rather than passing where the page is absent.

Every git property the shim relies on is exercised by a test rather than
assumed: that `git worktree add` runs `post-checkout` (a positive control
shows the hook running when nothing redirects it, so the negative test cannot
go vacuous), that `hash-object --no-filters` skips attribute conversion, that
a command-line `status.showUntrackedFiles` outranks the configured one, and
that `prune` is not selective.

The three outcomes the deleted wrapper tests covered return end to end: a
rewritten historical line and a truncated ledger are refused by the gate against
a committed base, and a true append is accepted — which end to end also means
carrying its witnessed release, so the accepted case is the last real release of
this ledger replayed against the one before it.

### Existing suites

`tests/test_receipt_shim_transparency.py` now hands the original a plain
checkout of the same commit, so the pair still judges identical bytes, and
compares the gate's own output with the shim's extra line asserted separately.
The two `--help` texts can no longer be identical, so the original's is pinned
against a literal at a fixed terminal width and the shim's is checked for the
new required argument.

Two suites besides the adversarial one also had to be adapted, because a
required `--commit` made the gate unreachable from them as they stood.
`tests/test_policyengine_ledger.py` imported `check_prefix`, so its
frozen-prefix test now recomputes the manifest's own per-line and whole-region
digests directly, and its tamper test initialises a repository and commits
before asking. `tests/test_release_chain.py` ran the gate over a mutated working tree through
one helper at twelve call sites (fourteen invocations, one of them
parametrised), which now commits and passes the object id; each of those tests reads its base ref before it writes, so the base
is still the parent of what is judged.

## Workflow

All three invocations now name the commit. The trusted base job passes the merge
sha it already read and shape-checked; the `pull_request` job reads its
workspace's HEAD, shape-checks it the same way, and passes that; the `push` job
passes `GITHUB_SHA`. There is a comment at each saying the object id is always
an argument and is never inferred from the checkout.

The `pull_request` job reads its id into a variable rather than inlining
`$(git … rev-parse HEAD)`, because a command substitution that failed inside an
argument list would not reliably stop the step under `errexit`, and the other
two ids are validated this way already.

Two test files join the pytest step: the new isolation suite, and the
byte-equivalence differential — which was never listed there, and had been
failing on this branch for some time with nothing to report it.

### The base gate is asked what it accepts

Both base-gate jobs capture the base gate's own `--help` and invoke it with the
arguments it advertises. This is not decoration; without it the change cannot be
deployed at all.

The judge on a pull request is the **base commit's** copy of the script.
`--commit` is being introduced by a pull request, so there is no ordering of that
merge and of the default branch's copy of this workflow in which both sides are
new at once:

* a new copy of this file invoking an old base gate fails on the unknown
  argument. That is not hypothetical — it is what this pull request's first
  `Append gate` run did, exiting 2 with
  `unrecognized arguments: --commit 233b28a3…`;
* an old copy invoking a new base gate fails on the missing required one.

The question goes to base-owned code about its own interface, so it moves no
trust: the `pull_request` job's YAML is candidate-controlled either way, and the
`pull_request_target` job's comes from the default branch. The help text is
captured into a variable rather than piped, so a base gate that cannot run at
all stops the step under `errexit` instead of being read as an old one. The
fallback is never silent — a run that takes it says on stderr which base
predates the argument and what it judged instead — and the workflow test
requires both the question and the notice, so the fallback cannot be widened
into the ordinary path without a failing assertion. Both branches come out once
no base reachable from this branch predates `--commit`.

### `main`'s copy of this workflow must be brought forward before this merges

**This is a merge blocker and it is outside this pull request.**
`origin/main` carries `.github/workflows/thesis-facts-append.yml` with the
pre-change invocation, and `pull_request_target` loads its YAML from the default
branch. Once the base of a pull request into `codex/thesis-ledger-facts` carries
a script that requires `--commit`, the trusted gate — run from `main`'s copy —
would fail on every subsequent resolver proposal.

The fix is to copy this branch's version of that file to `main`. Because that
version asks the base gate what it accepts, it is correct against bases on both
sides of this merge, so it can be landed on `main` first, with no window in
which either side is broken. I have not opened that pull request.

### Also recommended, and not part of this change

Turn on "require branches to be up to date before merging" for
`codex/thesis-ledger-facts`. The gate judges the merge commit named at the time
the job ran; a base that has moved since means the judged merge is not the merge
that lands.

## The pin

`pyproject.toml` pins the released `receipt==0.5.2`, and `uv.lock` records its hashed sdist (`8e27ff67…`) and wheel (`b6c1dec5…`); no git reference and no `tool.hatch.metadata.allow-direct-references` remain. The branch first pinned the integration head `e80cc5e` (the merge of #41, following #38, #39 and #40) as a bridge until the tag existed; the release is ten commits and four modules ahead of that head, and the difference is the release PR's own work: `release_chain.assert_no_redirecting_git_environment` refusing `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, `GIT_OBJECT_DIRECTORY` and `GIT_ALTERNATE_OBJECT_DIRECTORIES` at the public verifier entries (#45), a `_set_root` refusal for a missing, non-directory or symlink-looped root (#46), and `BaseException` guards in the CLI's refusal boundaries. None of it changes what the shim relies on: the shim's environment drops every `GIT_`-prefixed name and puts back three, none of the five, so the new refusal can never fire on this path, and `verify_append_gate`'s signature is unchanged.

## Tests at the released pin

```
$ uv run --locked python -c "import receipt; print(receipt.__version__)"
0.5.2

$ uv run --locked pytest -q tests/test_receipt_shim_transparency.py \
    tests/test_thesis_append_adversarial.py \
    tests/test_thesis_append_shim_isolation.py \
    tests/test_release_chain.py tests/test_policyengine_ledger.py
152 passed, 5 xfailed
```

The isolation suite collects 35 cases at this head. The whole directory at this pin, run by the second peer round: 2 failed, 969 passed, 16 skipped, 5 xfailed; the two failures are the pre-existing `test_build_series_catalog.py` pair described below.

### And on this pull request's own CI

`Append gate` and `Trusted base append gate` both pass. The `Append gate` run
took the documented fallback and said so, which is what the probe is for:

```
note: the base gate at 55bbf3d1c83f4b4d1bc425f0284050b2a1afd4ad predates
--commit, so it judges the workspace rather than an isolated checkout of
58f3b725178eaef74c6665d4489fc6d22ec3e08b.
thesis-facts append check OK: gate-only proposal; DATA_SURFACE unchanged;
GATE_SURFACE changes=['.github/workflows/thesis-facts-append.yml',
'scripts/check_thesis_facts_append.py']
```

Its pytest step, which now includes both new files, reports `147 passed,
5 xfailed` on `ubuntu-latest` with Python 3.14 — so the isolation suite's
git-behaviour assertions hold on a case-sensitive filesystem as well as on the
macOS one they were written on.

## The two failures are already on this branch

```
FAILED tests/test_build_series_catalog.py::test_committed_catalog_is_current_and_valid
FAILED tests/test_build_series_catalog.py::test_identity_uuid_map_matches_reviewed_anchor
```

Neither is caused by this change and neither is fixed by it. The first asserts
`committed["suspect_segments"] == []` and gets `['LNU02374597']`; the second
compares the catalog's identity-to-UUID digest against an anchor last updated by
hand on 2026-08-07, and the catalog now carries 228 series.

Every input to those two tests is byte-identical to this branch's tip — the
catalog, the observation journal, the UUID registry, the docket seed, the
builder, and the test file itself all hash the same at
`origin/codex/thesis-ledger-facts` as in this working tree — and the branch's own
CI says the same thing directly: the `CI` workflow has concluded `failure` on
every push to `codex/thesis-ledger-facts` since `c2aa68d` on 2026-08-23, which is
the commit that put `LNU02374597` into the journal. The builder itself is content:
`scripts/build_series_catalog.py --check` reports `catalog current: 228 series`.
What has gone stale is the hand-maintained review anchor and the empty
suspect-segments expectation, both of which the resolver append lane moved past.

Fixing them means editing `ledger/series_catalog.json` and the anchor constant,
which is a ledger proposal and belongs in its own pull request — a change under
`ledger/` here would turn this one into a data proposal that the gate would judge
on entirely different rules. `Arch checks` will be red on those two until that
lands, exactly as it is on the branch itself. The other three checks —
`Append gate`, `Trusted base append gate` and `Arch bundle drift` — are green,
which matches the base branch, where `Arch bundle drift` also succeeds on every
run whose `Arch checks` fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


