### PR TITLE
Pin receipt 0.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "odfpy>=1.4.1",
     "xlrd>=2.0.1",
     "pypdf>=6.0.0",
-    "receipt==0.6.0",
+    "receipt==0.6.1",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_thesis_append_shim_isolation.py
+++ b/tests/test_thesis_append_shim_isolation.py
@@ -68,13 +68,13 @@ def _released_receipt_wheel():
     import receipt.append_gate
 
     distribution = metadata.distribution("receipt")
-    assert distribution.version == "0.6.0"
+    assert distribution.version == "0.6.1"
     assert distribution.read_text("WHEEL") is not None
     direct_url = distribution.read_text("direct_url.json")
     if direct_url is not None:
         source = json.loads(direct_url)
         assert "archive_info" in source
-        assert source["url"].endswith("receipt-0.6.0-py3-none-any.whl")
+        assert source["url"].endswith("receipt-0.6.1-py3-none-any.whl")
     installed = pathlib.Path(distribution.locate_file("")).resolve()
     assert (
         pathlib.Path(receipt.append_gate.__file__).resolve().is_relative_to(installed)

--- a/uv.lock
+++ b/uv.lock
@@ -1687,7 +1687,7 @@ requires-dist = [
     { name = "pypdf", specifier = ">=6.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0,<9" },
     { name = "pyyaml", specifier = ">=6.0" },
-    { name = "receipt", specifier = "==0.6.0" },
+    { name = "receipt", specifier = "==0.6.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5.0" },
     { name = "scipy", specifier = ">=1.11.0" },
     { name = "sqlmodel", specifier = ">=0.0.22" },
@@ -2327,14 +2327,14 @@ wheels = [
 
 [[package]]
 name = "receipt"
-version = "0.6.0"
+version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/2d/952e672b5de571712ab896b9f93fd3ea373429eac0b24c88fb90dcc6cfc0/receipt-0.6.0.tar.gz", hash = "sha256:c84f221d83099dcd86d271de8ecadf10e7eb987b7a13761af520ac9311bf773d", size = 1615892, upload-time = "2026-09-05T16:51:22.810508Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/7d/b9eed2dda28a097b24f4b65aad207e72684a8c63bb8991012d3940f51443/receipt-0.6.1.tar.gz", hash = "sha256:7ad8f4b5f4ee609235c3d4d2c026aaad4c9043f763efd109e8be8dbda9cf9148", size = 1615783, upload-time = "2026-09-06T13:44:06.686Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/40/1bdf7498ff671dcb69dba776695f9d257d86a39dff689da63263282dc5b7/receipt-0.6.0-py3-none-any.whl", hash = "sha256:84dd540bc77f14547bcf5b4654ff22184a404aa280d8b13cda8e179593575734", size = 233986, upload-time = "2026-09-05T16:51:21.113950Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/6f/a8eaff1613da88561af4af8c05f7d1ec0758b3df62c92b3824b116602060/receipt-0.6.1-py3-none-any.whl", hash = "sha256:ef846067c5b3da958969607c63af17a49dbe6d9fb10edfe704b638101499626e", size = 234311, upload-time = "2026-09-06T13:44:04.799Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Pins `receipt` at 0.6.1 on the thesis-ledger branch: `pyproject.toml`, `uv.lock`, and the two literals in the isolation fixture (`tests/test_thesis_append_shim_isolation.py`) that assert the installed distribution's version and wheel name.

## What 0.6.1 changes

receipt 0.6.1 (PyPI, 2026-09-06) differs from 0.6.0 in `src/receipt/sign.py` and the version string alone: `KeyringSpec` refuses a non-integer threshold at construction, and `verify_any_generation` takes `allow_legacy`. The shims here (`scripts/check_thesis_facts_append.py`, `scripts/verify_release_chain.py`, `scripts/canonical_json.py`) sit over `receipt.append_gate`, `receipt.release_chain` and the canonical-JSON module; none touches the keyring surface, so every shim verdict and output line is the one 0.6.0 produced. The shim headers require a fresh byte-equivalence proof before each receipt upgrade: that proof is this repository's transparency and isolation suites run at the new pin, below and in CI.

## Lock

`uv lock` after the pin change updated the receipt package entry and, in the workspace package `policyengine-arch-data`, the specifier of its receipt dependency; no other lock line changes:

| artifact | sha256 | size |
|---|---|---|
| `receipt-0.6.1-py3-none-any.whl` | `ef846067c5b3da958969607c63af17a49dbe6d9fb10edfe704b638101499626e` | 234311 |
| `receipt-0.6.1.tar.gz` | `7ad8f4b5f4ee609235c3d4d2c026aaad4c9043f763efd109e8be8dbda9cf9148` | 1615783 |

Those are PyPI's digests for the release (`https://pypi.org/pypi/receipt/0.6.1/json`).

## Local run at the new pin (Python 3.14, this branch)

- `uv sync --locked --all-extras`; installed `receipt 0.6.1`.
- `scripts/verify_release_chain.py --full`: exit 0.
- `scripts/build_series_catalog.py --check`: catalog current, 228 series, exit 0.
- `pytest tests -q`: 972 passed, 16 skipped, 5 xfailed in 11:02, exit 0. The run includes `tests/test_receipt_shim_transparency.py` and `tests/test_thesis_append_shim_isolation.py`, the byte-equivalence and isolation suites the shim headers require before an upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
