### PR TITLE
Remove each test's tmp_path after it finishes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+"""Shared pytest configuration for Chronicle tests."""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+
+@pytest.fixture
+def tmp_path(tmp_path):
+    """Remove everything a test wrote under ``tmp_path`` once it finishes.
+
+    Several tests build real source-package suites and merged bundles under
+    ``tmp_path``; the merged consumer bundle alone writes about 14 GB of nested
+    suites. pytest keeps the three newest ``pytest-N`` base directories and only
+    prunes older ones when no other pytest session holds a lock on them, so with
+    many sessions running concurrently the outputs accumulate for days. Deleting
+    the per-test directory here keeps the base temp directory bounded regardless
+    of how many sessions are active.
+    """
+    yield tmp_path
+    shutil.rmtree(tmp_path, ignore_errors=True)


### PR DESCRIPTION
## What

Adds `tests/conftest.py` with a `tmp_path` override that deletes each test's temp directory after the test finishes.

## Why

`test_build_bundle_writes_merged_consumer_contract` builds the real source-package suites under `tmp_path`, about 14 GB per run, and the CLI bundle tests add a few hundred MB each. pytest keeps the three newest `pytest-N` base directories and only prunes older ones when no other pytest session holds a lock on them. With many agent sessions running the suite concurrently, nothing ever gets pruned: this morning the macOS temp folder held 69 base directories totalling 190 GB, almost all from this one test.

Removing the per-test directory at teardown keeps the base temp directory bounded no matter how many sessions are active.

## Verification

Full suite on this branch with `--basetemp` pointed at a fresh directory:

```
853 passed, 1 skipped, 14 warnings in 1607.12s
```

The base temp directory held 12 KB afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
